### PR TITLE
PDF content stream parser implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,11 @@ dependencies = [
 [[package]]
 name = "pdf-operator"
 version = "0.1.0"
+dependencies = [
+ "pdf-object",
+ "pdf-parser",
+ "pdf-tokenizer",
+]
 
 [[package]]
 name = "pdf-page"

--- a/pdf-object/src/number.rs
+++ b/pdf-object/src/number.rs
@@ -12,6 +12,7 @@ impl From<i64> for Number {
         }
     }
 }
+
 impl From<f64> for Number {
     fn from(value: f64) -> Self {
         Number {
@@ -20,8 +21,29 @@ impl From<f64> for Number {
         }
     }
 }
+
 impl Number {
     pub fn new(value: impl Into<Number>) -> Self {
         value.into()
+    }
+
+    pub fn as_f32(&self) -> Option<f32> {
+        if let Some(value) = self.real {
+            Some(value as f32)
+        } else if let Some(value) = self.integer {
+            Some(value as f32)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_i64(&self) -> Option<i64> {
+        if let Some(value) = self.real {
+            Some(value as i64)
+        } else if let Some(value) = self.integer {
+            Some(value)
+        } else {
+            None
+        }
     }
 }

--- a/pdf-operator/Cargo.toml
+++ b/pdf-operator/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+pdf-parser = { path = "../pdf-parser" }
+pdf-tokenizer = { path = "../pdf-tokenizer" }
+pdf-object = { path = "../pdf-object" }

--- a/pdf-operator/src/clipping_path_operators.rs
+++ b/pdf-operator/src/clipping_path_operators.rs
@@ -1,4 +1,7 @@
-use crate::{error::PdfPainterError, pdf_operator::PdfOperatorVariant};
+use crate::{
+    error::PdfPainterError,
+    pdf_operator::{Operands, PdfOperatorVariant},
+};
 
 /// Modifies the current clipping path by intersecting it with the current path, using the non-zero winding number rule to determine the region to clip.
 /// (PDF operator `W`)
@@ -10,14 +13,12 @@ impl ClipNonZero {
         "W"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::ClipNonZero(Self::new()))
     }
 }
 
@@ -31,13 +32,11 @@ impl ClipEvenOdd {
         "W*"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::ClipEvenOdd(Self::new()))
     }
 }

--- a/pdf-operator/src/color_operators.rs
+++ b/pdf-operator/src/color_operators.rs
@@ -1,4 +1,7 @@
-use crate::{error::PdfPainterError, pdf_operator::PdfOperatorVariant};
+use crate::{
+    error::PdfPainterError,
+    pdf_operator::{Operands, PdfOperatorVariant},
+};
 
 /// Sets the fill color to a grayscale value. (PDF operator `g`)
 /// The gray level applies to subsequent fill operations.
@@ -17,10 +20,9 @@ impl SetGrayFill {
         Self { gray }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let gray = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetGrayFill(Self::new(gray)))
     }
 }
 
@@ -41,10 +43,9 @@ impl SetGrayStroke {
         Self { gray }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let gray = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetGrayStroke(Self::new(gray)))
     }
 }
 
@@ -69,10 +70,11 @@ impl SetRGBFill {
         Self { r, g, b }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let r = operands.get_f32()?;
+        let g = operands.get_f32()?;
+        let b = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetRGBFill(Self::new(r, g, b)))
     }
 }
 
@@ -97,10 +99,11 @@ impl SetRGBStroke {
         Self { r, g, b }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let r = operands.get_f32()?;
+        let g = operands.get_f32()?;
+        let b = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetRGBStroke(Self::new(r, g, b)))
     }
 }
 
@@ -127,10 +130,12 @@ impl SetCMYKFill {
         Self { c, m, y, k }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let c = operands.get_f32()?;
+        let m = operands.get_f32()?;
+        let y = operands.get_f32()?;
+        let k = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetCMYKFill(Self::new(c, m, y, k)))
     }
 }
 
@@ -157,9 +162,11 @@ impl SetCMYKStroke {
         Self { c, m, y, k }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let c = operands.get_f32()?;
+        let m = operands.get_f32()?;
+        let y = operands.get_f32()?;
+        let k = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetCMYKStroke(Self::new(c, m, y, k)))
     }
 }

--- a/pdf-operator/src/error.rs
+++ b/pdf-operator/src/error.rs
@@ -1,7 +1,12 @@
+use pdf_parser::error::ParserError;
+use pdf_tokenizer::error::TokenizerError;
+
 /// Defines errors that can occur in pdf-painter crate.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PdfPainterError {
     UnimplementedOperation(&'static str),
+    OperandTokenizationError(String),
+    InvalidOperandType,
 }
 
 impl std::fmt::Display for PdfPainterError {
@@ -10,6 +15,24 @@ impl std::fmt::Display for PdfPainterError {
             PdfPainterError::UnimplementedOperation(name) => {
                 write!(f, "Unimplemented operation: {}", name)
             }
+            PdfPainterError::OperandTokenizationError(err) => {
+                write!(f, "Operand tokenization error: {}", err)
+            }
+            PdfPainterError::InvalidOperandType => {
+                write!(f, "Invalid operand type")
+            }
         }
+    }
+}
+
+impl From<TokenizerError> for PdfPainterError {
+    fn from(value: TokenizerError) -> Self {
+        Self::OperandTokenizationError(value.to_string())
+    }
+}
+
+impl From<ParserError> for PdfPainterError {
+    fn from(value: ParserError) -> Self {
+        Self::OperandTokenizationError(value.to_string())
     }
 }

--- a/pdf-operator/src/graphics_state_operators.rs
+++ b/pdf-operator/src/graphics_state_operators.rs
@@ -1,4 +1,7 @@
-use crate::{error::PdfPainterError, pdf_operator::PdfOperatorVariant};
+use crate::{
+    error::PdfPainterError,
+    pdf_operator::{Operands, PdfOperatorVariant},
+};
 
 /// Sets the line width for path stroking. (PDF operator `w`)
 #[derive(Debug, Clone, PartialEq)]
@@ -16,10 +19,9 @@ impl SetLineWidth {
         Self { width }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let width = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetLineWidth(Self::new(width)))
     }
 }
 
@@ -40,10 +42,9 @@ impl SetLineCapStyle {
         Self { style }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let style = operands.get_u8()?;
+        Ok(PdfOperatorVariant::SetLineCapStyle(Self::new(style)))
     }
 }
 
@@ -64,10 +65,9 @@ impl SetLineJoinStyle {
         Self { style }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let style = operands.get_u8()?;
+        Ok(PdfOperatorVariant::SetLineJoinStyle(Self::new(style)))
     }
 }
 
@@ -88,10 +88,9 @@ impl SetMiterLimit {
         Self { limit }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let limit = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetMiterLimit(Self::new(limit)))
     }
 }
 
@@ -113,10 +112,10 @@ impl SetDashPattern {
         Self { array, phase }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let array = operands.get_f32_array()?;
+        let phase = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetDashPattern(Self::new(array, phase)))
     }
 }
 
@@ -129,13 +128,12 @@ impl SaveGraphicsState {
         "q"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::SaveGraphicsState(Self::new()))
     }
 }
 
@@ -148,13 +146,11 @@ impl RestoreGraphicsState {
         "Q"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::RestoreGraphicsState(Self::new()))
     }
 }
 
@@ -175,9 +171,15 @@ impl ConcatMatrix {
         Self { matrix }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let a = operands.get_f32()?;
+        let b = operands.get_f32()?;
+        let c = operands.get_f32()?;
+        let d = operands.get_f32()?;
+        let e = operands.get_f32()?;
+        let f = operands.get_f32()?;
+        Ok(PdfOperatorVariant::ConcatMatrix(Self::new([
+            a, b, c, d, e, f,
+        ])))
     }
 }

--- a/pdf-operator/src/lib.rs
+++ b/pdf-operator/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod graphics_state_operators;
 pub mod marked_content_operators;
 pub mod operation_map;
+pub mod operator_tokenizer;
 pub mod path_operators;
 pub mod path_paint_operators;
 pub mod pdf_operator;
@@ -12,6 +13,8 @@ pub mod text_positioning_operators;
 pub mod text_showing_operators;
 pub mod text_state_operators;
 pub mod xobject_and_image_operators;
+
+extern crate alloc;
 
 // TextElement enum for ShowTextArray operator
 #[derive(Debug, Clone, PartialEq)]

--- a/pdf-operator/src/marked_content_operators.rs
+++ b/pdf-operator/src/marked_content_operators.rs
@@ -1,4 +1,7 @@
-use crate::{error::PdfPainterError, pdf_operator::PdfOperatorVariant};
+use crate::{
+    error::PdfPainterError,
+    pdf_operator::{Operands, PdfOperatorVariant},
+};
 
 /// Begins a marked-content sequence. (PDF operator `BMC`)
 /// Marked-content sequences associate a tag with a sequence of content stream operations.
@@ -17,10 +20,9 @@ impl BeginMarkedContent {
         Self { tag }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let tag = operands.get_str()?;
+        Ok(PdfOperatorVariant::BeginMarkedContent(Self::new(tag)))
     }
 }
 
@@ -44,10 +46,12 @@ impl BeginMarkedContentWithProps {
         Self { tag, properties }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let tag = operands.get_str()?;
+        let properties = operands.get_str()?;
+        Ok(PdfOperatorVariant::BeginMarkedContentWithProps(Self::new(
+            tag, properties,
+        )))
     }
 }
 
@@ -60,13 +64,11 @@ impl EndMarkedContent {
         "EMC"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::EndMarkedContent(Self::new()))
     }
 }

--- a/pdf-operator/src/operation_map.rs
+++ b/pdf-operator/src/operation_map.rs
@@ -1,8 +1,18 @@
+use pdf_object::Value;
+
 use crate::{
-    clipping_path_operators::*, color_operators::*, error::PdfPainterError,
-    graphics_state_operators::*, marked_content_operators::*, path_operators::*,
-    path_paint_operators::*, pdf_operator::PdfOperatorVariant, text_object_operators::*,
-    text_positioning_operators::*, text_showing_operators::*, text_state_operators::*,
+    clipping_path_operators::*,
+    color_operators::*,
+    error::PdfPainterError,
+    graphics_state_operators::*,
+    marked_content_operators::*,
+    path_operators::*,
+    path_paint_operators::*,
+    pdf_operator::{Operands, PdfOperatorVariant},
+    text_object_operators::*,
+    text_positioning_operators::*,
+    text_showing_operators::*,
+    text_state_operators::*,
     xobject_and_image_operators::*,
 };
 
@@ -12,15 +22,15 @@ use crate::{
 /// encountered in the PDF content.
 pub struct OperationMap {
     /// The string representation of the PDF operator (e.g., "m", "BT", "rg").
-    name: &'static str,
+    pub name: &'static str,
     /// A function pointer to the parser for this specific operator.
     /// The parser function takes a mutable vector of `PdfOperator` trait objects,
     /// reads the operator and its operands from an (implicit) input stream,
     /// and adds the newly created operator object to the vector.
-    parser: fn() -> Result<PdfOperatorVariant, PdfPainterError>,
+    pub parser: fn(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError>,
 }
 
-pub const READ_MAP: &'static [OperationMap] = &[
+pub(crate) const READ_MAP: &'static [OperationMap] = &[
     OperationMap {
         name: ClipNonZero::operator_name(),
         parser: ClipNonZero::read,

--- a/pdf-operator/src/operator_tokenizer.rs
+++ b/pdf-operator/src/operator_tokenizer.rs
@@ -1,0 +1,91 @@
+use alloc::borrow::Cow;
+use pdf_object::comment::Comment;
+use pdf_parser::{ParseObject, PdfParser, error::ParserError};
+use pdf_tokenizer::PdfToken;
+
+use crate::error::PdfPainterError;
+
+/// Defines a trait for reading PDF operators and their operands from an input source.
+///
+/// This trait abstracts the underlying data source and provides methods to read
+/// specific types of data required for parsing PDF content stream operators.
+pub trait OperatorReader<'a> {
+    /// Reads the name of a PDF operator from the input.
+    ///
+    /// Operator names are typically one or two alphabetic characters.
+    /// Whitespace preceding the operator name is skipped.
+    fn read_operation_name(&mut self) -> Result<Cow<'a, str>, PdfPainterError>;
+
+    /// Reads a floating-point number from the input.
+    fn read_operand(&mut self) -> Result<f32, PdfPainterError>;
+
+    /// Skips whitespaces and comments.
+    fn skip_whitespace_and_comments(&mut self) -> Result<(), PdfPainterError>;
+}
+
+impl<'a> OperatorReader<'a> for PdfParser<'a> {
+    fn read_operation_name(&mut self) -> Result<Cow<'a, str>, PdfPainterError> {
+        self.skip_whitespace();
+
+        let name_bytes = self
+            .tokenizer
+            .read_while_u8(|b| b.is_ascii_alphabetic() || b == b'*');
+        if name_bytes.is_empty() {
+            return Ok(Cow::Borrowed(""));
+        }
+
+        Ok(String::from_utf8_lossy(&name_bytes))
+    }
+
+    fn read_operand(&mut self) -> Result<f32, PdfPainterError> {
+        self.skip_whitespace();
+        let mut has_minus = false;
+
+        // 1. Check for optional sign.
+        if let Some(PdfToken::Plus) = self.tokenizer.peek()? {
+            self.tokenizer.read();
+        } else if let Some(PdfToken::Minus) = self.tokenizer.peek()? {
+            self.tokenizer.read();
+            has_minus = true;
+        }
+        // 2. Parse leading digits (integral part).
+        let digits = self.read_number::<i32>()?;
+
+        // 3. Check for decimal point
+        if let Some(PdfToken::Period) = self.tokenizer.peek()? {
+            self.tokenizer.read();
+            // 4. Parse fractional part.
+            let fraction = self.read_number::<i32>()?;
+            // 5. Combine integral and fractional parts.
+            let number_str = if has_minus {
+                format!("-{}.{}", digits, fraction)
+            } else {
+                format!("{}.{}", digits, fraction)
+            };
+            // 6. Convert to f64.
+            let number = number_str
+                .parse::<f32>()
+                .map_err(|err| PdfPainterError::OperandTokenizationError(err.to_string()))?;
+
+            self.skip_whitespace();
+            Ok(number)
+        } else {
+            // 7. No decimal point, parse as integer.
+            self.skip_whitespace();
+            if has_minus {
+                Ok(-(digits as f32))
+            } else {
+                Ok(digits as f32)
+            }
+        }
+    }
+
+    fn skip_whitespace_and_comments(&mut self) -> Result<(), PdfPainterError> {
+        self.skip_whitespace();
+
+        if let Some(PdfToken::Percent) = self.tokenizer.peek()? {
+            let _comment: Result<Comment, ParserError> = self.parse();
+        }
+        Ok(())
+    }
+}

--- a/pdf-operator/src/path_operators.rs
+++ b/pdf-operator/src/path_operators.rs
@@ -1,4 +1,7 @@
-use crate::{error::PdfPainterError, pdf_operator::PdfOperatorVariant};
+use crate::{
+    error::PdfPainterError,
+    pdf_operator::{Operands, PdfOperatorVariant},
+};
 
 /// Begins a new subpath by moving the current point to coordinates (x, y), omitting any connecting line segment. (PDF operator `m`)
 /// If the `m` operator is the first operator in a path, it sets the current point.
@@ -14,17 +17,15 @@ impl MoveTo {
     pub const fn operator_name() -> &'static str {
         "m"
     }
-}
 
-impl MoveTo {
     pub fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let x = operands.get_f32()?;
+        let y = operands.get_f32()?;
+        Ok(PdfOperatorVariant::MoveTo(Self::new(x, y)))
     }
 }
 
@@ -42,17 +43,15 @@ impl LineTo {
     pub const fn operator_name() -> &'static str {
         "l"
     }
-}
 
-impl LineTo {
     pub fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let x = operands.get_f32()?;
+        let y = operands.get_f32()?;
+        Ok(PdfOperatorVariant::LineTo(Self::new(x, y)))
     }
 }
 
@@ -79,9 +78,7 @@ impl CurveTo {
     pub const fn operator_name() -> &'static str {
         "c"
     }
-}
 
-impl CurveTo {
     pub fn new(x1: f32, y1: f32, x2: f32, y2: f32, x3: f32, y3: f32) -> Self {
         Self {
             x1,
@@ -93,10 +90,16 @@ impl CurveTo {
         }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let x1 = operands.get_f32()?;
+        let y1 = operands.get_f32()?;
+        let x2 = operands.get_f32()?;
+        let y2 = operands.get_f32()?;
+        let x3 = operands.get_f32()?;
+        let y3 = operands.get_f32()?;
+        Ok(PdfOperatorVariant::CurveTo(Self::new(
+            x1, y1, x2, y2, x3, y3,
+        )))
     }
 }
 
@@ -125,10 +128,12 @@ impl CurveToV {
         Self { x2, y2, x3, y3 }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let x2 = operands.get_f32()?;
+        let y2 = operands.get_f32()?;
+        let x3 = operands.get_f32()?;
+        let y3 = operands.get_f32()?;
+        Ok(PdfOperatorVariant::CurveToV(Self::new(x2, y2, x3, y3)))
     }
 }
 
@@ -156,10 +161,12 @@ impl CurveToY {
         Self { x1, y1, x3, y3 }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let x1 = operands.get_f32()?;
+        let y1 = operands.get_f32()?;
+        let x3 = operands.get_f32()?;
+        let y3 = operands.get_f32()?;
+        Ok(PdfOperatorVariant::CurveToY(Self::new(x1, y1, x3, y3)))
     }
 }
 
@@ -173,13 +180,12 @@ impl ClosePath {
         "h"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::ClosePath(Self::new()))
     }
 }
 
@@ -212,9 +218,13 @@ impl Rectangle {
         }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let x = operands.get_f32()?;
+        let y = operands.get_f32()?;
+        let width = operands.get_f32()?;
+        let height = operands.get_f32()?;
+        Ok(PdfOperatorVariant::Rectangle(Self::new(
+            x, y, width, height,
+        )))
     }
 }

--- a/pdf-operator/src/path_paint_operators.rs
+++ b/pdf-operator/src/path_paint_operators.rs
@@ -1,4 +1,7 @@
-use crate::{error::PdfPainterError, pdf_operator::PdfOperatorVariant};
+use crate::{
+    error::PdfPainterError,
+    pdf_operator::{Operands, PdfOperatorVariant},
+};
 
 /// Strokes the current path. (PDF operator `S`)
 #[derive(Debug, Clone, PartialEq)]
@@ -9,14 +12,12 @@ impl StrokePath {
         "S"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::StrokePath(Self::new()))
     }
 }
 
@@ -30,14 +31,12 @@ impl CloseStrokePath {
         "s"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::CloseStrokePath(Self::new()))
     }
 }
 
@@ -51,14 +50,12 @@ impl FillPathNonZero {
         "f" // TODO: or "F"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::FillPathNonZero(Self::new()))
     }
 }
 
@@ -71,14 +68,12 @@ impl FillPathEvenOdd {
         "f*"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::FillPathEvenOdd(Self::new()))
     }
 }
 
@@ -92,14 +87,12 @@ impl FillAndStrokePathNonZero {
         "B"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::FillAndStrokePathNonZero(Self::new()))
     }
 }
 
@@ -113,14 +106,12 @@ impl FillAndStrokePathEvenOdd {
         "B*"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::FillAndStrokePathEvenOdd(Self::new()))
     }
 }
 
@@ -134,13 +125,13 @@ impl CloseFillAndStrokePathNonZero {
         "b"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::CloseFillAndStrokePathNonZero(
+            Self::new(),
         ))
     }
 }
@@ -155,13 +146,13 @@ impl CloseFillAndStrokePathEvenOdd {
         "b*"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::CloseFillAndStrokePathEvenOdd(
+            Self::new(),
         ))
     }
 }
@@ -176,13 +167,11 @@ impl EndPath {
         "n"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::EndPath(Self::new()))
     }
 }

--- a/pdf-operator/src/pdf_operator.rs
+++ b/pdf-operator/src/pdf_operator.rs
@@ -1,9 +1,129 @@
+use pdf_object::{Value, comment::Comment};
+use pdf_parser::{ParseObject, PdfParser};
+use pdf_tokenizer::PdfToken;
+
 use crate::{
-    clipping_path_operators::*, color_operators::*, graphics_state_operators::*,
-    marked_content_operators::*, path_operators::*, path_paint_operators::*,
+    TextElement, clipping_path_operators::*, color_operators::*, error::PdfPainterError,
+    graphics_state_operators::*, marked_content_operators::*, operation_map::READ_MAP,
+    operator_tokenizer::OperatorReader, path_operators::*, path_paint_operators::*,
     text_object_operators::*, text_positioning_operators::*, text_showing_operators::*,
     text_state_operators::*, xobject_and_image_operators::*,
 };
+
+pub trait Op {
+    const NAME: &'static str;
+    const INSTRUCTION: &'static str;
+    const OPERAND_COUNT: usize;
+}
+
+pub struct Operands<'a>(&'a [Value]);
+
+impl Operands<'_> {
+    pub fn get_f32(&mut self) -> Result<f32, PdfPainterError> {
+        let value = self.0.get(0);
+        self.0 = &self.0[1..];
+
+        if let Some(Value::Number(number)) = value {
+            if let Some(number) = number.as_f32() {
+                Ok(number)
+            } else {
+                Err(PdfPainterError::InvalidOperandType)
+            }
+        } else {
+            Err(PdfPainterError::InvalidOperandType)
+        }
+    }
+
+    pub fn get_str(&mut self) -> Result<String, PdfPainterError> {
+        let value = self.0.get(0);
+        self.0 = &self.0[1..];
+
+        if let Some(Value::LiteralString(string)) = value {
+            Ok(string.0.clone())
+        } else if let Some(Value::HexString(string)) = value {
+            Ok(string.0.clone())
+        } else {
+            Err(PdfPainterError::InvalidOperandType)
+        }
+    }
+
+    pub fn get_name(&mut self) -> Result<String, PdfPainterError> {
+        let value = self.0.get(0);
+        self.0 = &self.0[1..];
+
+        if let Some(Value::Name(name)) = value {
+            Ok(name.0.clone())
+        } else {
+            Err(PdfPainterError::InvalidOperandType)
+        }
+    }
+
+    pub fn get_u8(&mut self) -> Result<u8, PdfPainterError> {
+        let value = self.0.get(0);
+        self.0 = &self.0[1..];
+
+        if let Some(Value::Number(number)) = value {
+            if let Some(number) = number.as_i64() {
+                u8::try_from(number).map_err(|_| PdfPainterError::InvalidOperandType)
+            } else {
+                Err(PdfPainterError::InvalidOperandType)
+            }
+        } else {
+            Err(PdfPainterError::InvalidOperandType)
+        }
+    }
+
+    pub fn get_text_element_array(&mut self) -> Result<Vec<TextElement>, PdfPainterError> {
+        let value = self.0.get(0);
+        self.0 = &self.0[1..];
+
+        if let Some(Value::Array(array_values)) = value {
+            let mut elements = Vec::new();
+            for val_obj in &array_values.0 {
+                match val_obj {
+                    Value::LiteralString(s) => {
+                        elements.push(TextElement::Text { value: s.0.clone() });
+                    }
+                    Value::Number(n) => {
+                        if let Some(num_f32) = n.as_f32() {
+                            elements.push(TextElement::Adjustment { amount: num_f32 });
+                        } else {
+                            return Err(PdfPainterError::InvalidOperandType);
+                        }
+                    }
+                    _ => return Err(PdfPainterError::InvalidOperandType),
+                }
+            }
+            Ok(elements)
+        } else {
+            Err(PdfPainterError::InvalidOperandType)
+        }
+    }
+
+    pub fn get_f32_array(&mut self) -> Result<Vec<f32>, PdfPainterError> {
+        let value = self.0.get(0);
+        self.0 = &self.0[1..];
+
+        if let Some(Value::Array(array_values)) = value {
+            let mut numbers = Vec::new();
+            for val_obj in &array_values.0 {
+                match val_obj {
+                    Value::Number(n) => {
+                        if let Some(num_f32) = n.as_f32() {
+                            numbers.push(num_f32);
+                        } else {
+                            return Err(PdfPainterError::InvalidOperandType);
+                        }
+                    }
+                    _ => return Err(PdfPainterError::InvalidOperandType),
+                }
+            }
+            Ok(numbers)
+        } else {
+            Err(PdfPainterError::InvalidOperandType)
+        }
+    }
+}
 
 /// Represents all possible PDF content stream operators defined within this crate.
 ///
@@ -13,6 +133,7 @@ use crate::{
 ///
 /// Each operator performs a specific function, such as
 /// drawing a line, displaying text, or setting a color.
+#[derive(Debug, Clone, PartialEq)]
 pub enum PdfOperatorVariant {
     LineTo(LineTo),
     MoveTo(MoveTo),
@@ -70,4 +191,306 @@ pub enum PdfOperatorVariant {
     BeginInlineImage(BeginInlineImage),
     InlineImageData(InlineImageData),
     EndInlineImage(EndInlineImage),
+}
+
+impl PdfOperatorVariant {
+    pub fn from(input: &[u8]) -> Result<Vec<PdfOperatorVariant>, PdfPainterError> {
+        let mut parser = PdfParser::from(input);
+        let mut operators = Vec::new();
+        let mut operands = Vec::new();
+
+        loop {
+            parser.skip_whitespace();
+
+            if let Some(PdfToken::Percent) = parser.tokenizer.peek()? {
+                let _comment: Comment = parser.parse()?;
+                continue;
+            }
+
+            let peeked = parser.tokenizer.peek()?;
+            if peeked.is_none() {
+                break;
+            }
+
+            if let Some(PdfToken::Alphabetic(_)) = &peeked {
+                let name = parser.read_operation_name()?;
+                if name.is_empty() {
+                    break;
+                }
+
+                for operation in READ_MAP {
+                    if name == operation.name {
+                        let mut ops = Operands(operands.as_slice());
+                        let operator = (operation.parser)(&mut ops)?;
+                        operators.push(operator);
+
+                        // Clear operands after they've been consumed.
+                        operands.clear();
+                        break;
+                    }
+                }
+                continue;
+            }
+
+            let value = parser.parse_object()?;
+            operands.push(value);
+        }
+
+        Ok(operators)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_simple() {
+        struct TestCase<'a> {
+            description: &'a str,
+            input: &'a [u8],
+            expected_ops: Vec<PdfOperatorVariant>,
+        }
+
+        let test_cases = vec![
+            TestCase {
+                description: "1. Simple moveto (m)",
+                input: b"100 100 m",
+                expected_ops: vec![PdfOperatorVariant::MoveTo(MoveTo::new(100.0, 100.0))],
+            },
+            TestCase {
+                description: "2. Moveto with real numbers",
+                input: b"50.5 75.2 m",
+                expected_ops: vec![PdfOperatorVariant::MoveTo(MoveTo::new(50.5, 75.2))],
+            },
+            TestCase {
+                description: "3. Moveto with negative coordinates",
+                input: b"-10 -20 m",
+                expected_ops: vec![PdfOperatorVariant::MoveTo(MoveTo::new(-10.0, -20.0))],
+            },
+            TestCase {
+                description: "4. Moveto followed by lineto (l)",
+                input: b"10 10 m 200 50 l",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(200.0, 50.0)),
+                ],
+            },
+            TestCase {
+                description: "5. Multiple lineto operations",
+                input: b"10 10 m 50 10 l 50 50 l 10 50 l",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 50.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(10.0, 50.0)),
+                ],
+            },
+            TestCase {
+                description: "6. Simple closepath (h) after drawing lines",
+                input: b"10 10 m 50 10 l 50 50 l h",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 50.0)),
+                    PdfOperatorVariant::ClosePath(ClosePath::new()),
+                ],
+            },
+            TestCase {
+                description: "7. Simple rectangle (re)",
+                input: b"50 50 100 75 re",
+                expected_ops: vec![PdfOperatorVariant::Rectangle(Rectangle::new(
+                    50.0, 50.0, 100.0, 75.0,
+                ))],
+            },
+            TestCase {
+                description: "8. Simple Bézier curve (c)",
+                input: b"0 0 m 10 10 90 10 100 0 c",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(0.0, 0.0)),
+                    PdfOperatorVariant::CurveTo(CurveTo::new(10.0, 10.0, 90.0, 10.0, 100.0, 0.0)),
+                ],
+            },
+            TestCase {
+                description: "9. Input with comments",
+                input:
+                    b"% initial comment\n10 20 m % moveto\n % another comment\n 30 40 l % lineto\n",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 20.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(30.0, 40.0)),
+                ],
+            },
+            TestCase {
+                description: "10. Empty input",
+                input: b"",
+                expected_ops: vec![],
+            },
+            TestCase {
+                description: "11. Comments and whitespace only",
+                input: b" % first comment \n % second comment \n ",
+                expected_ops: vec![],
+            },
+            TestCase {
+                description: "11. Multiple operators with varied spacing",
+                input: b" 10 10 m \n 20 20 l \r\n 30 30 l h ",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(20.0, 20.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(30.0, 30.0)),
+                    PdfOperatorVariant::ClosePath(ClosePath::new()),
+                ],
+            },
+            TestCase {
+                description: "12. Multiple subpaths (multiple 'm' operators)",
+                input: b"10 10 m 50 50 l 100 100 m 150 150 l",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 50.0)),
+                    PdfOperatorVariant::MoveTo(MoveTo::new(100.0, 100.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(150.0, 150.0)),
+                ],
+            },
+            TestCase {
+                description: "13. Rectangle followed by moveto/lineto",
+                input: b"10 10 50 50 re 70 70 m 100 100 l",
+                expected_ops: vec![
+                    PdfOperatorVariant::Rectangle(Rectangle::new(10.0, 10.0, 50.0, 50.0)),
+                    PdfOperatorVariant::MoveTo(MoveTo::new(70.0, 70.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(100.0, 100.0)),
+                ],
+            },
+            TestCase {
+                description: "14. Path construction followed by Stroke (S)",
+                input: b"10 10 m 100 100 l S",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(100.0, 100.0)),
+                    PdfOperatorVariant::StrokePath(StrokePath::new()),
+                ],
+            },
+            TestCase {
+                description: "15. Path construction followed by Fill (f)",
+                input: b"10 10 m 50 10 l 50 50 l 10 50 l h f",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 50.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(10.0, 50.0)),
+                    PdfOperatorVariant::ClosePath(ClosePath::new()),
+                    PdfOperatorVariant::FillPathNonZero(FillPathNonZero::new()),
+                ],
+            },
+            TestCase {
+                description: "16. Path construction followed by Fill EvenOdd (f*)",
+                input: b"10 10 m 50 10 l 50 50 l 10 50 l h f*",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 50.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(10.0, 50.0)),
+                    PdfOperatorVariant::ClosePath(ClosePath::new()),
+                    PdfOperatorVariant::FillPathEvenOdd(FillPathEvenOdd::new()),
+                ],
+            },
+            TestCase {
+                description: "17. Path construction followed by Stroke and Close (s)",
+                input: b"10 10 m 50 10 l 50 50 l s",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 50.0)),
+                    PdfOperatorVariant::CloseStrokePath(CloseStrokePath::new()),
+                ],
+            },
+            TestCase {
+                description: "18. Path construction followed by Fill and Stroke (B)",
+                input: b"10 10 100 50 re B",
+                expected_ops: vec![
+                    PdfOperatorVariant::Rectangle(Rectangle::new(10.0, 10.0, 100.0, 50.0)),
+                    PdfOperatorVariant::FillAndStrokePathNonZero(FillAndStrokePathNonZero::new()),
+                ],
+            },
+            TestCase {
+                description: "19. Path construction followed by Fill and Stroke EvenOdd (B*)",
+                input: b"10 10 100 50 re B*",
+                expected_ops: vec![
+                    PdfOperatorVariant::Rectangle(Rectangle::new(10.0, 10.0, 100.0, 50.0)),
+                    PdfOperatorVariant::FillAndStrokePathEvenOdd(FillAndStrokePathEvenOdd::new()),
+                ],
+            },
+            TestCase {
+                description: "20. Path construction followed by Close, Fill and Stroke (b)",
+                input: b"10 10 m 50 10 l 50 50 l b",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 50.0)),
+                    PdfOperatorVariant::CloseFillAndStrokePathNonZero(
+                        CloseFillAndStrokePathNonZero::new(),
+                    ),
+                ],
+            },
+            TestCase {
+                description: "21. Path construction followed by Close, Fill and Stroke EvenOdd (b*)",
+                input: b"10 10 m 50 10 l 50 50 l b*",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 50.0)),
+                    PdfOperatorVariant::CloseFillAndStrokePathEvenOdd(
+                        CloseFillAndStrokePathEvenOdd::new(),
+                    ),
+                ],
+            },
+            TestCase {
+                description: "22. Path construction followed by End Path (n)",
+                input: b"10 10 m 100 100 l n",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(100.0, 100.0)),
+                    PdfOperatorVariant::EndPath(EndPath::new()),
+                ],
+            },
+            TestCase {
+                description: "23. Complex sequence with curves and lines",
+                input: b"0 0 m 50 100 l 100 0 150 100 200 0 c 250 -50 300 0 y h",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(0.0, 0.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(50.0, 100.0)),
+                    PdfOperatorVariant::CurveTo(CurveTo::new(100.0, 0.0, 150.0, 100.0, 200.0, 0.0)),
+                    PdfOperatorVariant::CurveToY(CurveToY::new(250.0, -50.0, 300.0, 0.0)),
+                    PdfOperatorVariant::ClosePath(ClosePath::new()),
+                ],
+            },
+            TestCase {
+                description: "24. Multiple paths with stroke",
+                input: b"10 10 m 100 100 l 200 200 m 300 300 l S",
+                expected_ops: vec![
+                    PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 10.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(100.0, 100.0)),
+                    PdfOperatorVariant::MoveTo(MoveTo::new(200.0, 200.0)),
+                    PdfOperatorVariant::LineTo(LineTo::new(300.0, 300.0)),
+                    PdfOperatorVariant::StrokePath(StrokePath::new()),
+                ],
+            },
+        ];
+
+        for tc in test_cases {
+            let actual_ops = PdfOperatorVariant::from(tc.input).unwrap_or_else(|e| {
+                panic!(
+                    "Failed for test '{}': {:?}, input: '{}'",
+                    tc.description,
+                    e,
+                    String::from_utf8_lossy(tc.input)
+                );
+            });
+            assert_eq!(
+                actual_ops,
+                tc.expected_ops,
+                "Mismatch for test: '{}', input: '{}'",
+                tc.description,
+                String::from_utf8_lossy(tc.input)
+            );
+        }
+    }
 }

--- a/pdf-operator/src/text_object_operators.rs
+++ b/pdf-operator/src/text_object_operators.rs
@@ -1,4 +1,7 @@
-use crate::{error::PdfPainterError, pdf_operator::PdfOperatorVariant};
+use crate::{
+    error::PdfPainterError,
+    pdf_operator::{Operands, PdfOperatorVariant},
+};
 
 /// Begins a text object, initializing the text matrix and text line matrix to the identity matrix. (PDF operator `BT`)
 #[derive(Debug, Clone, PartialEq)]
@@ -9,14 +12,12 @@ impl BeginText {
         "BT"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::BeginText(Self::new()))
     }
 }
 
@@ -29,13 +30,11 @@ impl EndText {
         "ET"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::EndText(Self::new()))
     }
 }

--- a/pdf-operator/src/text_positioning_operators.rs
+++ b/pdf-operator/src/text_positioning_operators.rs
@@ -1,4 +1,7 @@
-use crate::{error::PdfPainterError, pdf_operator::PdfOperatorVariant};
+use crate::{
+    error::PdfPainterError,
+    pdf_operator::{Operands, PdfOperatorVariant},
+};
 
 /// Moves to the start of the next line, offset from the start of the current line by (`tx`, `ty`). (PDF operator `Td`)
 /// `tx` and `ty` are numbers expressed in unscaled text space units.
@@ -21,10 +24,10 @@ impl MoveTextPosition {
         Self { tx, ty }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let tx = operands.get_f32()?;
+        let ty = operands.get_f32()?;
+        Ok(PdfOperatorVariant::MoveTextPosition(Self::new(tx, ty)))
     }
 }
 
@@ -48,9 +51,11 @@ impl MoveTextPositionAndSetLeading {
         Self { tx, ty }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let tx = operands.get_f32()?;
+        let ty = operands.get_f32()?;
+        Ok(PdfOperatorVariant::MoveTextPositionAndSetLeading(
+            Self::new(tx, ty),
         ))
     }
 }
@@ -76,10 +81,16 @@ impl SetTextMatrix {
         Self { matrix }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let a = operands.get_f32()?;
+        let b = operands.get_f32()?;
+        let c = operands.get_f32()?;
+        let d = operands.get_f32()?;
+        let e = operands.get_f32()?;
+        let f = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetTextMatrix(Self::new([
+            a, b, c, d, e, f,
+        ])))
     }
 }
 
@@ -94,13 +105,11 @@ impl MoveToNextLine {
         "T*"
     }
 
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(_operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        Ok(PdfOperatorVariant::MoveToNextLine(Self::new()))
     }
 }

--- a/pdf-operator/src/text_showing_operators.rs
+++ b/pdf-operator/src/text_showing_operators.rs
@@ -1,5 +1,8 @@
 use crate::TextElement;
-use crate::{error::PdfPainterError, pdf_operator::PdfOperatorVariant};
+use crate::{
+    error::PdfPainterError,
+    pdf_operator::{Operands, PdfOperatorVariant},
+};
 
 /// Shows a text string. (PDF operator `Tj`)
 #[derive(Debug, Clone, PartialEq)]
@@ -17,10 +20,9 @@ impl ShowText {
         Self { text }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let text = operands.get_str()?;
+        Ok(PdfOperatorVariant::ShowText(Self::new(text)))
     }
 }
 
@@ -41,10 +43,9 @@ impl MoveNextLineShowText {
         Self { text }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let text = operands.get_str()?;
+        Ok(PdfOperatorVariant::MoveNextLineShowText(Self::new(text)))
     }
 }
 
@@ -74,10 +75,15 @@ impl SetSpacingMoveShowText {
         }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let word_spacing = operands.get_f32()?;
+        let char_spacing = operands.get_f32()?;
+        let text = operands.get_str()?;
+        Ok(PdfOperatorVariant::SetSpacingMoveShowText(Self::new(
+            word_spacing,
+            char_spacing,
+            text,
+        )))
     }
 }
 
@@ -100,9 +106,8 @@ impl ShowTextArray {
         Self { elements }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let elements = operands.get_text_element_array()?;
+        Ok(PdfOperatorVariant::ShowTextArray(Self::new(elements)))
     }
 }

--- a/pdf-operator/src/text_state_operators.rs
+++ b/pdf-operator/src/text_state_operators.rs
@@ -1,4 +1,7 @@
-use crate::{error::PdfPainterError, pdf_operator::PdfOperatorVariant};
+use crate::{
+    error::PdfPainterError,
+    pdf_operator::{Operands, PdfOperatorVariant},
+};
 
 /// Sets the character spacing, `Tc`, which is a number expressed in unscaled text space units. (PDF operator `Tc`)
 #[derive(Debug, Clone, PartialEq)]
@@ -11,16 +14,14 @@ impl SetCharacterSpacing {
     pub const fn operator_name() -> &'static str {
         "Tc"
     }
-}
-impl SetCharacterSpacing {
+
     pub fn new(spacing: f32) -> Self {
         Self { spacing }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let spacing = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetCharacterSpacing(Self::new(spacing)))
     }
 }
 
@@ -41,10 +42,9 @@ impl SetWordSpacing {
         Self { spacing }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let spacing = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetWordSpacing(Self::new(spacing)))
     }
 }
 
@@ -64,10 +64,9 @@ impl SetHorizontalScaling {
         Self { scale }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let scale = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetHorizontalScaling(Self::new(scale)))
     }
 }
 
@@ -87,10 +86,9 @@ impl SetLeading {
         Self { leading }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let leading = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetLeading(Self::new(leading)))
     }
 }
 
@@ -112,10 +110,10 @@ impl SetFont {
         Self { name, size }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let name = operands.get_name()?;
+        let size = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetFont(Self::new(name, size)))
     }
 }
 
@@ -143,10 +141,9 @@ impl SetRenderingMode {
         Self { mode }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let mode = operands.get_u8()?;
+        Ok(PdfOperatorVariant::SetRenderingMode(Self::new(mode)))
     }
 }
 
@@ -166,9 +163,8 @@ impl SetTextRise {
         Self { rise }
     }
 
-    pub fn read() -> Result<PdfOperatorVariant, PdfPainterError> {
-        Err(PdfPainterError::UnimplementedOperation(
-            Self::operator_name(),
-        ))
+    pub fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfPainterError> {
+        let rise = operands.get_f32()?;
+        Ok(PdfOperatorVariant::SetTextRise(Self::new(rise)))
     }
 }

--- a/pdf-page/src/content_stream.rs
+++ b/pdf-page/src/content_stream.rs
@@ -1,0 +1,14 @@
+use pdf_operator::pdf_operator::PdfOperatorVariant;
+
+use crate::error::PageError;
+
+pub struct ContentStream {
+    pub operations: Vec<PdfOperatorVariant>,
+}
+
+impl ContentStream {
+    pub fn from(input: &[u8]) -> Result<Self, PageError> {
+        let operations = PdfOperatorVariant::from(input)?;
+        Ok(Self { operations })
+    }
+}

--- a/pdf-page/src/error.rs
+++ b/pdf-page/src/error.rs
@@ -1,4 +1,5 @@
 use pdf_object::error::ObjectError;
+use pdf_operator::error::PdfPainterError;
 
 /// Defines errors that can occur when interpreting a PDF page object.
 #[derive(Debug, Clone, PartialEq)]
@@ -12,11 +13,19 @@ pub enum PageError {
     /// Wraps an error message from an `ObjectError`
     /// encountered while processing a PDF object related to the page.
     ObjectError(String),
+    /// Wraps an error message from a `PdfPainterError`
+    PdfOperatorError(String),
 }
 
 impl From<ObjectError> for PageError {
     fn from(err: ObjectError) -> Self {
         Self::ObjectError(err.to_string())
+    }
+}
+
+impl From<PdfPainterError> for PageError {
+    fn from(err: PdfPainterError) -> Self {
+        Self::PdfOperatorError(err.to_string())
     }
 }
 
@@ -33,6 +42,13 @@ impl std::fmt::Display for PageError {
                 write!(f, "Invalid `/MediaBox` entry: {}", err)
             }
             PageError::ObjectError(err) => {
+                write!(
+                    f,
+                    "Failed to process a PDF object related to the page: {}",
+                    err
+                )
+            }
+            PageError::PdfOperatorError(err) => {
                 write!(
                     f,
                     "Failed to process a PDF object related to the page: {}",

--- a/pdf-page/src/lib.rs
+++ b/pdf-page/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod content_stream;
 pub mod error;
 pub mod media_box;
 pub mod page;

--- a/pdf-page/src/page.rs
+++ b/pdf-page/src/page.rs
@@ -1,4 +1,4 @@
-use crate::{error::PageError, media_box::MediaBox};
+use crate::{content_stream::ContentStream, error::PageError, media_box::MediaBox};
 use pdf_object::{
     ObjectVariant, Value, dictionary::Dictionary, indirect_object::IndirectObject,
     object_collection::ObjectCollection,
@@ -119,7 +119,12 @@ impl PdfPage {
                     if let Value::IndirectObject(s) = obj {
                         // println!("Has arry inner {:?}", s);
                         if let Some(ss) = objects.get(s.object_number()) {
-                            println!("inner inner cont: {:?}", ss);
+                            if let ObjectVariant::Stream(s) = ss {
+                                let content_stream = ContentStream::from(s.data.as_slice())?;
+                                println!("content stream: {:?}", content_stream.operations);
+                            } else {
+                                println!("inner inner cont: {:?}", ss);
+                            }
                         }
                     }
                 }

--- a/pdf-parser/src/cross_reference_table.rs
+++ b/pdf-parser/src/cross_reference_table.rs
@@ -80,28 +80,30 @@ impl ParseObject<CrossReferenceTable> for PdfParser<'_> {
         loop {
             // Read the first object number.
             if let Some(PdfToken::Number(_)) = self.tokenizer.peek()? {
-                let first_object_number_in_section =
-                    self.read_number::<i32>(ParserError::InvalidNumber)?;
+                let first_object_number_in_section = self.read_number::<i32>()?;
                 if first_object_number.is_none() {
                     first_object_number = Some(first_object_number_in_section);
                 }
             }
 
             // Read the number of objects.
-            let number_of_objects =
-                self.read_number::<u32>(CrossReferenceTableError::MissingTableEntryCount)?;
+            let number_of_objects = self
+                .read_number::<u32>()
+                .map_err(|err| CrossReferenceTableError::MissingTableEntryCount)?;
 
             // Read the entries.
             for _ in 0..number_of_objects {
                 total_number_of_entries += 1;
 
                 // Read the object number.
-                let object_number =
-                    self.read_number::<u32>(CrossReferenceTableError::MissingObjectNumber)?;
+                let object_number = self
+                    .read_number::<u32>()
+                    .map_err(|err| CrossReferenceTableError::MissingObjectNumber)?;
 
                 // Read the generation number.
-                let generation_number =
-                    self.read_number::<u16>(CrossReferenceTableError::MissingGenerationNumber)?;
+                let generation_number = self
+                    .read_number::<u16>()
+                    .map_err(|err| CrossReferenceTableError::MissingGenerationNumber)?;
 
                 // Read the status.
                 if let Some(PdfToken::Alphabetic(e)) = self.tokenizer.read() {

--- a/pdf-parser/src/indirect_object.rs
+++ b/pdf-parser/src/indirect_object.rs
@@ -54,10 +54,14 @@ impl ParseObject<ObjectVariant> for PdfParser<'_> {
         const ENDOBJ_KEYWORD: &[u8] = b"endobj";
 
         // Read the object number.
-        let object_number = self.read_number(IndirectObjectError::MissingObjectNumber)?;
+        let object_number = self
+            .read_number()
+            .map_err(|err| IndirectObjectError::MissingObjectNumber)?;
 
         // Read the generation number.
-        let generation_number = self.read_number(IndirectObjectError::MissingGenerationNumber)?;
+        let generation_number = self
+            .read_number()
+            .map_err(|err| IndirectObjectError::MissingGenerationNumber)?;
 
         // If the next token is 'R', it means this is an object reference.
         if let Some(PdfToken::Alphabetic(b'R')) = self.tokenizer.peek()? {

--- a/pdf-parser/src/lib.rs
+++ b/pdf-parser/src/lib.rs
@@ -17,14 +17,11 @@ pub mod trailer;
 use std::{rc::Rc, str::FromStr};
 
 use error::ParserError;
-use pdf_object::{
-    ObjectVariant, Value, dictionary::Dictionary, indirect_object::IndirectObject,
-    stream::StreamObject, trailer::Trailer,
-};
+use pdf_object::{ObjectVariant, Value, dictionary::Dictionary, trailer::Trailer};
 use pdf_tokenizer::{PdfToken, Tokenizer};
 
 pub struct PdfParser<'a> {
-    tokenizer: Tokenizer<'a>,
+    pub tokenizer: Tokenizer<'a>,
 }
 
 impl<'a> From<&'a [u8]> for PdfParser<'a> {
@@ -99,7 +96,7 @@ impl<'a> PdfParser<'a> {
         Ok(())
     }
 
-    fn skip_whitespace(&mut self) {
+    pub fn skip_whitespace(&mut self) {
         let _ = self.tokenizer.read_while_u8(|b| Self::id_pdf_whitespace(b));
     }
 
@@ -120,10 +117,10 @@ impl<'a> PdfParser<'a> {
     /// # Returns
     ///
     /// - `Result` indicating success or failure.
-    fn read_number<T: FromStr>(&mut self, error: impl Into<ParserError>) -> Result<T, ParserError> {
+    pub fn read_number<T: FromStr>(&mut self) -> Result<T, ParserError> {
         let number_str = self.tokenizer.read_while_u8(|b| b.is_ascii_digit());
         if number_str.is_empty() {
-            return Err(error.into());
+            return Err(ParserError::UnexpectedEndOfFile);
         }
 
         let number = String::from_utf8_lossy(number_str)

--- a/pdf-parser/src/number.rs
+++ b/pdf-parser/src/number.rs
@@ -33,13 +33,13 @@ impl ParseObject<Number> for PdfParser<'_> {
         }
 
         // 2. Parse leading digits (integral part).
-        let digits = self.read_number::<i64>(ParserError::InvalidNumber)?;
+        let digits = self.read_number::<i64>()?;
 
         // 3. Check for decimal point
         if let Some(PdfToken::Period) = self.tokenizer.peek()? {
             self.tokenizer.read();
             // 4. Parse fractional part.
-            let fraction = self.read_number::<i64>(ParserError::InvalidNumber)?;
+            let fraction = self.read_number::<i64>()?;
             // 5. Combine integral and fractional parts.
             let number_str = if has_minus {
                 format!("-{}.{}", digits, fraction)

--- a/pdf-parser/src/trailer.rs
+++ b/pdf-parser/src/trailer.rs
@@ -90,7 +90,9 @@ impl ParseObject<Trailer> for PdfParser<'_> {
         self.read_keyword(START_XREF_KEYWORD)?;
 
         // Read the offset of the xref section.
-        let offset = self.read_number::<u32>(TrailerError::MissingOffset)?;
+        let offset = self
+            .read_number::<u32>()
+            .map_err(|err| TrailerError::MissingOffset)?;
 
         Ok(Trailer::new(dictionary, offset))
     }

--- a/pdf-tokenizer/src/lib.rs
+++ b/pdf-tokenizer/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod error;
 
+use std::str::FromStr;
+
 use error::TokenizerError;
 
 pub struct Tokenizer<'a> {
@@ -171,7 +173,7 @@ impl<'a> Tokenizer<'a> {
         Ok(result)
     }
 
-    pub fn read_while_u8<F>(&mut self, condition: F) -> &[u8]
+    pub fn read_while_u8<F>(&mut self, condition: F) -> &'a [u8]
     where
         F: Fn(u8) -> bool,
     {
@@ -181,11 +183,25 @@ impl<'a> Tokenizer<'a> {
         }
         &self.input[start..self.position]
     }
+
+    pub fn read_number<T: FromStr>(&mut self) -> Result<T, TokenizerError> {
+        let number_str = self.read_while_u8(|b| b.is_ascii_digit());
+        if number_str.is_empty() {
+            return Err(TokenizerError::InvalidNumber);
+        }
+
+        let number = String::from_utf8_lossy(number_str)
+            .parse::<T>()
+            .or(Err(TokenizerError::InvalidNumber))?;
+
+        Ok(number)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt::Debug;
 
     #[test]
     fn test_tokenize_number() {
@@ -195,5 +211,90 @@ mod tests {
         assert_eq!(tokenizer.read(), Some(PdfToken::Number(2)));
         assert_eq!(tokenizer.read(), Some(PdfToken::Number(3)));
         assert_eq!(tokenizer.read(), None);
+    }
+
+    // Helper function to comprehensively test read_number
+    fn check_read_number<T: FromStr + PartialEq + Debug>(
+        input: &'static [u8],
+        expected_output: Result<T, TokenizerError>,
+        expected_pos_after_read: usize,
+        expected_remaining_data: &'static [u8],
+    ) {
+        let mut tokenizer = Tokenizer::new(input);
+        let result: Result<T, TokenizerError> = tokenizer.read_number();
+
+        assert_eq!(
+            result,
+            expected_output,
+            "Test failed for input: \"{}\". Expected result: {:?}, got: {:?}.",
+            String::from_utf8_lossy(input),
+            expected_output,
+            result
+        );
+
+        assert_eq!(
+            tokenizer.position,
+            expected_pos_after_read,
+            "Test failed for input: \"{}\". Expected position: {}, got: {}.",
+            String::from_utf8_lossy(input),
+            expected_pos_after_read,
+            tokenizer.position
+        );
+
+        assert_eq!(
+            tokenizer.data(),
+            expected_remaining_data,
+            "Test failed for input: \"{}\". Expected remaining data: \"{}\", got: \"{}\".",
+            String::from_utf8_lossy(input),
+            String::from_utf8_lossy(expected_remaining_data),
+            String::from_utf8_lossy(tokenizer.data())
+        );
+    }
+
+    #[test]
+    fn test_read_number_generic_cases() {
+        // Successful parsing
+        check_read_number::<u32>(b"123 abc", Ok(123), 3, b" abc");
+        check_read_number::<u64>(b"9876543210", Ok(9876543210), 10, b"");
+        check_read_number::<u8>(b"0xyz", Ok(0), 1, b"xyz");
+        check_read_number::<String>(b"007 bond", Ok("007".to_string()), 3, b" bond");
+        check_read_number::<u16>(b"65535stop", Ok(65535), 5, b"stop");
+        check_read_number::<i32>(b"123.45", Ok(123), 3, b".45"); // Reads only the integer part
+
+        // Input with no digits at the current position
+        check_read_number::<u32>(b"abc123", Err(TokenizerError::InvalidNumber), 0, b"abc123");
+        check_read_number::<u32>(b" xyz", Err(TokenizerError::InvalidNumber), 0, b" xyz");
+        check_read_number::<u32>(b"", Err(TokenizerError::InvalidNumber), 0, b"");
+        check_read_number::<String>(
+            b" no_digits",
+            Err(TokenizerError::InvalidNumber),
+            0,
+            b" no_digits",
+        );
+
+        // For u8 (max 255)
+        check_read_number::<u8>(b"256", Err(TokenizerError::InvalidNumber), 3, b"");
+        check_read_number::<u8>(
+            b"300 and more",
+            Err(TokenizerError::InvalidNumber),
+            3,
+            b" and more",
+        );
+
+        // For i16 (max 32767)
+        check_read_number::<i16>(b"32768", Err(TokenizerError::InvalidNumber), 5, b"");
+        check_read_number::<i16>(
+            b"100000rest",
+            Err(TokenizerError::InvalidNumber),
+            6,
+            b"rest",
+        );
+
+        // For i8 (min -128, max 127)
+        // While `read_number` itself doesn't handle signs, if `T` was signed and `FromStr` for `T`
+        // expected only non-negative numbers from this particular path, this would test it.
+        // However, `read_number` only extracts positive digit sequences.
+        // The following tests `FromStr` for `i8` with a number that's too large positive.
+        check_read_number::<i8>(b"128", Err(TokenizerError::InvalidNumber), 3, b"");
     }
 }


### PR DESCRIPTION
This commit introduces a PDF content stream parser that tokenizes raw byte arrays and constructs a
sequence of `PdfOperatorVariant` enums, representing the structured content of a page stream.

Closes #14 