### PR TITLE
Adds FlateDecode stream decompression support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,46 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "pdf-document"
 version = "0.1.0"
 dependencies = [
@@ -30,6 +70,7 @@ version = "0.1.0"
 name = "pdf-parser"
 version = "0.1.0"
 dependencies = [
+ "flate2",
  "pdf-object",
  "pdf-tokenizer",
 ]

--- a/pdf-document/src/lib.rs
+++ b/pdf-document/src/lib.rs
@@ -68,7 +68,7 @@ impl PdfDocument {
         // Iterate over the `Kids` array and extract the individual page objects.
         let mut pages = vec![];
         for c in &kids.0 {
-            let p = c.as_ref().as_object().ok_or(PdfError::MissingPages)?;
+            let p = c.as_object().ok_or(PdfError::MissingPages)?;
 
             // Get the page object dictionary.
             let page_obj = objects

--- a/pdf-object/src/array.rs
+++ b/pdf-object/src/array.rs
@@ -1,10 +1,10 @@
 use crate::Value;
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct Array(pub Vec<Box<Value>>);
+pub struct Array(pub Vec<Value>);
 
 impl Array {
-    pub fn new(values: Vec<Box<Value>>) -> Self {
+    pub fn new(values: Vec<Value>) -> Self {
         Array(values)
     }
 }

--- a/pdf-object/src/indirect_object.rs
+++ b/pdf-object/src/indirect_object.rs
@@ -1,9 +1,6 @@
 use std::rc::Rc;
 
-use crate::{
-    Value,
-    stream::{self, Stream},
-};
+use crate::{Value, stream::Stream};
 
 /// Represents an indirect object or a reference to an object in a PDF file.
 /// An indirect object is a data structure that can be referenced by other objects.

--- a/pdf-object/src/stream.rs
+++ b/pdf-object/src/stream.rs
@@ -1,10 +1,10 @@
 #[derive(Debug, PartialEq, Clone)]
 pub struct Stream {
-    pub data: Vec<u8>,
+    pub data: String,
 }
 
 impl Stream {
-    pub fn new(data: Vec<u8>) -> Self {
+    pub fn new(data: String) -> Self {
         Stream { data }
     }
 }

--- a/pdf-page/src/lib.rs
+++ b/pdf-page/src/lib.rs
@@ -12,10 +12,10 @@ use pdf_object::{
 /// its resources, and other attributes according to PDF 1.7 specification.
 pub struct PdfPage {
     /// The page object dictionary containing all page-specific information.
-    // dictionary: Dictionary,
     /// Reference to the parent page tree node.
     parent: Option<IndirectObjectOrReference>,
-    /// The contents of the page, which can be a stream or an array of streams.
+    /// The contents of the page, which can be a single stream object or
+    /// an array of streams.
     contents: Value,
 }
 
@@ -108,12 +108,26 @@ impl PdfPage {
         } else {
             contents = contents_ref.object.as_ref().unwrap().clone();
         }
+        println!("contents {:?}", contents);
 
         if let Value::IndirectObject(ss) = &contents {
             if ss.object.is_none() {
                 contents = objects.get(ss.object_number).unwrap().clone();
             } else {
                 contents = ss.object.as_ref().unwrap().clone();
+            }
+        }
+
+        if let Value::Array(array) = &mut contents {
+            for obj in array.0.iter_mut() {
+                if let Value::IndirectObject(ss) = obj {
+                    let ii = objects.get(ss.object_number);
+                    if ii.is_none() {
+                        panic!()
+                    }
+                    let ii = ii.unwrap();
+                    *obj = ii;
+                }
             }
         }
         println!("id {} contents {:?}", id, contents);

--- a/pdf-parser/Cargo.toml
+++ b/pdf-parser/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 pdf-tokenizer = { path = "../pdf-tokenizer" }
 pdf-object = { path = "../pdf-object" }
+flate2 = "1.1.1"

--- a/pdf-parser/src/array.rs
+++ b/pdf-parser/src/array.rs
@@ -39,7 +39,7 @@ impl ParseObject<Array> for PdfParser<'_> {
 
             match self.parse_object() {
                 Ok(value) => {
-                    values.push(Box::new(value));
+                    values.push(value);
                 }
                 Err(err) => {
                     return Err(ParserError::ArrayError(ArrayError::InvalidObject(format!(


### PR DESCRIPTION
This commit introduces support for decompressing PDF stream objects that are encoded with the "FlateDecode" filter.

Closes #4