### PR TITLE
pdf-canvas: correct PDF 1.7 text matrix handling

### DIFF
--- a/crates/pdf-canvas/src/canvas_state.rs
+++ b/crates/pdf-canvas/src/canvas_state.rs
@@ -1,5 +1,6 @@
 use pdf_graphics::{
-    BlendMode, LineCap, LineJoin, color::Color, pdf_path::PdfPath, transform::Transform,
+    BlendMode, LineCap, LineJoin, TextRenderingMode, color::Color, pdf_path::PdfPath,
+    transform::Transform,
 };
 use pdf_page::{pattern::Pattern, resources::Resources};
 
@@ -33,6 +34,8 @@ pub(crate) struct CanvasState<'a> {
     pub pattern: Option<&'a Pattern>,
     /// The current blend mode, controlling compositing behavior.
     pub blend_mode: Option<BlendMode>,
+    /// The current text rendering mode.
+    pub rendering_mode: Option<TextRenderingMode>,
 }
 
 impl CanvasState<'_> {
@@ -61,6 +64,7 @@ impl Default for CanvasState<'_> {
             line_cap: LineCap::Butt,
             line_join: LineJoin::Miter,
             blend_mode: None,
+            rendering_mode: None,
         }
     }
 }

--- a/crates/pdf-canvas/src/canvas_text_ops.rs
+++ b/crates/pdf-canvas/src/canvas_text_ops.rs
@@ -16,11 +16,14 @@ use pdf_graphics::transform::Transform;
 impl<T: std::error::Error> TextPositioningOps for PdfCanvas<'_, T> {
     fn move_text_position(&mut self, tx: f32, ty: f32) -> Result<(), Self::ErrorType> {
         let mat = Transform::from_translate(tx, ty);
+        // PDF 1.7 (Tj and text positioning): Td updates Tlm = Tlm * T(tx, ty), then Tm = Tlm.
+        // Use post-multiplication to move in text space coordinates.
         self.current_state_mut()?
             .text_state
             .line_matrix
-            .concat(&mat);
-        self.current_state_mut()?.text_state.matrix = self.current_state()?.text_state.line_matrix;
+            .post_concat(&mat);
+        let lm = self.current_state()?.text_state.line_matrix;
+        self.current_state_mut()?.text_state.matrix = lm;
         Ok(())
     }
 
@@ -29,10 +32,10 @@ impl<T: std::error::Error> TextPositioningOps for PdfCanvas<'_, T> {
         tx: f32,
         ty: f32,
     ) -> Result<(), Self::ErrorType> {
-        Err(PdfCanvasError::NotImplemented(format!(
-            "move_text_position_and_set_leading TD: tx={}, ty={}",
-            tx, ty
-        )))
+        // TD: Set leading to -ty, then perform Td(tx, ty)
+        let neg_ty = -ty;
+        self.current_state_mut()?.text_state.leading = neg_ty;
+        self.move_text_position(tx, ty)
     }
 
     fn set_text_matrix(
@@ -45,15 +48,23 @@ impl<T: std::error::Error> TextPositioningOps for PdfCanvas<'_, T> {
         f: f32,
     ) -> Result<(), Self::ErrorType> {
         let mat = Transform::from_row(a, b, c, d, e, f);
+        // Tm operator sets both Tm and Tlm to the same matrix.
         self.current_state_mut()?.text_state.line_matrix = mat;
         self.current_state_mut()?.text_state.matrix = mat;
         Ok(())
     }
 
     fn move_to_start_of_next_line(&mut self) -> Result<(), Self::ErrorType> {
-        Err(PdfCanvasError::NotImplemented(
-            "move_to_start_of_next_line T*".into(),
-        ))
+        // T*: Move to start of next line using current leading: Tlm = Tlm * T(0, -Tl); Tm = Tlm.
+        let leading = self.current_state()?.text_state.leading;
+        let mat = Transform::from_translate(0.0, -leading);
+        self.current_state_mut()?
+            .text_state
+            .line_matrix
+            .post_concat(&mat);
+        let lm = self.current_state()?.text_state.line_matrix;
+        self.current_state_mut()?.text_state.matrix = lm;
+        Ok(())
     }
 }
 
@@ -86,10 +97,9 @@ impl<T: std::error::Error> TextStateOps for PdfCanvas<'_, T> {
     }
 
     fn set_text_leading(&mut self, leading: f32) -> Result<(), Self::ErrorType> {
-        Err(PdfCanvasError::NotImplemented(format!(
-            "set_text_leading TL: {}",
-            leading
-        )))
+        // TL sets the text leading parameter
+        self.current_state_mut()?.text_state.leading = leading;
+        Ok(())
     }
 
     fn set_font_and_size(&mut self, font_name: &str, size: f32) -> Result<(), Self::ErrorType> {
@@ -116,10 +126,9 @@ impl<T: std::error::Error> TextStateOps for PdfCanvas<'_, T> {
         Err(PdfCanvasError::FontNotFound(font_name.to_string()))
     }
 
-    fn set_text_rendering_mode(&mut self, _mode: TextRenderingMode) -> Result<(), Self::ErrorType> {
-        Err(PdfCanvasError::NotImplemented(
-            "set_text_rendering_mode".into(),
-        ))
+    fn set_text_rendering_mode(&mut self, mode: TextRenderingMode) -> Result<(), Self::ErrorType> {
+        self.current_state_mut()?.rendering_mode = Some(mode);
+        Ok(())
     }
 
     fn set_text_rise(&mut self, rise: f32) -> Result<(), Self::ErrorType> {
@@ -132,7 +141,7 @@ impl<T: std::error::Error> TextShowingOps for PdfCanvas<'_, T> {
     fn show_text(&mut self, text: &[u8]) -> Result<(), Self::ErrorType> {
         // Extract text state parameters for rendering.
         let TextState {
-            matrix,
+            mut matrix,
             horizontal_scaling,
             font_size,
             character_spacing,
@@ -153,10 +162,15 @@ impl<T: std::error::Error> TextShowingOps for PdfCanvas<'_, T> {
                     horizontal_scaling,
                     rise,
                     current_transform,
-                    matrix,
+                    &mut matrix,
                     type3_font,
+                    word_spacing,
+                    character_spacing,
                 )?;
-                renderer.render_text(text)
+                renderer.render_text(text)?;
+                // Persist the updated Tm
+                self.current_state_mut()?.text_state.matrix = matrix;
+                Ok(())
             }
             Font::Type1(type1_font) => {
                 let mut renderer = Type1FontRenderer::new(
@@ -164,13 +178,16 @@ impl<T: std::error::Error> TextShowingOps for PdfCanvas<'_, T> {
                     type1_font,
                     font_size,
                     horizontal_scaling,
-                    matrix,
+                    &mut matrix,
                     current_transform,
                     rise,
                     word_spacing,
                     character_spacing,
                 );
-                renderer.render_text(text)
+                renderer.render_text(text)?;
+                // Persist the updated Tm
+                self.current_state_mut()?.text_state.matrix = matrix;
+                Ok(())
             }
             Font::TrueType(_) | Font::Type0(_) => {
                 let mut renderer = TrueTypeFontRenderer::new(
@@ -178,13 +195,15 @@ impl<T: std::error::Error> TextShowingOps for PdfCanvas<'_, T> {
                     current_font,
                     font_size,
                     horizontal_scaling,
-                    matrix,
+                    &mut matrix,
                     current_transform,
                     rise,
                     word_spacing,
                     character_spacing,
                 )?;
-                renderer.render_text(text)
+                renderer.render_text(text)?;
+                self.current_state_mut()?.text_state.matrix = matrix;
+                Ok(())
             }
         }
     }
@@ -199,11 +218,12 @@ impl<T: std::error::Error> TextShowingOps for PdfCanvas<'_, T> {
                     self.show_text(value.as_bytes())?;
                 }
                 TextElement::Adjustment { amount } => {
+                    // TJ adjustment: Tm = Tm * T( -amount/1000 * Tfs * Th, 0 )
                     let amount = (*amount) / 1000.0;
                     let state = self.current_state_mut()?;
-                    let tx =
-                        -amount * state.text_state.font_size * state.text_state.horizontal_scaling;
-                    state.text_state.matrix.translate(tx, 0.0);
+                    let th = state.text_state.horizontal_scaling / 100.0;
+                    let tx = -amount * state.text_state.font_size * th;
+                    state.text_state.matrix.post_translate(tx, 0.0);
                 }
                 TextElement::HexString { value } => {
                     self.show_text(value)?;

--- a/crates/pdf-canvas/src/text_state.rs
+++ b/crates/pdf-canvas/src/text_state.rs
@@ -18,6 +18,8 @@ pub(crate) struct TextState<'a> {
     pub(crate) word_spacing: f32,
     /// Text rise (Ts), a vertical offset from the baseline, in unscaled text space units.
     pub(crate) rise: f32,
+    /// Text leading (Tl), the vertical distance between baselines.
+    pub(crate) leading: f32,
     /// The current font resource.
     pub(crate) font: Option<&'a Font>,
 }
@@ -32,6 +34,7 @@ impl Default for TextState<'_> {
             character_spacing: 0.0,
             word_spacing: 0.0,
             rise: 0.0,
+            leading: 0.0,
             font: None,
         }
     }

--- a/crates/pdf-canvas/src/truetype_font_renderer.rs
+++ b/crates/pdf-canvas/src/truetype_font_renderer.rs
@@ -45,7 +45,7 @@ pub(crate) struct TrueTypeFontRenderer<'a, T: PdfOperatorBackend + Canvas> {
     /// The default glyph width for the font, used if specific widths are not provided.
     default_width: f32,
     /// The current text matrix (Tm), which positions the text.
-    text_matrix: Transform,
+    text_matrix: &'a mut Transform,
     /// The Current Transformation Matrix (CTM) at the time of rendering.
     current_transform: Transform,
     /// The font size in user space units.
@@ -67,7 +67,7 @@ impl<'a, T: PdfOperatorBackend + Canvas> TrueTypeFontRenderer<'a, T> {
         font: &'a Font,
         font_size: f32,
         horizontal_scaling: f32,
-        text_matrix: Transform,
+        text_matrix: &'a mut Transform,
         current_transform: Transform,
         rise: f32,
         word_spacing: f32,
@@ -198,7 +198,7 @@ impl<T: PdfOperatorBackend + Canvas> TextRenderer for TrueTypeFontRenderer<'_, T
             // Compose the final transformation matrix for this glyph:
             // m_params -> text matrix -> current transformation matrix
             let mut glyph_matrix_for_char = m_params;
-            glyph_matrix_for_char.concat(&self.text_matrix);
+            glyph_matrix_for_char.concat(self.text_matrix);
             glyph_matrix_for_char.concat(&self.current_transform);
 
             // Build the glyph outline using the composed transform.
@@ -241,8 +241,8 @@ impl<T: PdfOperatorBackend + Canvas> TextRenderer for TrueTypeFontRenderer<'_, T
             let advance_x =
                 (glyph_width_tfs_scaled + char_spacing + word_spacing_for_char) * th_factor;
 
-            // Advance the text matrix for the next glyph.
-            self.text_matrix.translate(advance_x, 0.0);
+            // Advance the text matrix for the next glyph using post-multiplication.
+            self.text_matrix.post_translate(advance_x, 0.0);
         }
 
         Ok(())

--- a/crates/pdf-canvas/src/type1_font_renderer.rs
+++ b/crates/pdf-canvas/src/type1_font_renderer.rs
@@ -13,7 +13,7 @@ pub(crate) struct Type1FontRenderer<'a, T: PdfOperatorBackend + Canvas> {
     canvas: &'a mut T,
     font: &'a Type1Font,
     /// The current text matrix (Tm), which positions the text.
-    text_matrix: Transform,
+    text_matrix: &'a mut Transform,
     /// The Current Transformation Matrix (CTM) at the time of rendering.
     current_transform: Transform,
     /// The font size in user space units.
@@ -35,7 +35,7 @@ impl<'a, T: PdfOperatorBackend + Canvas> Type1FontRenderer<'a, T> {
         font: &'a Type1Font,
         font_size: f32,
         horizontal_scaling: f32,
-        text_matrix: Transform,
+        text_matrix: &'a mut Transform,
         current_transform: Transform,
         rise: f32,
         word_spacing: f32,
@@ -87,7 +87,7 @@ impl<T: PdfOperatorBackend + Canvas> TextRenderer for Type1FontRenderer<'_, T> {
             // Compose the final transformation matrix for this glyph:
             // m_params -> text matrix -> current transformation matrix
             let mut glyph_matrix_for_char = m_params;
-            glyph_matrix_for_char.concat(&self.text_matrix);
+            glyph_matrix_for_char.concat(self.text_matrix);
             glyph_matrix_for_char.concat(&self.current_transform);
 
             let char_code = *u;
@@ -122,7 +122,7 @@ impl<T: PdfOperatorBackend + Canvas> TextRenderer for Type1FontRenderer<'_, T> {
             };
             let advance_x =
                 (glyph_width_tfs_scaled + self.char_spacing + word_spacing_for_char) * th_factor;
-            self.text_matrix.translate(advance_x, 0.0);
+            self.text_matrix.post_translate(advance_x, 0.0);
         }
 
         Ok(())

--- a/crates/pdf-canvas/src/type3_font_renderer.rs
+++ b/crates/pdf-canvas/src/type3_font_renderer.rs
@@ -29,22 +29,31 @@ pub(crate) struct Type3FontRenderer<'a, T: PdfOperatorBackend + Canvas> {
     /// The Current Transformation Matrix (CTM) at the time of rendering.
     current_transform: Transform,
     /// The current text matrix (Tm), which positions the text.
-    text_matrix: Transform,
+    text_matrix: &'a mut Transform,
     /// The Type 3 font definition, containing glyph content streams.
     type3_font: &'a Type3Font,
     /// The font size.
     font_size: f32,
+    /// Word spacing (Tw)
+    word_spacing: f32,
+    /// Character spacing (Tc)
+    char_spacing: f32,
+    /// Horizontal scaling factor (Th), expressed as a percentage.
+    horizontal_scaling: f32,
 }
 
 impl<'a, T: PdfOperatorBackend + Canvas> Type3FontRenderer<'a, T> {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         canvas: &'a mut T,
         font_size: f32,
         horizontal_scaling: f32,
         text_rise: f32,
         current_transform: Transform,
-        text_matrix: Transform,
+        text_matrix: &'a mut Transform,
         type3_font: &'a Type3Font,
+        word_spacing: f32,
+        char_spacing: f32,
     ) -> Result<Self, Type3FontRendererError> {
         let font_matrix = if let [a, b, c, d, e, f] = type3_font.font_matrix.as_slice() {
             Transform::from_row(*a, *b, *c, *d, *e, *f)
@@ -74,6 +83,9 @@ impl<'a, T: PdfOperatorBackend + Canvas> Type3FontRenderer<'a, T> {
             text_matrix,
             type3_font,
             font_size,
+            word_spacing,
+            char_spacing,
+            horizontal_scaling,
         })
     }
 }
@@ -87,7 +99,7 @@ impl<T: PdfOperatorBackend + Canvas> TextRenderer for Type3FontRenderer<'_, T> {
             // Multiply by the font size, horizontal scaling, and rise matrix (S).
             text_rendering_matrix.concat(&self.font_size_matrix);
             // Multiply by the current text matrix (Tm).
-            text_rendering_matrix.concat(&self.text_matrix);
+            text_rendering_matrix.concat(self.text_matrix);
             // Multiply by the current transformation matrix (CTM).
             text_rendering_matrix.concat(&self.current_transform);
 
@@ -139,11 +151,24 @@ impl<T: PdfOperatorBackend + Canvas> TextRenderer for Type3FontRenderer<'_, T> {
 
             // 7. Advance the text matrix (Tm) to position the next glyph.
             if let Some(width) = glyph_width {
-                // The glyph width is given in glyph space. Scale it up by
-                // the font size and a conventional 1000-unit glyph space grid to
-                // calculate the final horizontal displacement in text space.
-                let advance = width * self.font_size / 1000.0;
-                self.text_matrix.translate(advance, 0.0);
+                // Compute displacement vector in text space for (width, 0) in glyph space
+                let (x1, y1) = self.font_matrix.transform_point(width, 0.0);
+                let (x0, y0) = self.font_matrix.transform_point(0.0, 0.0);
+                let (wx_ts, wy_ts) = (x1 - x0, y1 - y0);
+
+                let th = self.horizontal_scaling / 100.0;
+                let base_adv_x = wx_ts * self.font_size;
+                let base_adv_y = wy_ts * self.font_size;
+
+                let word_spacing_for_char = if char_code_byte == 32 {
+                    self.word_spacing
+                } else {
+                    0.0
+                };
+                let advance_x = (base_adv_x + self.char_spacing + word_spacing_for_char) * th;
+                let advance_y = base_adv_y;
+
+                self.text_matrix.post_translate(advance_x, advance_y);
             }
         }
 


### PR DESCRIPTION
- Implement Tm/Tlm per PDF 1.7 (ISO 32000-1) text-positioning rules.
- Apply TJ adjustments correctly
- Treat horizontal scaling as a percentage (Th),
- Use factor Th/100 where applied
- Persist updated Tm back to state after show_text for all font types