### PR TITLE
refactor: centralize crate error types and improve diagnostics

### DIFF
--- a/crates/pdf-canvas/src/canvas_clip_ops.rs
+++ b/crates/pdf-canvas/src/canvas_clip_ops.rs
@@ -7,14 +7,14 @@ impl<B: CanvasBackend> ClippingPathOps for PdfCanvas<'_, B> {
     type ErrorType = PdfCanvasError;
     fn clip_path_nonzero_winding(&mut self) -> Result<(), Self::ErrorType> {
         let Some(path) = self.current_path.take() else {
-            return Err(PdfCanvasError::NoActivePath);
+            return Err(PdfCanvasError::PathRequired);
         };
         self.set_clip_path(path, PathFillType::Winding)
     }
 
     fn clip_path_even_odd(&mut self) -> Result<(), Self::ErrorType> {
         let Some(path) = self.current_path.take() else {
-            return Err(PdfCanvasError::NoActivePath);
+            return Err(PdfCanvasError::PathRequired);
         };
         self.set_clip_path(path, PathFillType::EvenOdd)
     }

--- a/crates/pdf-canvas/src/canvas_external_object_ops.rs
+++ b/crates/pdf-canvas/src/canvas_external_object_ops.rs
@@ -84,7 +84,7 @@ const MASK_1BIT: u8 = 0x01;
 /// # Errors
 ///
 /// - [`PdfCanvasError::InvalidImageData`] if `data` has insufficient bytes.
-/// - [`PdfCanvasError::NotImplemented`] if `bits` is not 1, 2, 4, or 8.
+/// - [`PdfCanvasError::UnsupportedFeature`] if `bits` is not 1, 2, 4, or 8.
 ///
 /// # Bit Packing Layout
 ///
@@ -125,7 +125,7 @@ fn extract_index(data: &[u8], bits: usize, bit_pos: &mut usize) -> Result<u32, P
             u32::from((byte >> shift) & MASK_1BIT)
         }
         _ => {
-            return Err(PdfCanvasError::NotImplemented(format!(
+            return Err(PdfCanvasError::UnsupportedFeature(format!(
                 "BitsPerComponent {bits} not supported for indexed images"
             )));
         }
@@ -227,7 +227,7 @@ impl<B: CanvasBackend> XObjectOps for PdfCanvas<'_, B> {
         let resources = self
             .current_state()?
             .resources
-            .ok_or(PdfCanvasError::MissingPageResources)?;
+            .ok_or(PdfCanvasError::PageResourcesMissing)?;
 
         let xobj = resources
             .xobject(xobject_name)

--- a/crates/pdf-canvas/src/canvas_graphics_state_ops.rs
+++ b/crates/pdf-canvas/src/canvas_graphics_state_ops.rs
@@ -69,7 +69,7 @@ impl<B: CanvasBackend> GraphicsStateOps for PdfCanvas<'_, B> {
         let resources = self
             .current_state()?
             .resources
-            .ok_or(PdfCanvasError::MissingPageResources)?;
+            .ok_or(PdfCanvasError::PageResourcesMissing)?;
 
         let Some(states) = resources.external_graphics_state(dict_name) else {
             // If the specified `ExtGState` is not found, the ignored parameters should not cause an error.
@@ -91,12 +91,12 @@ impl<B: CanvasBackend> GraphicsStateOps for PdfCanvas<'_, B> {
                     self.current_state_mut()?.miter_limit = *miter;
                 }
                 ExternalGraphicsStateKey::DashPattern(..) => {
-                    return Err(PdfCanvasError::NotImplemented(
+                    return Err(PdfCanvasError::UnsupportedFeature(
                         "ExtGState: DashPattern".into(),
                     ));
                 }
                 ExternalGraphicsStateKey::RenderingIntent(_) => {
-                    return Err(PdfCanvasError::NotImplemented(
+                    return Err(PdfCanvasError::UnsupportedFeature(
                         "ExtGState: RenderingIntent".into(),
                     ));
                 }
@@ -104,14 +104,14 @@ impl<B: CanvasBackend> GraphicsStateOps for PdfCanvas<'_, B> {
                 ExternalGraphicsStateKey::OverprintFill(_) => {}
                 ExternalGraphicsStateKey::OverprintMode(_) => {}
                 ExternalGraphicsStateKey::Font(..) => {
-                    return Err(PdfCanvasError::NotImplemented("ExtGState: Font".into()));
+                    return Err(PdfCanvasError::UnsupportedFeature("ExtGState: Font".into()));
                 }
                 ExternalGraphicsStateKey::BlendMode(modes) => {
                     // Store the blend mode(s) in the current graphics state.
                     // PDF spec: If multiple blend modes are specified, use the first one supported.
                     // We only support the first for now.
                     if modes.len() > 1 {
-                        return Err(PdfCanvasError::NotImplemented(
+                        return Err(PdfCanvasError::UnsupportedFeature(
                             "ExtGState: Only one blend mode is supported".into(),
                         ));
                     }
@@ -123,7 +123,7 @@ impl<B: CanvasBackend> GraphicsStateOps for PdfCanvas<'_, B> {
                     // Handle the `/SMask` entry from an `ExtGState` dictionary.
                     if let Some(smask) = smask.as_ref() {
                         if let XObject::Image(_) = &smask.shape {
-                            return Err(PdfCanvasError::NotImplemented(
+                            return Err(PdfCanvasError::UnsupportedFeature(
                                 "SoftMask with Image shape".into(),
                             ));
                         } else if let XObject::Form(form) = &smask.shape {

--- a/crates/pdf-canvas/src/canvas_path_ops.rs
+++ b/crates/pdf-canvas/src/canvas_path_ops.rs
@@ -40,7 +40,7 @@ impl<B: CanvasBackend> PathConstructionOps for PdfCanvas<'_, B> {
             path.curve_to(x, y, x2, y2, x3, y3);
             Ok(())
         } else {
-            Err(PdfCanvasError::NoCurrentPoint)
+            Err(PdfCanvasError::CurrentPointRequired)
         }
     }
 

--- a/crates/pdf-canvas/src/canvas_text_ops.rs
+++ b/crates/pdf-canvas/src/canvas_text_ops.rs
@@ -155,7 +155,7 @@ impl<B: CanvasBackend> TextShowingOps for PdfCanvas<'_, B> {
             .current_state()?
             .text_state
             .font
-            .ok_or(PdfCanvasError::NoCurrentFont)?;
+            .ok_or(PdfCanvasError::CurrentFontRequired)?;
 
         match current_font {
             Font::Type3(type3_font) => {

--- a/crates/pdf-canvas/src/error.rs
+++ b/crates/pdf-canvas/src/error.rs
@@ -1,49 +1,39 @@
-use pdf_color_space::color_space::ColorSpaceError;
+use pdf_color_space::error::ColorSpaceError;
 use thiserror::Error;
-
-use crate::truetype_font_renderer::TrueTypeFontRendererError;
 
 /// Defines errors that can occur during PDF canvas operations.
 #[derive(Debug, Error)]
 pub enum PdfCanvasError {
-    #[error("No active path to perform the painting operation")]
-    NoActivePath,
-    #[error("Operation requires a current point, but none is set")]
-    NoCurrentPoint,
-    #[error("Operation requires a current font, but none is set")]
-    NoCurrentFont,
-    #[error("Missing page resources")]
-    MissingPageResources,
-    #[error("Invalid font: {0}")]
-    InvalidFont(&'static str),
-    #[error("Font '{0}' not found")]
+    #[error("The current operation requires an active path, but no path has been started")]
+    PathRequired,
+    #[error("The current operation requires a current point, but no current point is set")]
+    CurrentPointRequired,
+    #[error("The current operation requires a current font, but no font is selected")]
+    CurrentFontRequired,
+    #[error("Page resources are missing")]
+    PageResourcesMissing,
+    #[error("Invalid font data: {0}")]
+    InvalidFont(String),
+    #[error("Font resource '{0}' was not found")]
     FontNotFound(String),
-    #[error("Color space '{0}' not found in resources")]
+    #[error("Color space resource '{0}' was not found")]
     ColorSpaceNotFound(String),
-    #[error("Pattern '{0}' not found")]
+    #[error("Pattern resource '{0}' was not found")]
     PatternNotFound(String),
-    #[error("Font '{0}' is a Type3 font but is missing its definition data")]
-    MissingType3FontData(String),
-    #[error(
-        "Graphics state stack is empty, cannot access current state. This indicates an internal error."
-    )]
+    #[error("Graphics state stack is empty while accessing the current state")]
     EmptyGraphicsStateStack,
-    #[error("Cannot restore graphics state: stack underflow (no state to restore).")]
+    #[error("Cannot restore graphics state because the stack is already at its base state")]
     GraphicsStateStackUnderflow,
-    #[error("TrueType font rendering error: {0}")]
-    TrueTypeFontError(#[from] TrueTypeFontRendererError),
-    #[error("Extrenal object '{0}' not found in resources")]
+    #[error("Failed to parse TrueType font data: {0}")]
+    TrueTypeFontParse(String),
+    #[error("External object (XObject) '{0}' was not found in page resources")]
     XObjectNotFound(String),
-    #[error("Page missing media box")]
-    MissingMediaBox,
-    #[error("Failed numeric conversion: {0}")]
-    NumericConversionError(&'static str),
     #[error("Invalid image data: {0}")]
     InvalidImageData(String),
-    #[error("No current color space is set for this operation")]
+    #[error("The current operation requires a color space, but none is set")]
     ColorSpaceNotSet,
-    #[error("Not implemented: {0}")]
-    NotImplemented(String),
+    #[error("Unsupported PDF canvas feature: {0}")]
+    UnsupportedFeature(String),
     #[error("Canvas backend error: {0}")]
     BackendError(String),
     #[error("Color space error: {0}")]

--- a/crates/pdf-canvas/src/pdf_canvas.rs
+++ b/crates/pdf-canvas/src/pdf_canvas.rs
@@ -253,10 +253,10 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
                 colors: Cow::Borrowed(&color_stops.colors),
                 positions: Cow::Borrowed(&color_stops.positions),
             }),
-            Shading::FunctionBased { .. } => Err(PdfCanvasError::NotImplemented(
+            Shading::FunctionBased { .. } => Err(PdfCanvasError::UnsupportedFeature(
                 "FunctionBased shading not implemented".into(),
             )),
-            Shading::Unsupported { name } => Err(PdfCanvasError::NotImplemented(format!(
+            Shading::Unsupported { name } => Err(PdfCanvasError::UnsupportedFeature(format!(
                 "Shading type '{}' not implemented",
                 name
             ))),

--- a/crates/pdf-canvas/src/text_state.rs
+++ b/crates/pdf-canvas/src/text_state.rs
@@ -176,7 +176,7 @@ impl TextState<'_> {
 
         let hmtx = font_ref
             .hmtx()
-            .map_err(|_| PdfCanvasError::InvalidFont("missing or invalid hmtx table"))?;
+            .map_err(|_| PdfCanvasError::InvalidFont("missing or invalid hmtx table".into()))?;
 
         // If the glyph is absent from hmtx (sparse coverage), use zero advance
         // so that any already-drawn outline is not lost.

--- a/crates/pdf-canvas/src/truetype_font_renderer.rs
+++ b/crates/pdf-canvas/src/truetype_font_renderer.rs
@@ -8,18 +8,6 @@ use read_fonts::TableProvider;
 use skrifa::{
     FontRef, GlyphId, MetadataProvider, charmap::Charmap, outline::OutlineGlyphCollection,
 };
-use thiserror::Error;
-
-/// Defines errors that can occur during TrueType font rendering.
-#[derive(Debug, Error)]
-pub enum TrueTypeFontRendererError {
-    #[error("The font file object is not a stream, but a {found_type}")]
-    FontFileNotStream { found_type: &'static str },
-    #[error("Failed to parse the TrueType font file: {0}")]
-    FontParseError(String),
-    #[error("Incomplete 2-byte character at the end of the string")]
-    IncompleteTwoByteCharacter,
-}
 
 /// Handles the conversion of TrueType glyph outlines into PDF path
 /// operations, applying the appropriate transformations for font size,
@@ -79,7 +67,7 @@ impl<'a, 'b, B: CanvasBackend> TrueTypeFontRenderer<'a, 'b, B> {
         is_symbolic: bool,
     ) -> Result<Self, PdfCanvasError> {
         let font_ref = FontRef::new(stream_object)
-            .map_err(|e| TrueTypeFontRendererError::FontParseError(e.to_string()))?;
+            .map_err(|e| PdfCanvasError::TrueTypeFontParse(e.to_string()))?;
         let outlines = font_ref.outline_glyphs();
         let charmap = font_ref.charmap();
 

--- a/crates/pdf-canvas/src/type1_font_renderer.rs
+++ b/crates/pdf-canvas/src/type1_font_renderer.rs
@@ -24,7 +24,7 @@ impl<'a, 'b, B: CanvasBackend> Type1FontRenderer<'a, 'b, B> {
         font_bytes: &'b [u8],
     ) -> Result<Self, PdfCanvasError> {
         let font_ref = FontRef::new(font_bytes)
-            .map_err(|_| PdfCanvasError::InvalidFont("invalid font data"))?;
+            .map_err(|_| PdfCanvasError::InvalidFont("unrecognized Type 1 font data".into()))?;
 
         let outlines = font_ref.outline_glyphs();
 
@@ -56,14 +56,13 @@ impl<'a, 'b, B: CanvasBackend> Type1FontRenderer<'a, 'b, B> {
 
 impl<B: CanvasBackend> TextRenderer for Type1FontRenderer<'_, '_, B> {
     fn render_text(&mut self, iter: impl Iterator<Item = u16>) -> Result<(), PdfCanvasError> {
-        let cff = self
-            .font_ref
-            .cff()
-            .map_err(|_| PdfCanvasError::InvalidFont("failed to read CFF table from Type1 font"))?;
+        let cff = self.font_ref.cff().map_err(|_| {
+            PdfCanvasError::InvalidFont("failed to read the CFF table from the Type 1 font".into())
+        })?;
 
-        let charset = cff
-            .charset(0)
-            .map_err(|_| PdfCanvasError::InvalidFont("failed to read CFF charset"))?;
+        let charset = cff.charset(0).map_err(|_| {
+            PdfCanvasError::InvalidFont("failed to read the Type 1 font CFF charset".into())
+        })?;
 
         for char_code in iter {
             let state = self.canvas.current_state()?;

--- a/crates/pdf-color-space/src/cal_gray_color_space.rs
+++ b/crates/pdf-color-space/src/cal_gray_color_space.rs
@@ -1,7 +1,7 @@
 use pdf_graphics::color::Color;
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
-use crate::color_space::{ColorSpace, ColorSpaceError};
+use crate::{color_space::ColorSpace, error::ColorSpaceError};
 
 /// Calibrated Gray color space.
 ///

--- a/crates/pdf-color-space/src/cal_rgb_color_space.rs
+++ b/crates/pdf-color-space/src/cal_rgb_color_space.rs
@@ -2,7 +2,7 @@ use pdf_graphics::color::Color;
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
 use crate::cal_gray_color_space::xyz_to_srgb;
-use crate::color_space::{ColorSpace, ColorSpaceError};
+use crate::{color_space::ColorSpace, error::ColorSpaceError};
 
 /// Calibrated RGB color space.
 ///

--- a/crates/pdf-color-space/src/color_space.rs
+++ b/crates/pdf-color-space/src/color_space.rs
@@ -1,28 +1,10 @@
 use pdf_graphics::color::Color;
-use thiserror::Error;
-
-/// Errors that can occur when parsing PDF color spaces.
-#[derive(Debug, Error)]
-pub enum ColorSpaceError {
-    #[error("Failed to resolve PDF object: {0}")]
-    ObjectError(#[from] pdf_object::error::ObjectError),
-    #[error("Invalid or unsupported ColorSpace: {description}")]
-    InvalidColorSpace { description: String },
-    #[error("Function parsing error: {0}")]
-    FunctionError(#[from] pdf_function::function::FunctionReadError),
-    #[error("Indexed color space error: {0}")]
-    IndexedColorSpaceError(String),
-    #[error("Insufficient color components: expected {0}, found {1}")]
-    InsufficientComponents(usize, usize),
-    #[error("Unsupported color space: {0}")]
-    Unsupported(String),
-}
 
 use crate::{
     cal_gray_color_space::CalGrayColorSpace, cal_rgb_color_space::CalRGBColorSpace,
-    device_n_color_space::DeviceNColorSpace, icc_based_color_space::ICCBasedColorSpace,
-    indexed_color_space::IndexedColorSpace, lab_color_space::LabColorSpace,
-    separation_color_space::SeparationColorSpace,
+    device_n_color_space::DeviceNColorSpace, error::ColorSpaceError,
+    icc_based_color_space::ICCBasedColorSpace, indexed_color_space::IndexedColorSpace,
+    lab_color_space::LabColorSpace, separation_color_space::SeparationColorSpace,
 };
 
 #[derive(Debug, Clone)]

--- a/crates/pdf-color-space/src/color_space_reader.rs
+++ b/crates/pdf-color-space/src/color_space_reader.rs
@@ -2,7 +2,6 @@ use pdf_object::{
     dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
 };
 
-use crate::color_space::{ColorSpace, ColorSpaceError};
 use crate::{
     cal_gray_color_space::parse_cal_gray_color_space,
     cal_rgb_color_space::parse_cal_rgb_color_space,
@@ -11,6 +10,7 @@ use crate::{
     indexed_color_space::parse_indexed_color_space, lab_color_space::parse_lab_color_space,
     separation_color_space::parse_separation_color_space,
 };
+use crate::{color_space::ColorSpace, error::ColorSpaceError};
 
 /// Maximum nesting depth for color space definitions.
 ///

--- a/crates/pdf-color-space/src/device_n_color_space.rs
+++ b/crates/pdf-color-space/src/device_n_color_space.rs
@@ -2,8 +2,7 @@ use pdf_graphics::color::Color;
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
 use crate::{
-    color_space::{ColorSpace, ColorSpaceError},
-    color_space_reader::parse_color_space_object,
+    color_space::ColorSpace, color_space_reader::parse_color_space_object, error::ColorSpaceError,
 };
 
 /// DeviceN color space.
@@ -41,28 +40,18 @@ pub(crate) fn parse_device_n_color_space(
     arr: &[ObjectVariant],
     depth: usize,
 ) -> Result<ColorSpace, ColorSpaceError> {
-    if arr.len() < 4 {
+    let [_, names_obj, alt_obj, _, _] = arr else {
         return Err(ColorSpaceError::InvalidColorSpace {
             description: format!("/DeviceN requires at least 4 elements, found {}", arr.len()),
         });
-    }
+    };
 
-    let names_obj = arr
-        .get(1)
-        .ok_or_else(|| ColorSpaceError::InvalidColorSpace {
-            description: "/DeviceN missing names array".into(),
-        })?;
     let names = names_obj
         .try_array(objects)?
         .iter()
         .map(|n| n.try_str(objects).map(|s| s.into_owned()))
         .collect::<Result<Vec<_>, _>>()?;
 
-    let alt_obj = arr
-        .get(2)
-        .ok_or_else(|| ColorSpaceError::InvalidColorSpace {
-            description: "/DeviceN missing alternate space".into(),
-        })?;
     let alternate_space = parse_color_space_object(objects, alt_obj, depth)?;
 
     Ok(ColorSpace::DeviceN(DeviceNColorSpace {

--- a/crates/pdf-color-space/src/error.rs
+++ b/crates/pdf-color-space/src/error.rs
@@ -1,0 +1,18 @@
+use thiserror::Error;
+
+/// Errors that can occur when parsing PDF color spaces.
+#[derive(Debug, Error)]
+pub enum ColorSpaceError {
+    #[error("Failed to resolve PDF object: {0}")]
+    ObjectError(#[from] pdf_object::error::ObjectError),
+    #[error("Invalid or unsupported ColorSpace: {description}")]
+    InvalidColorSpace { description: String },
+    #[error("Function parsing error: {0}")]
+    FunctionError(#[from] pdf_function::error::FunctionReadError),
+    #[error("Indexed color space error: {0}")]
+    IndexedColorSpaceError(String),
+    #[error("Insufficient color components: expected {0}, found {1}")]
+    InsufficientComponents(usize, usize),
+    #[error("Unsupported color space: {0}")]
+    Unsupported(String),
+}

--- a/crates/pdf-color-space/src/icc_based_color_space.rs
+++ b/crates/pdf-color-space/src/icc_based_color_space.rs
@@ -4,8 +4,7 @@ use pdf_graphics::color::Color;
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
 use crate::{
-    color_space::{ColorSpace, ColorSpaceError},
-    color_space_reader::parse_color_space_object,
+    color_space::ColorSpace, color_space_reader::parse_color_space_object, error::ColorSpaceError,
 };
 
 /// ICC profile-based color space.

--- a/crates/pdf-color-space/src/indexed_color_space.rs
+++ b/crates/pdf-color-space/src/indexed_color_space.rs
@@ -2,8 +2,7 @@ use pdf_graphics::color::Color;
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
 use crate::{
-    color_space::{ColorSpace, ColorSpaceError},
-    color_space_reader::parse_color_space_object,
+    color_space::ColorSpace, color_space_reader::parse_color_space_object, error::ColorSpaceError,
 };
 
 /// Indexed (palette-based) color space.

--- a/crates/pdf-color-space/src/lab_color_space.rs
+++ b/crates/pdf-color-space/src/lab_color_space.rs
@@ -1,7 +1,7 @@
 use pdf_graphics::color::Color;
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
-use crate::color_space::{ColorSpace, ColorSpaceError};
+use crate::{color_space::ColorSpace, error::ColorSpaceError};
 
 /// CIE 1976 L*a*b* color space.
 ///

--- a/crates/pdf-color-space/src/lib.rs
+++ b/crates/pdf-color-space/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cal_rgb_color_space;
 pub mod color_space;
 pub mod color_space_reader;
 pub mod device_n_color_space;
+pub mod error;
 pub mod icc_based_color_space;
 pub mod indexed_color_space;
 pub mod lab_color_space;

--- a/crates/pdf-color-space/src/separation_color_space.rs
+++ b/crates/pdf-color-space/src/separation_color_space.rs
@@ -3,8 +3,7 @@ use pdf_graphics::color::Color;
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
 use crate::{
-    color_space::{ColorSpace, ColorSpaceError},
-    color_space_reader::parse_color_space_object,
+    color_space::ColorSpace, color_space_reader::parse_color_space_object, error::ColorSpaceError,
 };
 
 /// Separation color space.

--- a/crates/pdf-content-stream/src/color_operators.rs
+++ b/crates/pdf-content-stream/src/color_operators.rs
@@ -403,10 +403,10 @@ impl PdfOperator for SetNonStrokingColorSc {
         }
 
         if values.is_empty() {
-            return Err(PdfOperatorError::IncorrectOperandCount {
-                op_name: "sc".to_string(),
+            return Err(PdfOperatorError::OperandCountMismatch {
+                operator: "sc".to_string(),
                 expected: 1,
-                got: 0,
+                actual: 0,
             });
         }
 
@@ -439,10 +439,10 @@ impl PdfOperator for SetStrokingColorSc {
         }
 
         if values.is_empty() {
-            return Err(PdfOperatorError::IncorrectOperandCount {
-                op_name: "SC".to_string(),
+            return Err(PdfOperatorError::OperandCountMismatch {
+                operator: "SC".to_string(),
                 expected: 1,
-                got: 0,
+                actual: 0,
             });
         }
 

--- a/crates/pdf-content-stream/src/error.rs
+++ b/crates/pdf-content-stream/src/error.rs
@@ -3,43 +3,43 @@ use pdf_parser::error::ParserError;
 use pdf_tokenizer::error::TokenizerError;
 use thiserror::Error;
 
-/// Defines errors that can occur in pdf-painter crate.
+/// Errors that can occur while parsing or validating PDF content stream operators.
 #[derive(Error, Debug, PartialEq)]
 pub enum PdfOperatorError {
-    #[error("Unimplemented operation: {0}")]
-    UnimplementedOperation(&'static str),
-    #[error("Unknown operator: '{0}'")]
+    #[error("PDF operator '{0}' is recognized but not implemented")]
+    UnsupportedOperator(&'static str),
+    #[error("Unknown PDF operator '{0}'")]
     UnknownOperator(String),
-    #[error("Missing operand: expected a {expected_type}")]
-    MissingOperand { expected_type: &'static str },
-    #[error("Invalid operand type: expected {expected_type}, found {found_type}")]
-    InvalidOperandType {
-        expected_type: &'static str,
-        found_type: &'static str,
+    #[error("Missing operand; expected {expected}")]
+    OperandMissing { expected: &'static str },
+    #[error("Invalid operand type; expected {expected}, found {found}")]
+    OperandTypeMismatch {
+        expected: &'static str,
+        found: &'static str,
     },
-    #[error("Invalid operand value: expected {expected}, found {value}")]
+    #[error("Invalid operand value; expected {expected}, found '{found}'")]
     InvalidOperandValue {
         expected: &'static str,
-        value: String,
+        found: String,
     },
-    #[error("Failed to convert a PDF value to number of type '{expected_type}': {source}")]
-    OperandNumericConversionError {
-        expected_type: &'static str,
+    #[error("Failed to convert operand to {target_type}: {source}")]
+    OperandNumberConversion {
+        target_type: &'static str,
         #[source]
         source: ObjectError,
     },
-    #[error("Incorrect operand count for operation '{op_name}': expected {expected}, got {got}")]
-    IncorrectOperandCount {
-        op_name: String,
+    #[error("Operator '{operator}' expects {expected} operand(s), got {actual}")]
+    OperandCountMismatch {
+        operator: String,
         expected: usize,
-        got: usize,
+        actual: usize,
     },
-    #[error("Tokenizer error: {0}")]
-    Tokenizer(#[from] TokenizerError),
-    #[error("Parser error: {0}")]
-    Parser(#[from] ParserError),
-    #[error("Empty text")]
-    EmptyText,
-    #[error("PDF Object error: {0}")]
-    ObjectError(#[from] ObjectError),
+    #[error("Tokenizer error while reading a content stream: {0}")]
+    TokenizerError(#[from] TokenizerError),
+    #[error("Parser error while reading a content stream: {0}")]
+    ParserError(#[from] ParserError),
+    #[error("Text-showing operator received an empty text operand")]
+    EmptyTextOperand,
+    #[error("Object error while reading a content stream: {0}")]
+    Object(#[from] ObjectError),
 }

--- a/crates/pdf-content-stream/src/graphics_state_operators.rs
+++ b/crates/pdf-content-stream/src/graphics_state_operators.rs
@@ -48,7 +48,7 @@ impl SetLineCapStyle {
             Some(style_enum) => Ok(Self { style: style_enum }),
             None => Err(PdfOperatorError::InvalidOperandValue {
                 expected: "line cap style (0 butt, 1 round, 2 projecting square)",
-                value: style.to_string(),
+                found: style.to_string(),
             }),
         }
     }
@@ -82,7 +82,7 @@ impl SetLineJoinStyle {
             Some(style_enum) => Ok(Self { style: style_enum }),
             None => Err(PdfOperatorError::InvalidOperandValue {
                 expected: "line join style (0 miter, 1 round, 2 bevel)",
-                value: style.to_string(),
+                found: style.to_string(),
             }),
         }
     }

--- a/crates/pdf-content-stream/src/pdf_operator/operands.rs
+++ b/crates/pdf-content-stream/src/pdf_operator/operands.rs
@@ -20,8 +20,8 @@ impl Operands {
         if !self.0.is_empty() {
             Ok(self.0.remove(0))
         } else {
-            Err(PdfOperatorError::MissingOperand {
-                expected_type: "Operand",
+            Err(PdfOperatorError::OperandMissing {
+                expected: "an operand",
             })
         }
     }
@@ -36,9 +36,9 @@ impl Operands {
             ObjectVariant::HexString(s)
             | ObjectVariant::Name(s)
             | ObjectVariant::LiteralString(s) => Ok(String::from_utf8_lossy(&s).into_owned()),
-            other => Err(PdfOperatorError::InvalidOperandType {
-                expected_type: "String (HexString, Name, or LiteralString)",
-                found_type: other.name(),
+            other => Err(PdfOperatorError::OperandTypeMismatch {
+                expected: "a string operand (HexString, Name, or LiteralString)",
+                found: other.name(),
             }),
         }
     }
@@ -49,9 +49,9 @@ impl Operands {
             ObjectVariant::HexString(s)
             | ObjectVariant::Name(s)
             | ObjectVariant::LiteralString(s) => Ok(s),
-            _ => Err(PdfOperatorError::InvalidOperandType {
-                expected_type: "Bytes (HexString, Name, or LiteralString)",
-                found_type: object.name(),
+            _ => Err(PdfOperatorError::OperandTypeMismatch {
+                expected: "a byte string operand (HexString, Name, or LiteralString)",
+                found: object.name(),
             }),
         }
     }

--- a/crates/pdf-content-stream/src/pdf_operator/variants.rs
+++ b/crates/pdf-content-stream/src/pdf_operator/variants.rs
@@ -250,9 +250,9 @@ fn parse_operator(
         && operands.len() != required_count
     {
         let name_str = String::from_utf8_lossy(name);
-        return Err(PdfOperatorError::IncorrectOperandCount {
-            op_name: name_str.to_string(),
-            got: operands.len(),
+        return Err(PdfOperatorError::OperandCountMismatch {
+            operator: name_str.to_string(),
+            actual: operands.len(),
             expected: required_count,
         });
     }

--- a/crates/pdf-content-stream/src/text_state_operators.rs
+++ b/crates/pdf-content-stream/src/text_state_operators.rs
@@ -167,7 +167,7 @@ impl SetRenderingMode {
             Some(mode) => Ok(Self { mode }),
             None => Err(PdfOperatorError::InvalidOperandValue {
                 expected: "One of the valid text rendering modes (0-7)",
-                value: mode.to_string(),
+                found: mode.to_string(),
             }),
         }
     }

--- a/crates/pdf-content-stream/src/xobject_and_image_operators.rs
+++ b/crates/pdf-content-stream/src/xobject_and_image_operators.rs
@@ -80,7 +80,7 @@ impl PdfOperator for InlineImageData {
         // This `read` function, within the current `Operands` model, cannot access or parse
         // the actual image data that follows the ID token.
         // Proper parsing of inline image data requires special handling in the main parser loop.
-        Err(PdfOperatorError::UnimplementedOperation(
+        Err(PdfOperatorError::UnsupportedOperator(
             "Parsing inline image data is not implemented in this operator's read function.",
         ))
     }

--- a/crates/pdf-document/src/encryption.rs
+++ b/crates/pdf-document/src/encryption.rs
@@ -10,17 +10,9 @@
 //! - The encryption dictionary contains parameters needed to decrypt the document.
 //! - Before reading other objects, the encryption dictionary must be resolved first.
 
-use pdf_object::{dictionary::Dictionary, error::ObjectError, object_resolver::ObjectResolver};
-use thiserror::Error;
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 
-/// Errors that can occur while processing PDF encryption.
-#[derive(Debug, Error)]
-pub enum EncryptionError {
-    #[error("unsupported encryption version: {version}")]
-    UnsupportedVersion { version: i32 },
-    #[error("object error while parsing encryption: {0}")]
-    ObjectError(#[from] ObjectError),
-}
+use crate::error::PdfReaderError;
 
 /// Standard security handler filter names.
 #[derive(Debug, Clone, PartialEq)]
@@ -76,7 +68,7 @@ impl std::fmt::Display for EncryptionVersion {
 }
 
 impl TryFrom<i32> for EncryptionVersion {
-    type Error = EncryptionError;
+    type Error = PdfReaderError;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
@@ -85,7 +77,7 @@ impl TryFrom<i32> for EncryptionVersion {
             3 => Ok(EncryptionVersion::V3),
             4 => Ok(EncryptionVersion::V4),
             5 => Ok(EncryptionVersion::V5),
-            _ => Err(EncryptionError::UnsupportedVersion { version: value }),
+            _ => Err(PdfReaderError::UnsupportedEncryptionVersion { version: value }),
         }
     }
 }
@@ -150,11 +142,11 @@ impl EncryptDictionary {
     ///
     /// # Returns
     ///
-    /// An `EncryptDictionary` on success, or an `EncryptionError` if parsing fails.
+    /// An `EncryptDictionary` on success, or a `PdfReaderError` if parsing fails.
     pub fn from_dictionary(
         dict: &Dictionary,
         objects: &dyn ObjectResolver,
-    ) -> Result<Self, EncryptionError> {
+    ) -> Result<Self, PdfReaderError> {
         let filter = dict
             .get_or_err("Filter")?
             .try_str(objects)

--- a/crates/pdf-document/src/error.rs
+++ b/crates/pdf-document/src/error.rs
@@ -1,25 +1,17 @@
 use pdf_object::error::ObjectError;
-use pdf_page::pages::PdfPagesError;
+use pdf_page::error::PdfPagesError;
 use pdf_parser::{error::ParserError, header::HeaderError};
 use thiserror::Error;
 
+use crate::decryption::DecryptionError;
+
 /// Errors that can occur while reading a PDF document.
 #[derive(Debug, Error)]
-pub enum PdfError {
-    /// An error occurred during the parsing phase of the PDF document structure.
-    #[error("read error: {0}")]
-    ReadError(String),
-    /// The PDF document trailer dictionary could not be found or is malformed.
+pub enum PdfReaderError {
     #[error("missing trailer")]
     MissingTrailer,
-    /// The `Pages` entry in the document catalog is missing or invalid.
-    #[error("missing page tree")]
-    MissingPageTree,
-    /// The document catalog (the object referenced by `/Root` in the trailer) is missing or invalid.
-    #[error("missing catalog")]
-    MissingCatalog,
-    #[error("missing type")]
-    MissingType,
+    #[error("unexpected reference object at offset {offset}")]
+    UnexpectedReference { offset: usize },
     #[error("{0}")]
     ObjectError(#[from] ObjectError),
     #[error("{0}")]
@@ -28,4 +20,14 @@ pub enum PdfError {
     ParserError(#[from] ParserError),
     #[error("Error parsing PDF header: {0}")]
     HeaderError(#[from] HeaderError),
+    #[error("unsupported PDF version: {0}.{1}")]
+    UnsupportedVersion(u8, u8),
+    #[error("invalid cross-reference table at offset {offset}")]
+    InvalidXrefAtOffset { offset: usize },
+    #[error("unsupported encryption version: {version}")]
+    UnsupportedEncryptionVersion { version: i32 },
+    #[error("decryption error: {0}")]
+    DecryptionError(#[from] DecryptionError),
+    #[error("missing document ID required for encryption")]
+    MissingDocumentId,
 }

--- a/crates/pdf-document/src/object_stream.rs
+++ b/crates/pdf-document/src/object_stream.rs
@@ -3,7 +3,7 @@ use pdf_object::{
 };
 use pdf_parser::parser::PdfParser;
 
-use crate::reader::PdfReaderError;
+use crate::error::PdfReaderError;
 
 /// Parses an object stream (PDF 1.5+) and extracts all objects stored within it.
 ///

--- a/crates/pdf-document/src/reader.rs
+++ b/crates/pdf-document/src/reader.rs
@@ -1,7 +1,8 @@
 use std::collections::{BTreeMap, HashMap};
 
-use crate::decryption::{DecryptionError, DocumentDecryptor};
+use crate::decryption::DocumentDecryptor;
 use crate::document::PdfDocument;
+use crate::error::PdfReaderError;
 use crate::object_stream::read_object_stream;
 use pdf_object::indirect_object::IndirectObject;
 use pdf_object::object_resolver::{ObjectResolver, PassthroughResolver};
@@ -14,39 +15,11 @@ use pdf_object::{
 };
 use pdf_object_collection::object_collection::ObjectCollection;
 use pdf_page::page::PdfPage;
-use pdf_page::pages::{PdfPages, PdfPagesError};
+use pdf_page::pages::PdfPages;
 use pdf_page::resource::Resource;
-use pdf_parser::{error::ParserError, header::HeaderError, parser::PdfParser};
-use thiserror::Error;
+use pdf_parser::parser::PdfParser;
 
-use crate::encryption::{EncryptDictionary, EncryptionError};
-
-/// Errors that can occur while reading a PDF document.
-#[derive(Debug, Error)]
-pub enum PdfReaderError {
-    #[error("missing trailer")]
-    MissingTrailer,
-    #[error("unexpected reference object at offset {offset}")]
-    UnexpectedReference { offset: usize },
-    #[error("{0}")]
-    ObjectError(#[from] ObjectError),
-    #[error("{0}")]
-    PdfPagesError(#[from] PdfPagesError),
-    #[error("{0}")]
-    ParserError(#[from] ParserError),
-    #[error("Error parsing PDF header: {0}")]
-    HeaderError(#[from] HeaderError),
-    #[error("unsupported PDF version: {0}.{1}")]
-    UnsupportedVersion(u8, u8),
-    #[error("invalid cross-reference table at offset {offset}")]
-    InvalidXrefAtOffset { offset: usize },
-    #[error("encryption error: {0}")]
-    EncryptionError(#[from] EncryptionError),
-    #[error("decryption error: {0}")]
-    DecryptionError(#[from] DecryptionError),
-    #[error("missing document ID required for encryption")]
-    MissingDocumentId,
-}
+use crate::encryption::EncryptDictionary;
 
 #[derive(Default)]
 pub struct PdfReader;

--- a/crates/pdf-font/src/cff_builder.rs
+++ b/crates/pdf-font/src/cff_builder.rs
@@ -4,7 +4,7 @@ use write_fonts::{
     types::Tag,
 };
 
-use crate::font::FontError;
+use crate::error::FontError;
 
 /// Builds a minimal OpenType font from raw CFF (Compact Font Format) bytes.
 ///

--- a/crates/pdf-font/src/encoding.rs
+++ b/crates/pdf-font/src/encoding.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
-use thiserror::Error;
+
+use crate::error::FontError;
 
 /// Represents the base encoding of a font.
 #[derive(Default, PartialEq, Clone, Debug)]
@@ -16,8 +17,6 @@ pub enum FontEncoding {
     MacExpert,
     /// Windows ANSI encoding.
     WinAnsi,
-    /// PDF Document encoding.
-    PDFDocEncoding,
     /// Unknown encoding.
     Unknown(String),
 }
@@ -29,22 +28,9 @@ impl From<Cow<'_, str>> for FontEncoding {
             "MacExpertEncoding" => Self::MacExpert,
             "StandardEncoding" => Self::Standard,
             "WinAnsiEncoding" => Self::WinAnsi,
-            "PDFDocEncoding" => Self::PDFDocEncoding,
             _ => Self::Unknown(name.to_string()),
         }
     }
-}
-
-#[derive(Debug, Error, Clone, PartialEq)]
-pub enum EncodingReadError {
-    #[error("PDF Object error: {0}")]
-    ObjectError(#[from] pdf_object::error::ObjectError),
-    #[error("BaseEncoding must be a name or string")]
-    InvalidBaseEncodingType,
-    #[error("PDFDocEncoding is not yet supported")]
-    UnsupportedPdfDocEncoding,
-    #[error("Unknown base encoding '{0}'")]
-    UnknownBaseEncoding(String),
 }
 
 #[derive(Debug)]
@@ -60,17 +46,14 @@ impl Default for Encoding {
 }
 
 impl Encoding {
-    pub(crate) fn from_base_encoding(encoding: FontEncoding) -> Result<Self, EncodingReadError> {
+    pub(crate) fn from_base_encoding(encoding: FontEncoding) -> Result<Self, FontError> {
         let names = match encoding {
             FontEncoding::Standard => names_from_base(&STANDARD_NAMES),
             FontEncoding::WinAnsi => names_from_base(&WIN_ANSI_NAMES),
             FontEncoding::MacRoman => names_from_base(&MAC_ROMAN_NAMES),
             FontEncoding::MacExpert => names_from_base(&MAC_EXPERT_NAMES),
-            FontEncoding::PDFDocEncoding => {
-                return Err(EncodingReadError::UnsupportedPdfDocEncoding);
-            }
             FontEncoding::Unknown(name) => {
-                return Err(EncodingReadError::UnknownBaseEncoding(name));
+                return Err(FontError::UnsupportedBaseEncoding(name));
             }
             FontEncoding::None => Vec::new(),
         };
@@ -81,7 +64,7 @@ impl Encoding {
         &mut self,
         differences_obj: &ObjectVariant,
         objects: &dyn ObjectResolver,
-    ) -> Result<(), EncodingReadError> {
+    ) -> Result<(), FontError> {
         let mut current_range_start = 0_usize;
 
         for chunk in differences_obj.try_array(objects)? {
@@ -106,7 +89,7 @@ impl Encoding {
     pub fn from_dictionary(
         dictionary: &pdf_object::dictionary::Dictionary,
         objects: &dyn ObjectResolver,
-    ) -> Result<Self, EncodingReadError> {
+    ) -> Result<Self, FontError> {
         let mut encoding = match dictionary.get("BaseEncoding") {
             Some(base) => {
                 let base_encoding = FontEncoding::from(base.try_str(objects)?);

--- a/crates/pdf-font/src/error.rs
+++ b/crates/pdf-font/src/error.rs
@@ -1,0 +1,28 @@
+use pdf_content_stream::error::PdfOperatorError;
+use pdf_object::error::ObjectError;
+use thiserror::Error;
+
+use crate::glyph_widths_map::GlyphWidthsMapError;
+
+/// Defines errors that can occur while reading a font object.
+#[derive(Debug, Error, PartialEq)]
+pub enum FontError {
+    #[error("{0}")]
+    ObjectError(#[from] ObjectError),
+    #[error("Unsupported or invalid font subtype '{subtype}'")]
+    UnsupportedFontSubtype { subtype: String },
+    #[error("Failed to build CFF font: {0}")]
+    FontBuildError(String),
+    #[error("Error parsing content stream operators: {0}")]
+    ContentStreamError(#[from] PdfOperatorError),
+    #[error("Missing embedded font file stream")]
+    MissingFontFile,
+    #[error("{0}")]
+    GlyphWidthsMapError(#[from] GlyphWidthsMapError),
+    #[error("Unsupported CIDFont subtype '{subtype}'")]
+    UnsupportedCidFontSubtype { subtype: String },
+    #[error("Invalid /DescendantFonts entry in Type0 font: {0}")]
+    InvalidDescendantFonts(&'static str),
+    #[error("Unsupported /BaseEncoding value '{0}'")]
+    UnsupportedBaseEncoding(String),
+}

--- a/crates/pdf-font/src/font.rs
+++ b/crates/pdf-font/src/font.rs
@@ -1,44 +1,12 @@
 use std::borrow::Cow;
 
-use pdf_object::{dictionary::Dictionary, error::ObjectError, object_resolver::ObjectResolver};
-use thiserror::Error;
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 
 use crate::{
-    char_vec::CharVec,
-    glyph_name_to_unicode::glyph_name_to_unicode,
-    standard14::Standard14Font,
-    to_unicode_cmap::ToUnicodeCMap,
-    true_type_font::TrueTypeFont,
-    type0_font::{Type0Font, Type0FontError},
-    type1_font::Type1Font,
-    type3_font::{Type3Font, Type3FontError},
+    char_vec::CharVec, error::FontError, glyph_name_to_unicode::glyph_name_to_unicode,
+    standard14::Standard14Font, to_unicode_cmap::ToUnicodeCMap, true_type_font::TrueTypeFont,
+    type0_font::Type0Font, type1_font::Type1Font, type3_font::Type3Font,
 };
-
-/// Defines errors that can occur while reading a font object.
-#[derive(Debug, Error, PartialEq)]
-pub enum FontError {
-    #[error("{0}")]
-    ObjectError(#[from] ObjectError),
-    #[error("Error processing Type3 font: {0}")]
-    Type3FontError(#[from] Type3FontError),
-    #[error("Error processing Type0 font: {0}")]
-    Type0FontError(#[from] Type0FontError),
-    #[error("Unsupported or invalid font subtype '{subtype}'")]
-    UnsupportedFontSubtype { subtype: String },
-    #[error("Unsupported or invalid font subtype '{0}'")]
-    InvalidFontSubtype(String),
-    #[error("Failed to build font: {0}")]
-    FontBuildError(String),
-    #[error("Encoding reading error: {0}")]
-    EncodingReadError(#[from] crate::encoding::EncodingReadError),
-    /// The font dictionary or descriptor lacks an embedded font program stream
-    /// (`FontFile`, `FontFile2`, or `FontFile3`).
-    ///
-    /// For Type 1 fonts this is a sentinel: `Font::from_dictionary` catches it
-    /// and substitutes a bundled Standard 14 TrueType fallback.
-    #[error("Missing embedded font file stream")]
-    MissingFontFile,
-}
 
 /// Represents a font object in a PDF document.
 pub enum Font {

--- a/crates/pdf-font/src/lib.rs
+++ b/crates/pdf-font/src/lib.rs
@@ -1,6 +1,7 @@
 mod cff_builder;
 pub mod char_vec;
 pub mod encoding;
+pub mod error;
 pub mod flags;
 pub mod font;
 pub mod glyph_name_to_unicode;

--- a/crates/pdf-font/src/simple_font_glyph_map.rs
+++ b/crates/pdf-font/src/simple_font_glyph_map.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 
-use crate::font::FontError;
+use crate::error::FontError;
 
 pub struct SimpleFontGlyphWidthsMap;
 

--- a/crates/pdf-font/src/true_type_font.rs
+++ b/crates/pdf-font/src/true_type_font.rs
@@ -7,8 +7,8 @@ use pdf_object::{
 
 use crate::{
     encoding::{Encoding, FontEncoding},
+    error::FontError,
     flags::FontFlags,
-    font::FontError,
     simple_font_glyph_map::SimpleFontGlyphWidthsMap,
     standard14::Standard14Font,
     to_unicode_cmap::ToUnicodeCMap,

--- a/crates/pdf-font/src/type0_font.rs
+++ b/crates/pdf-font/src/type0_font.rs
@@ -1,17 +1,12 @@
 use std::collections::HashMap;
 
-use pdf_object::{dictionary::Dictionary, error::ObjectError, object_resolver::ObjectResolver};
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 use read_fonts::{FontRef, TableProvider};
 
 use crate::{
-    encoding::FontEncoding,
-    font::FontError,
-    glyph_widths_map::{GlyphWidthsMap, GlyphWidthsMapError},
-    to_unicode_cmap::ToUnicodeCMap,
-    true_type_font::TrueTypeFont,
-    type1_font::Type1Font,
+    encoding::FontEncoding, error::FontError, glyph_widths_map::GlyphWidthsMap,
+    to_unicode_cmap::ToUnicodeCMap, true_type_font::TrueTypeFont, type1_font::Type1Font,
 };
-use thiserror::Error;
 
 /// Represents a PDF Type0 (composite) font, which references a CIDFont
 /// for glyph definitions.
@@ -52,19 +47,6 @@ pub enum CidFontSubType {
     Type2,
 }
 
-/// Defines errors that can occur while reading a PDF objects.
-#[derive(Debug, Error, Clone, PartialEq)]
-pub enum Type0FontError {
-    #[error("{0}")]
-    ObjectError(#[from] ObjectError),
-    #[error("GlyphWidthsMap parsing error: {0}")]
-    GlyphWidthsMapError(#[from] GlyphWidthsMapError),
-    #[error("Unsupported CIDFont subtype '{subtype}'")]
-    UnsupportedCidFontSubtype { subtype: String },
-    #[error("Invalid /DescendantFonts entry in Type0 font: {0}")]
-    InvalidDescendantFonts(&'static str),
-}
-
 impl Type0Font {
     pub fn from_dictionary(
         dictionary: &Dictionary,
@@ -93,16 +75,15 @@ impl Type0Font {
             .get_or_err("DescendantFonts")?
             .try_array(objects)?;
         if descendant_fonts_array.len() != 1 {
-            return Err(Type0FontError::InvalidDescendantFonts(
-                "Expected exactly one descendant font",
-            )
-            .into());
+            return Err(
+                FontError::InvalidDescendantFonts("Expected exactly one descendant font").into(),
+            );
         }
 
         // Retrieve the sole CIDFont dictionary from the array.
         let dictionary = descendant_fonts_array
             .first()
-            .ok_or(Type0FontError::InvalidDescendantFonts("Array is empty"))?
+            .ok_or(FontError::InvalidDescendantFonts("Array is empty"))?
             .try_dictionary(objects)?;
 
         // Determine the CIDFont subtype which dictates how glyph data is stored:
@@ -112,7 +93,7 @@ impl Type0Font {
             "CIDFontType0" => CidFontSubType::Type0,
             "CIDFontType2" => CidFontSubType::Type2,
             other => {
-                return Err(Type0FontError::UnsupportedCidFontSubtype {
+                return Err(FontError::UnsupportedCidFontSubtype {
                     subtype: other.to_string(),
                 }
                 .into());
@@ -131,9 +112,9 @@ impl Type0Font {
         // default width for specific CIDs.
         let widths_map = dictionary
             .get("W")
-            .map(|obj| -> Result<GlyphWidthsMap, Type0FontError> {
+            .map(|obj| -> Result<GlyphWidthsMap, FontError> {
                 let resolved_obj = obj.try_array(objects)?;
-                GlyphWidthsMap::from_array(resolved_obj, objects).map_err(Type0FontError::from)
+                GlyphWidthsMap::from_array(resolved_obj, objects).map_err(FontError::from)
             })
             .transpose()?;
 

--- a/crates/pdf-font/src/type1_font.rs
+++ b/crates/pdf-font/src/type1_font.rs
@@ -7,7 +7,7 @@ use pdf_object::{
 use crate::{
     cff_builder::build_cff_font,
     encoding::{Encoding, FontEncoding},
-    font::FontError,
+    error::FontError,
     simple_font_glyph_map::SimpleFontGlyphWidthsMap,
     to_unicode_cmap::ToUnicodeCMap,
 };

--- a/crates/pdf-font/src/type3_font.rs
+++ b/crates/pdf-font/src/type3_font.rs
@@ -1,15 +1,14 @@
 use std::collections::HashMap;
 
-use pdf_content_stream::{error::PdfOperatorError, pdf_operator::PdfOperatorVariant};
+use pdf_content_stream::pdf_operator::PdfOperatorVariant;
 use pdf_graphics::{rect::Rect, transform::Transform};
 use pdf_object::{
-    dictionary::Dictionary, error::ObjectError, object_resolver::ObjectResolver,
-    object_variant::ObjectVariant,
+    dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
 };
-use thiserror::Error;
 
 use crate::{
-    encoding::{Encoding, EncodingReadError, FontEncoding},
+    encoding::{Encoding, FontEncoding},
+    error::FontError,
     to_unicode_cmap::ToUnicodeCMap,
 };
 
@@ -35,22 +34,11 @@ pub struct Type3Font {
     pub to_unicode: Option<ToUnicodeCMap>,
 }
 
-/// Defines errors that can occur while parsing a Type 3 font object.
-#[derive(Debug, Error, PartialEq)]
-pub enum Type3FontError {
-    #[error("Object error: {0}")]
-    ObjectError(#[from] ObjectError),
-    #[error("Error parsing content stream operators: {0}")]
-    ContentStreamError(#[from] PdfOperatorError),
-    #[error("Encoding read error: {0}")]
-    EncodingReadError(#[from] EncodingReadError),
-}
-
 impl Type3Font {
     pub fn from_dictionary(
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
-    ) -> Result<Self, Type3FontError> {
+    ) -> Result<Self, FontError> {
         let [a, b, c, d, e, f] = dictionary
             .get_or_err("FontMatrix")?
             .try_array_of::<f32, 6>(objects)?;

--- a/crates/pdf-function/src/error.rs
+++ b/crates/pdf-function/src/error.rs
@@ -1,0 +1,46 @@
+use pdf_object::error::ObjectError;
+use pdf_postscript::calculator::CalcError;
+use thiserror::Error;
+
+/// Errors that can occur when parsing a PDF Function dictionary.
+#[derive(Debug, Error)]
+pub enum FunctionReadError {
+    /// The `/FunctionType` entry is missing or has an unsupported value.
+    #[error("Invalid /FunctionType value")]
+    InvalidFunctionType,
+    /// The `/Encode` array length must be exactly `2 * number of functions`.
+    #[error("Encode array length must be exactly 2 * number of functions")]
+    InvalidEncodeLength,
+    /// The `/Bounds` array length must be `number of functions - 1`.
+    #[error("Bounds array length must be number of functions - 1")]
+    InvalidBoundsLength,
+    /// Failed to parse the `/Domain` array.
+    #[error("Domain parsing error: {0}")]
+    DomainParsingError(#[from] ObjectError),
+    /// Error during PostScript code parsing.
+    #[error("PostScript calculator error: {0}")]
+    PostScriptCalculatorError(#[from] CalcError),
+    /// The `/Size` array is empty or invalid for a sampled function.
+    #[error("Size array must have at least one element")]
+    InvalidSizeArray,
+    /// The `/BitsPerSample` value is invalid.
+    #[error("BitsPerSample must be 1, 2, 4, 8, 12, 16, 24, or 32")]
+    InvalidBitsPerSample,
+    /// The stream data is too short for the declared sample table.
+    #[error(
+        "Stream data is too short for the sample table (expected {expected} bytes, got {actual})"
+    )]
+    InsufficientStreamData { expected: usize, actual: usize },
+    /// The `/Order` value is invalid (must be 1 or 3).
+    #[error("Order must be 1 (linear) or 3 (cubic)")]
+    InvalidOrder,
+    /// The `/Decode` array length is invalid.
+    #[error("Decode array length must be exactly 2 * number of outputs")]
+    InvalidDecodeLength,
+    /// C0 and C1 arrays must have the same length (validated at parse time).
+    #[error("C0 and C1 arrays must have the same length")]
+    MismatchedC0C1Length,
+    /// A sample value could not be converted to the required numeric type.
+    #[error("Sample data conversion failed")]
+    InvalidSampleData,
+}

--- a/crates/pdf-function/src/exponential_interpolation.rs
+++ b/crates/pdf-function/src/exponential_interpolation.rs
@@ -1,8 +1,9 @@
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
-use crate::function::{
-    Function, FunctionImpl, FunctionInterpolationError, FunctionReadError, clamp_and_normalize,
-    get_pair,
+use crate::{
+    error::FunctionReadError,
+    function::{Function, FunctionImpl, clamp_and_normalize, get_pair},
+    function_interpolation_error::FunctionInterpolationError,
 };
 
 #[derive(Debug, Clone)]
@@ -46,12 +47,12 @@ impl FunctionImpl for ExponentialFunction {
             })?;
 
         // Normalize input to [0, 1]
-        let x_normalized =
-            clamp_and_normalize(x, self.domain).ok_or(FunctionInterpolationError::InvalidDomain)?;
+        let x_normalized = clamp_and_normalize(x, self.domain)
+            .ok_or(FunctionInterpolationError::InvalidDomainInterval)?;
 
         // Guard against 0^(negative) which is undefined
         if self.exponent < 0.0 && x_normalized == 0.0 {
-            return Err(FunctionInterpolationError::NegativeExponentAtZero);
+            return Err(FunctionInterpolationError::UndefinedExponentiationAtZero);
         }
 
         // Apply interpolation formula: c0 + x^N * (c1 - c0)
@@ -172,7 +173,7 @@ mod tests {
         let f = make_exp(vec![0.0], vec![1.0], -1.0);
         assert!(matches!(
             f.interpolate(&[0.0]),
-            Err(FunctionInterpolationError::NegativeExponentAtZero)
+            Err(FunctionInterpolationError::UndefinedExponentiationAtZero)
         ));
     }
 }

--- a/crates/pdf-function/src/function.rs
+++ b/crates/pdf-function/src/function.rs
@@ -6,115 +6,14 @@
 //! - Type 3: Stitching functions (combining multiple functions)
 //! - Type 4: PostScript Calculator functions
 
-use pdf_object::{
-    error::ObjectError, object_resolver::ObjectResolver, object_variant::ObjectVariant,
-};
-use pdf_postscript::calculator::CalcError;
-use thiserror::Error;
+use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
 use crate::{
-    exponential_interpolation::ExponentialFunction,
+    error::FunctionReadError, exponential_interpolation::ExponentialFunction,
+    function_interpolation_error::FunctionInterpolationError,
     postscript_calculator::PostScriptCalculatorFunction, sampled::SampledFunction,
     stitching::StitchingFunction,
 };
-
-/// Errors that can occur when parsing a PDF Function dictionary.
-#[derive(Debug, Error)]
-pub enum FunctionReadError {
-    /// The `/FunctionType` entry is missing or has an unsupported value.
-    #[error("Invalid /FunctionType value")]
-    InvalidFunctionType,
-    /// The function requires an associated stream but none was provided.
-    #[error("Stream data is required for {function_type:?} functions")]
-    StreamRequired { function_type: FunctionType },
-    /// The `/Encode` array length must be exactly `2 * number of functions`.
-    #[error("Encode array length must be exactly 2 * number of functions")]
-    InvalidEncodeLength,
-    /// The `/Bounds` array length must be `number of functions - 1`.
-    #[error("Bounds array length must be number of functions - 1")]
-    InvalidBoundsLength,
-    /// A function entry was not a dictionary or stream.
-    #[error("Function entry must be a dictionary or stream")]
-    InvalidFunctionEntryType,
-    /// Failed to read a required dictionary entry.
-    #[error("Failed to read function value for '{entry_description}': {source}")]
-    EntryReadError {
-        entry_description: &'static str,
-        #[source]
-        source: ObjectError,
-    },
-    /// Failed to parse the `/Domain` array.
-    #[error("Domain parsing error: {0}")]
-    DomainParsingError(#[from] ObjectError),
-    /// Error during PostScript code parsing.
-    #[error("PostScript calculator error: {0}")]
-    PostScriptCalculatorError(#[from] CalcError),
-    /// The `/Size` array is empty or invalid for a sampled function.
-    #[error("Size array must have at least one element")]
-    InvalidSizeArray,
-    /// The `/BitsPerSample` value is invalid.
-    #[error("BitsPerSample must be 1, 2, 4, 8, 12, 16, 24, or 32")]
-    InvalidBitsPerSample,
-    /// The stream data is too short for the declared sample table.
-    #[error(
-        "Stream data is too short for the sample table (expected {expected} bytes, got {actual})"
-    )]
-    InsufficientStreamData { expected: usize, actual: usize },
-    /// The `/Order` value is invalid (must be 1 or 3).
-    #[error("Order must be 1 (linear) or 3 (cubic)")]
-    InvalidOrder,
-    /// The `/Decode` array length is invalid.
-    #[error("Decode array length must be exactly 2 * number of outputs")]
-    InvalidDecodeLength,
-    /// C0 and C1 arrays must have the same length (validated at parse time).
-    #[error("C0 and C1 arrays must have the same length")]
-    MismatchedC0C1Length,
-    /// A sample value could not be converted to the required numeric type.
-    #[error("Sample data conversion failed")]
-    InvalidSampleData,
-}
-
-/// Errors that can occur during function interpolation.
-#[derive(Debug, Error)]
-pub enum FunctionInterpolationError {
-    #[error("Interpolation is not supported for function type {0:?}")]
-    UnsupportedFunctionType(FunctionType),
-    #[error("Domain must be an increasing interval (domain[0] < domain[1])")]
-    InvalidDomain,
-    #[error("PostScript calculator error: {0}")]
-    PostScriptCalculatorError(#[from] CalcError),
-    #[error("Encode array length must be exactly 2 * number of functions")]
-    InvalidEncodeLength,
-    #[error("Bounds array length must be number of functions - 1")]
-    InvalidBoundsLength,
-    #[error("Index calculation overflow or out-of-bounds during encode access")]
-    EncodeIndexError,
-    #[error("Result stack does not contain enough values for declared range")]
-    InsufficientResultStack,
-    #[error("Negative exponent with zero normalized input produces undefined result")]
-    NegativeExponentAtZero,
-    #[error("Input value is NaN")]
-    InputIsNaN,
-    #[error("Sample index out of bounds")]
-    SampleIndexOutOfBounds,
-    #[error("Invalid sample data")]
-    InvalidSampleData,
-    #[error(
-        "Function returned insufficient color components: required {required}, returned {returned}"
-    )]
-    InsufficientColorComponents { required: usize, returned: usize },
-    #[error("Indexed color space is unsupported for color conversion")]
-    IndexedColorSpaceUnsupported,
-    /// Cubic spline interpolation for Type 0 functions is not implemented.
-    #[error("Cubic spline interpolation (Order=3) is not implemented for sampled functions")]
-    CubicInterpolationNotSupported,
-    /// Caller provided fewer inputs than the function requires.
-    #[error("Insufficient inputs: expected {expected}, got {got}")]
-    InsufficientInputs { expected: usize, got: usize },
-    /// A bounds value in a stitching function is NaN.
-    #[error("Bounds array contains NaN — cannot determine segment for input value")]
-    InvalidBounds,
-}
 
 /// Represents the type of a PDF Function object (Table 38 in PDF spec).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/pdf-function/src/function_interpolation_error.rs
+++ b/crates/pdf-function/src/function_interpolation_error.rs
@@ -1,0 +1,44 @@
+use pdf_postscript::calculator::CalcError;
+use thiserror::Error;
+
+use crate::function::FunctionType;
+
+/// Errors that can occur during function interpolation.
+#[derive(Debug, Error)]
+pub enum FunctionInterpolationError {
+    #[error("interpolation is not implemented for {0:?} functions")]
+    UnsupportedFunctionType(FunctionType),
+    #[error("/Domain must define a strictly increasing interval [min, max]")]
+    InvalidDomainInterval,
+    #[error("PostScript calculator error: {0}")]
+    PostScriptCalculatorError(#[from] CalcError),
+    #[error("/Encode must contain exactly two values for each stitched sub-function")]
+    InvalidEncodeLength,
+    #[error("/Bounds must contain exactly one fewer value than /Functions")]
+    InvalidBoundsLength,
+    #[error("function data is internally inconsistent: indexed lookup was out of bounds")]
+    FunctionDataIndexOutOfBounds,
+    #[error("PostScript function returned fewer values than required by /Range")]
+    PostScriptResultStackUnderflow,
+    #[error("cannot evaluate 0 raised to a negative exponent")]
+    UndefinedExponentiationAtZero,
+    #[error("function produced a non-finite numeric value")]
+    NonFiniteNumericValue,
+    #[error("sample lookup produced an out-of-bounds coordinate or offset")]
+    SampleCoordinateOutOfBounds,
+    #[error("sample data is invalid or cannot be decoded")]
+    InvalidSampleData,
+    #[error("function returned too few color components: expected {required}, got {returned}")]
+    ColorComponentCountMismatch { required: usize, returned: usize },
+    #[error("indexed color spaces are not supported for function color conversion")]
+    IndexedColorSpaceNotSupported,
+    /// Cubic spline interpolation for Type 0 functions is not implemented.
+    #[error("sampled functions with /Order 3 are recognized but not implemented")]
+    CubicInterpolationUnsupported,
+    /// Caller provided fewer inputs than the function requires.
+    #[error("function requires {expected} input value(s), got {got}")]
+    InsufficientInputs { expected: usize, got: usize },
+    /// A bounds value in a stitching function is NaN.
+    #[error("/Bounds contains NaN, so the stitching segment cannot be determined")]
+    BoundsContainNaN,
+}

--- a/crates/pdf-function/src/lib.rs
+++ b/crates/pdf-function/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod error;
 pub mod exponential_interpolation;
 pub mod function;
+pub mod function_interpolation_error;
 pub mod postscript_calculator;
 pub mod sampled;
 pub mod stitching;

--- a/crates/pdf-function/src/postscript_calculator.rs
+++ b/crates/pdf-function/src/postscript_calculator.rs
@@ -2,8 +2,10 @@ use num_traits::ToPrimitive;
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 use pdf_postscript::operator::Operator;
 
-use crate::function::{
-    Function, FunctionImpl, FunctionInterpolationError, FunctionReadError, get_pair,
+use crate::{
+    error::FunctionReadError,
+    function::{Function, FunctionImpl, get_pair},
+    function_interpolation_error::FunctionInterpolationError,
 };
 
 #[derive(Debug, Clone)]
@@ -26,8 +28,8 @@ impl PostScriptCalculatorFunction {
         let mut stack = Vec::with_capacity(input_count);
 
         for i in 0..input_count {
-            let (start, end) =
-                get_pair(domain, i).ok_or(FunctionInterpolationError::EncodeIndexError)?;
+            let (start, end) = get_pair(domain, i)
+                .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;
 
             let val = inputs
                 .get(i)
@@ -55,12 +57,14 @@ impl PostScriptCalculatorFunction {
         for i in 0..output_count {
             let val = *result_stack
                 .get(i)
-                .ok_or(FunctionInterpolationError::InsufficientResultStack)?;
+                .ok_or(FunctionInterpolationError::PostScriptResultStackUnderflow)?;
 
-            let (min, max) =
-                get_pair(range, i).ok_or(FunctionInterpolationError::EncodeIndexError)?;
+            let (min, max) = get_pair(range, i)
+                .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;
 
-            let v_f32 = val.to_f32().ok_or(FunctionInterpolationError::InputIsNaN)?;
+            let v_f32 = val
+                .to_f32()
+                .ok_or(FunctionInterpolationError::NonFiniteNumericValue)?;
 
             outputs.push(v_f32.clamp(min, max));
         }

--- a/crates/pdf-function/src/sampled.rs
+++ b/crates/pdf-function/src/sampled.rs
@@ -2,9 +2,10 @@ use num_derive::FromPrimitive;
 use num_traits::{FromPrimitive, ToPrimitive};
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
-use crate::function::{
-    Function, FunctionImpl, FunctionInterpolationError, FunctionReadError, ensure_stream_len,
-    get_pair, linear_interpolate,
+use crate::{
+    error::FunctionReadError,
+    function::{Function, FunctionImpl, ensure_stream_len, get_pair, linear_interpolate},
+    function_interpolation_error::FunctionInterpolationError,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, FromPrimitive, Default)]
@@ -166,7 +167,7 @@ impl FunctionImpl for SampledFunction {
     ///
     /// Supports N-dimensional multilinear interpolation as defined in ISO 32000 §7.10.2.
     /// Cubic spline interpolation (Order=3) is recognised in the dictionary but not yet
-    /// implemented; it returns [`FunctionInterpolationError::CubicInterpolationNotSupported`].
+    /// implemented; it returns [`FunctionInterpolationError::CubicInterpolationUnsupported`].
     fn interpolate(&self, inputs: &[f32]) -> Result<Vec<f32>, FunctionInterpolationError> {
         let m = self.size.len();
 
@@ -178,14 +179,14 @@ impl FunctionImpl for SampledFunction {
         }
 
         if self.order == InterpolationOrder::Cubic {
-            return Err(FunctionInterpolationError::CubicInterpolationNotSupported);
+            return Err(FunctionInterpolationError::CubicInterpolationUnsupported);
         }
 
         // Encode each input dimension to a continuous sample coordinate.
         let mut enc_coords: Vec<f32> = Vec::with_capacity(m);
         for i in 0..m {
-            let (domain_min, domain_max) =
-                get_pair(&self.domain, i).ok_or(FunctionInterpolationError::EncodeIndexError)?;
+            let (domain_min, domain_max) = get_pair(&self.domain, i)
+                .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;
             let x_clamped = inputs
                 .get(i)
                 .copied()
@@ -195,8 +196,8 @@ impl FunctionImpl for SampledFunction {
                 })?
                 .clamp(domain_min, domain_max);
 
-            let (encode_min, encode_max) =
-                get_pair(&self.encode, i).ok_or(FunctionInterpolationError::EncodeIndexError)?;
+            let (encode_min, encode_max) = get_pair(&self.encode, i)
+                .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;
             let encoded =
                 linear_interpolate(x_clamped, domain_min, domain_max, encode_min, encode_max);
 
@@ -204,11 +205,11 @@ impl FunctionImpl for SampledFunction {
                 .size
                 .get(i)
                 .copied()
-                .ok_or(FunctionInterpolationError::EncodeIndexError)?;
+                .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;
             let max_i = size_i
                 .saturating_sub(1)
                 .to_f32()
-                .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
 
             enc_coords.push(encoded.clamp(0.0, max_i));
         }
@@ -222,12 +223,12 @@ impl FunctionImpl for SampledFunction {
                 .size
                 .get(i)
                 .copied()
-                .ok_or(FunctionInterpolationError::EncodeIndexError)?;
+                .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;
             let max_i_idx = size_i.saturating_sub(1);
             let low = enc
                 .floor()
                 .to_usize()
-                .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
             let high = low.saturating_add(1).min(max_i_idx);
             idx_low.push(low);
             idx_high.push(high);
@@ -242,25 +243,25 @@ impl FunctionImpl for SampledFunction {
                 .size
                 .get(next)
                 .copied()
-                .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
             let next_stride = strides
                 .get(next)
                 .copied()
-                .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
             let s = strides
                 .get_mut(i)
-                .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
             *s = next_size
                 .checked_mul(next_stride)
-                .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
         }
 
         // Multilinear interpolation: iterate over all 2^m corners of the hypercube.
-        let m_u32 =
-            u32::try_from(m).map_err(|_| FunctionInterpolationError::SampleIndexOutOfBounds)?;
+        let m_u32 = u32::try_from(m)
+            .map_err(|_| FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
         let num_corners = 1usize
             .checked_shl(m_u32)
-            .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+            .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
 
         let mut accum = vec![0.0f32; self.output_count];
         for corner in 0..num_corners {
@@ -269,27 +270,27 @@ impl FunctionImpl for SampledFunction {
 
             for dim in 0..m {
                 let dim_u32 = u32::try_from(dim)
-                    .map_err(|_| FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                    .map_err(|_| FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
                 let use_high = (corner >> dim_u32) & 1 == 1;
                 let (idx, frac_part) = if use_high {
                     let i = idx_high
                         .get(dim)
                         .copied()
-                        .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                        .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
                     let f = fracs
                         .get(dim)
                         .copied()
-                        .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                        .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
                     (i, f)
                 } else {
                     let i = idx_low
                         .get(dim)
                         .copied()
-                        .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                        .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
                     let f = fracs
                         .get(dim)
                         .copied()
-                        .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                        .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
                     (i, 1.0 - f)
                 };
                 weight *= frac_part;
@@ -297,25 +298,25 @@ impl FunctionImpl for SampledFunction {
                 let stride = strides
                     .get(dim)
                     .copied()
-                    .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                    .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
                 flat_index = flat_index
                     .checked_add(
                         idx.checked_mul(stride)
-                            .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?,
+                            .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?,
                     )
-                    .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                    .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
             }
 
             for (j, accum_j) in accum.iter_mut().enumerate() {
                 let sample_idx = flat_index
                     .checked_mul(self.output_count)
                     .and_then(|v| v.checked_add(j))
-                    .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                    .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
                 let sample = self
                     .samples
                     .get(sample_idx)
                     .copied()
-                    .ok_or(FunctionInterpolationError::SampleIndexOutOfBounds)?;
+                    .ok_or(FunctionInterpolationError::SampleCoordinateOutOfBounds)?;
                 *accum_j += weight * sample;
             }
         }
@@ -323,12 +324,12 @@ impl FunctionImpl for SampledFunction {
         // Apply decode mapping and range clamping (ISO 32000 §7.10.2).
         let mut outputs = Vec::with_capacity(self.output_count);
         for (j, &interp) in accum.iter().enumerate() {
-            let (decode_min, decode_max) =
-                get_pair(&self.decode, j).ok_or(FunctionInterpolationError::EncodeIndexError)?;
+            let (decode_min, decode_max) = get_pair(&self.decode, j)
+                .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;
             let decoded = decode_min + interp * (decode_max - decode_min);
 
-            let (range_min, range_max) =
-                get_pair(&self.range, j).ok_or(FunctionInterpolationError::EncodeIndexError)?;
+            let (range_min, range_max) = get_pair(&self.range, j)
+                .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;
             outputs.push(decoded.clamp(range_min, range_max));
         }
 
@@ -507,7 +508,7 @@ mod tests {
         f.order = InterpolationOrder::Cubic;
         assert!(matches!(
             f.interpolate(&[0.5]),
-            Err(FunctionInterpolationError::CubicInterpolationNotSupported)
+            Err(FunctionInterpolationError::CubicInterpolationUnsupported)
         ));
     }
 }

--- a/crates/pdf-function/src/stitching.rs
+++ b/crates/pdf-function/src/stitching.rs
@@ -2,9 +2,10 @@ use std::cmp::Ordering;
 
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
-use crate::function::{
-    Function, FunctionImpl, FunctionInterpolationError, FunctionReadError, get_pair,
-    linear_interpolate,
+use crate::{
+    error::FunctionReadError,
+    function::{Function, FunctionImpl, get_pair, linear_interpolate},
+    function_interpolation_error::FunctionInterpolationError,
 };
 
 #[derive(Debug, Clone)]
@@ -27,11 +28,11 @@ impl StitchingFunction {
         } else {
             let prev_idx = index
                 .checked_sub(1)
-                .ok_or(FunctionInterpolationError::EncodeIndexError)?;
+                .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;
             *self
                 .bounds
                 .get(prev_idx)
-                .ok_or(FunctionInterpolationError::EncodeIndexError)?
+                .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?
         };
 
         let b1 = if index >= self.bounds.len() {
@@ -40,7 +41,7 @@ impl StitchingFunction {
             *self
                 .bounds
                 .get(index)
-                .ok_or(FunctionInterpolationError::EncodeIndexError)?
+                .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?
         };
 
         Ok((b0, b1))
@@ -64,7 +65,7 @@ impl FunctionImpl for StitchingFunction {
         // Reject NaN bounds: partial_cmp returns None for NaN, which would silently
         // return the wrong segment index.
         if self.bounds.iter().any(|b| b.is_nan()) {
-            return Err(FunctionInterpolationError::InvalidBounds);
+            return Err(FunctionInterpolationError::BoundsContainNaN);
         }
 
         // Clamp input to domain
@@ -84,8 +85,8 @@ impl FunctionImpl for StitchingFunction {
         let (b0, b1) = self.get_subdomain(index)?;
 
         // Get encoding values [e0, e1] for mapping to sub-function domain
-        let (e0, e1) =
-            get_pair(&self.encode, index).ok_or(FunctionInterpolationError::EncodeIndexError)?;
+        let (e0, e1) = get_pair(&self.encode, index)
+            .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;
         // Map input from [b0, b1] to [e0, e1]
         let x_mapped = linear_interpolate(x_clamped, b0, b1, e0, e1);
 
@@ -93,7 +94,7 @@ impl FunctionImpl for StitchingFunction {
         let func = self
             .functions
             .get(index)
-            .ok_or(FunctionInterpolationError::EncodeIndexError)?;
+            .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;
         func.interpolate(&[x_mapped])
     }
 
@@ -223,7 +224,7 @@ mod tests {
         );
         assert!(matches!(
             f.interpolate(&[0.5]),
-            Err(FunctionInterpolationError::InvalidBounds)
+            Err(FunctionInterpolationError::BoundsContainNaN)
         ));
     }
 }

--- a/crates/pdf-page/src/color_stops.rs
+++ b/crates/pdf-page/src/color_stops.rs
@@ -2,7 +2,7 @@ use pdf_color_space::color_space::ColorSpace;
 use pdf_function::function::{Function, FunctionImpl};
 use pdf_graphics::color::Color;
 
-use crate::pages::PdfPagesError;
+use crate::error::PdfPagesError;
 
 /// Default domain range for shading functions when not explicitly specified.
 const DEFAULT_DOMAIN: [f32; 2] = [0.0, 1.0];

--- a/crates/pdf-page/src/error.rs
+++ b/crates/pdf-page/src/error.rs
@@ -1,0 +1,72 @@
+use pdf_color_space::error::ColorSpaceError;
+use pdf_content_stream::error::PdfOperatorError;
+use pdf_font::error::FontError;
+use pdf_function::{
+    error::FunctionReadError, function_interpolation_error::FunctionInterpolationError,
+};
+
+use pdf_object::error::ObjectError;
+use thiserror::Error;
+
+/// Errors that can occur during parsing of a PDF Pages object.
+#[derive(Error, Debug)]
+pub enum PdfPagesError {
+    #[error("invalid /Kids entry type: expected /Page or /Pages, found '{found_type}'")]
+    InvalidKidsEntryType { found_type: String },
+    #[error("{0}")]
+    Object(#[from] ObjectError),
+    #[error("failed to parse content stream: {0}")]
+    ContentStream(#[from] PdfOperatorError),
+    #[error("{0}")]
+    ColorSpace(#[from] ColorSpaceError),
+    #[error("{0}")]
+    FunctionInterpolation(#[from] FunctionInterpolationError),
+    #[error("failed to process font: {0}")]
+    Font(#[from] FontError),
+    #[error(
+        "invalid /ExtGState entry '/{entry}': expected {expected_structure}, found {actual_structure}"
+    )]
+    InvalidExtGStateEntryStructure {
+        entry: String,
+        expected_structure: &'static str,
+        actual_structure: String,
+    },
+    #[error("invalid /ExtGState entry '/{entry}': {reason}")]
+    InvalidExtGStateEntryValue { entry: String, reason: String },
+    #[error("invalid /PaintType value: {value}")]
+    InvalidPaintType { value: i32 },
+    #[error("invalid /PatternType value: {value}")]
+    InvalidPatternType { value: i32 },
+    #[error("invalid /TilingType value: {value}")]
+    InvalidTilingType { value: i32 },
+    #[error("invalid /ShadingType value: {value}")]
+    InvalidShadingType { value: i32 },
+    #[error("unsupported XObject /Subtype: '{subtype}'")]
+    UnsupportedXObjectSubtype { subtype: String },
+    #[error("missing required dictionary entry '/{entry}'")]
+    MissingRequiredEntry { entry: &'static str },
+    /// The `/SMask` entry referenced a non-image XObject.
+    ///
+    /// Per the PDF specification, soft masks must always be Image XObjects
+    /// with a `/ColorSpace` of `/DeviceGray`.
+    #[error("invalid soft mask XObject: /SMask must reference an image XObject")]
+    InvalidSoftMaskXObject,
+    /// The image has zero-area dimensions (width or height is zero).
+    #[error("invalid image dimensions: width={width}, height={height}")]
+    InvalidImageDimensions { width: usize, height: usize },
+    /// The bits per component value is not supported.
+    ///
+    /// Only 1-bit and 8-bit-per-component images are currently supported.
+    #[error("unsupported image BitsPerComponent value: {bits_per_component} (supported: 1, 8)")]
+    UnsupportedImageBitsPerComponent { bits_per_component: usize },
+    /// The color space reported zero color components, which is invalid.
+    #[error("invalid image color space: reported zero color components")]
+    InvalidColorComponentCount,
+    #[error("truncated image data: expected at least {expected_bytes} bytes, got {actual_bytes}")]
+    TruncatedImageData {
+        expected_bytes: usize,
+        actual_bytes: usize,
+    },
+    #[error("{0}")]
+    FunctionRead(#[from] FunctionReadError),
+}

--- a/crates/pdf-page/src/external_graphics_state.rs
+++ b/crates/pdf-page/src/external_graphics_state.rs
@@ -1,40 +1,10 @@
-use std::borrow::Cow;
-
 use pdf_object::{
-    dictionary::Dictionary, error::ObjectError, object_resolver::ObjectResolver,
-    object_variant::ObjectVariant,
+    dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
 };
 
-use thiserror::Error;
-
-use crate::{
-    resource_cache::ResourceCache,
-    xobject::{XObject, XObjectError},
-};
+use crate::{error::PdfPagesError, resource_cache::ResourceCache, xobject::XObject};
 use num_traits::FromPrimitive;
 use pdf_graphics::{BlendMode, LineCap, LineJoin, MaskMode};
-
-/// Errors that can occur during parsing of an External Graphics State dictionary.
-#[derive(Error, Debug)]
-pub enum ExternalGraphicsStateError {
-    #[error(
-        "Invalid array structure for key '{key_name}': expected {expected_desc}, found {actual_desc}"
-    )]
-    InvalidArrayStructureError {
-        key_name: Cow<'static, str>,
-        expected_desc: &'static str,
-        actual_desc: String,
-    },
-    #[error("Invalid value for key '{key_name}': {description}")]
-    InvalidValueError {
-        key_name: Cow<'static, str>,
-        description: String,
-    },
-    #[error("Error reading Soft Mask XObject: {0}")]
-    SMaskReadError(#[from] XObjectError),
-    #[error("{0}")]
-    ObjectError(#[from] ObjectError),
-}
 
 /// Soft mask extracted from an ExtGState `SMask` entry.
 pub struct SoftMask {
@@ -122,7 +92,7 @@ impl ExternalGraphicsState {
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
         cache: &mut dyn ResourceCache,
-    ) -> Result<Self, ExternalGraphicsStateError> {
+    ) -> Result<Self, PdfPagesError> {
         let mut params: Vec<ExternalGraphicsStateKey> = Vec::new();
 
         for (name, value) in &dictionary.dictionary {
@@ -146,14 +116,33 @@ impl ExternalGraphicsState {
     }
 }
 
-fn parse_mask_mode(value: Cow<'_, str>) -> Result<MaskMode, ExternalGraphicsStateError> {
-    match value.as_ref() {
+fn invalid_ext_gstate_entry_structure(
+    entry: &str,
+    expected_structure: &'static str,
+    actual_structure: String,
+) -> PdfPagesError {
+    PdfPagesError::InvalidExtGStateEntryStructure {
+        entry: entry.to_string(),
+        expected_structure,
+        actual_structure,
+    }
+}
+
+fn invalid_ext_gstate_entry_value(entry: &str, reason: impl Into<String>) -> PdfPagesError {
+    PdfPagesError::InvalidExtGStateEntryValue {
+        entry: entry.to_string(),
+        reason: reason.into(),
+    }
+}
+
+fn parse_mask_mode(value: &str) -> Result<MaskMode, PdfPagesError> {
+    match value {
         "Luminosity" => Ok(MaskMode::Luminosity),
         "Alpha" => Ok(MaskMode::Alpha),
-        other => Err(ExternalGraphicsStateError::InvalidValueError {
-            key_name: Cow::Borrowed("MaskMode"),
-            description: format!("Unknown SMask type '{}'", other),
-        }),
+        other => Err(invalid_ext_gstate_entry_value(
+            "SMask/S",
+            format!("unsupported soft mask mode '{other}' (expected 'Alpha' or 'Luminosity')"),
+        )),
     }
 }
 
@@ -161,14 +150,14 @@ fn parse_dash_pattern(
     key_name: &str,
     value: &ObjectVariant,
     objects: &dyn ObjectResolver,
-) -> Result<ExternalGraphicsStateKey, ExternalGraphicsStateError> {
+) -> Result<ExternalGraphicsStateKey, PdfPagesError> {
     let arr = value.try_array(objects)?;
     let [dash_array, dash_phase] = arr else {
-        return Err(ExternalGraphicsStateError::InvalidArrayStructureError {
-            key_name: Cow::Owned(key_name.to_string()),
-            expected_desc: "array with 2 elements",
-            actual_desc: format!("array with {} elements", arr.len()),
-        });
+        return Err(invalid_ext_gstate_entry_structure(
+            key_name,
+            "an array with exactly 2 elements",
+            format!("an array with {} elements", arr.len()),
+        ));
     };
 
     let dash_array = dash_array.try_vec_of::<f32>(objects)?;
@@ -182,21 +171,21 @@ fn parse_font(
     key_name: &str,
     value: &ObjectVariant,
     objects: &dyn ObjectResolver,
-) -> Result<ExternalGraphicsStateKey, ExternalGraphicsStateError> {
+) -> Result<ExternalGraphicsStateKey, PdfPagesError> {
     let arr = value.try_array(objects)?;
     let [font_ref, font_size] = arr else {
-        return Err(ExternalGraphicsStateError::InvalidArrayStructureError {
-            key_name: Cow::Owned(key_name.to_string()),
-            expected_desc: "array with 2 elements",
-            actual_desc: format!("array with {} elements", arr.len()),
-        });
+        return Err(invalid_ext_gstate_entry_structure(
+            key_name,
+            "an array with exactly 2 elements",
+            format!("an array with {} elements", arr.len()),
+        ));
     };
     let font_ref = font_ref.try_object_number()?;
     let font_size = font_size.try_number::<f32>(objects)?;
     Ok(ExternalGraphicsStateKey::Font(font_ref, font_size))
 }
 
-fn to_blend_mode(s: &str) -> Result<BlendMode, ExternalGraphicsStateError> {
+fn to_blend_mode(s: &str) -> Result<BlendMode, PdfPagesError> {
     match s {
         "Normal" => Ok(BlendMode::Normal),
         "Multiply" => Ok(BlendMode::Multiply),
@@ -214,17 +203,17 @@ fn to_blend_mode(s: &str) -> Result<BlendMode, ExternalGraphicsStateError> {
         "Saturation" => Ok(BlendMode::Saturation),
         "Color" => Ok(BlendMode::Color),
         "Luminosity" => Ok(BlendMode::Luminosity),
-        _ => Err(ExternalGraphicsStateError::InvalidValueError {
-            key_name: Cow::Borrowed("BM"),
-            description: format!("Unknown blend mode '{}'", s),
-        }),
+        _ => Err(invalid_ext_gstate_entry_value(
+            "BM",
+            format!("unsupported blend mode '{s}'"),
+        )),
     }
 }
 
 fn parse_blend_mode(
     value: &ObjectVariant,
     objects: &dyn ObjectResolver,
-) -> Result<ExternalGraphicsStateKey, ExternalGraphicsStateError> {
+) -> Result<ExternalGraphicsStateKey, PdfPagesError> {
     let blend_modes_vec: Vec<BlendMode> = if value.is_array() {
         value
             .try_array(objects)?
@@ -244,10 +233,10 @@ fn parse_soft_mask(
     value: &ObjectVariant,
     objects: &dyn ObjectResolver,
     cache: &mut dyn ResourceCache,
-) -> Result<ExternalGraphicsStateKey, ExternalGraphicsStateError> {
+) -> Result<ExternalGraphicsStateKey, PdfPagesError> {
     let smask = match value {
         ObjectVariant::Dictionary(dict) => {
-            let mask_type = parse_mask_mode(dict.get_or_err("S")?.try_str(objects)?)?;
+            let mask_type = parse_mask_mode(dict.get_or_err("S")?.try_str(objects)?.as_ref())?;
 
             // Parse the "G" key for the `XObject`
             let stream = dict.get_or_err("G")?.try_stream(objects)?;
@@ -259,10 +248,10 @@ fn parse_soft_mask(
         other => match other.try_str(objects)?.as_ref() {
             "None" => None,
             _ => {
-                return Err(ExternalGraphicsStateError::InvalidValueError {
-                    key_name: Cow::Owned(key_name.to_string()),
-                    description: "SMask must be 'None'".to_string(),
-                });
+                return Err(invalid_ext_gstate_entry_value(
+                    key_name,
+                    "expected a soft mask dictionary or the name 'None'",
+                ));
             }
         },
     };
@@ -279,7 +268,7 @@ fn parse_entry(
     value: &ObjectVariant,
     objects: &dyn ObjectResolver,
     cache: &mut dyn ResourceCache,
-) -> Result<Option<ExternalGraphicsStateKey>, ExternalGraphicsStateError> {
+) -> Result<Option<ExternalGraphicsStateKey>, PdfPagesError> {
     let parsed = match name {
         "TR" => ExternalGraphicsStateKey::TransferFunction,
         "TR2" => ExternalGraphicsStateKey::TransferFunctionNew,
@@ -288,20 +277,20 @@ fn parse_entry(
         "LC" => {
             let cap_val = value.try_number::<i32>(objects)?;
             let cap = LineCap::from_i32(cap_val).ok_or_else(|| {
-                ExternalGraphicsStateError::InvalidValueError {
-                    key_name: Cow::Owned(name.to_string()),
-                    description: format!("Invalid LineCap value: {}", cap_val),
-                }
+                invalid_ext_gstate_entry_value(
+                    name,
+                    format!("unsupported line cap value {cap_val} (expected 0, 1, or 2)"),
+                )
             })?;
             ExternalGraphicsStateKey::LineCap(cap)
         }
         "LJ" => {
             let join_val = value.try_number::<i32>(objects)?;
             let join = LineJoin::from_i32(join_val).ok_or_else(|| {
-                ExternalGraphicsStateError::InvalidValueError {
-                    key_name: Cow::Owned(name.to_string()),
-                    description: format!("Invalid LineJoin value: {}", join_val),
-                }
+                invalid_ext_gstate_entry_value(
+                    name,
+                    format!("unsupported line join value {join_val} (expected 0, 1, or 2)"),
+                )
             })?;
             ExternalGraphicsStateKey::LineJoin(join)
         }

--- a/crates/pdf-page/src/form.rs
+++ b/crates/pdf-page/src/form.rs
@@ -1,26 +1,13 @@
 use pdf_content_stream::content_stream::ContentStream;
-use pdf_content_stream::error::PdfOperatorError;
 use pdf_graphics::rect::Rect;
 use pdf_graphics::transform::Transform;
-use pdf_object::error::ObjectError;
 use pdf_object::stream::StreamObject;
 use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
-use thiserror::Error;
 
+use crate::error::PdfPagesError;
 use crate::matrix::Matrix;
 use crate::resource_cache::ResourceCache;
-use crate::resources::{Resources, ResourcesError};
-
-/// Errors that can occur during parsing of a Form XObject.
-#[derive(Debug, Error)]
-pub enum FormXObjectError {
-    #[error("Error parsing /Resources: {source}")]
-    ResourcesError { source: Box<ResourcesError> },
-    #[error("Error parsing content stream: {0}")]
-    ContentStreamError(#[from] PdfOperatorError),
-    #[error("{0}")]
-    ObjectError(#[from] ObjectError),
-}
+use crate::resources::Resources;
 
 /// Represents a PDF Form XObject.
 pub struct FormXObject {
@@ -41,7 +28,7 @@ impl FormXObject {
         stream_data: &StreamObject,
         objects: &dyn ObjectResolver,
         cache: &mut dyn ResourceCache,
-    ) -> Result<Self, FormXObjectError> {
+    ) -> Result<Self, PdfPagesError> {
         // Retrieve the `/BBox` entry.
         let bbox = Rect::from(
             dictionary
@@ -53,11 +40,7 @@ impl FormXObject {
         let matrix = Matrix::from_dictionary(dictionary, objects)?;
 
         // Parse the `/Resources` entry if present, mapping any errors.
-        let resources = Resources::read(dictionary, objects, cache).map_err(|err| {
-            FormXObjectError::ResourcesError {
-                source: Box::new(err),
-            }
-        })?;
+        let resources = Resources::read(dictionary, objects, cache)?;
 
         // Parse the content stream data.
         let content_stream = ContentStream::from_stream(stream_data)?;

--- a/crates/pdf-page/src/image.rs
+++ b/crates/pdf-page/src/image.rs
@@ -10,56 +10,10 @@
 use std::borrow::Cow;
 
 use pdf_graphics::PixelFormat;
-use pdf_object::{
-    dictionary::Dictionary, error::ObjectError, object_resolver::ObjectResolver,
-    stream::StreamObject,
-};
-use thiserror::Error;
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver, stream::StreamObject};
 
-use crate::{
-    resource_cache::ResourceCache,
-    xobject::{XObject, XObjectError},
-};
-use pdf_color_space::{
-    color_space::{ColorSpace, ColorSpaceError},
-    indexed_color_space::IndexedColorSpace,
-};
-
-/// Errors that can occur when parsing or processing PDF Image XObjects.
-#[derive(Debug, Error)]
-pub enum ImageXObjectError {
-    /// The `/SMask` entry referenced a non-image XObject.
-    ///
-    /// Per the PDF specification, soft masks must always be Image XObjects
-    /// with a `/ColorSpace` of `/DeviceGray`.
-    #[error("SMask must be an Image XObject, but found a different XObject type")]
-    SMaskNotImage,
-    /// An error occurred while reading the soft mask XObject.
-    #[error("Failed to read SMask XObject: {source}")]
-    SMaskReadError {
-        /// The underlying XObject error.
-        source: Box<XObjectError>,
-    },
-    /// An error occurred while parsing the color space.
-    #[error("ColorSpace error: {0}")]
-    ColorSpaceError(#[from] ColorSpaceError),
-    /// An error occurred while resolving PDF objects.
-    #[error("Object error: {0}")]
-    ObjectError(#[from] ObjectError),
-    /// The image has zero-area dimensions (width or height is zero).
-    #[error("image has zero dimensions: {width}x{height}")]
-    ZeroImageDimensions { width: usize, height: usize },
-    /// The bits per component value is not supported.
-    ///
-    /// Only 1-bit and 8-bit-per-component images are currently supported.
-    #[error("unsupported bits per component: {bits} (only 1 and 8 are supported)")]
-    UnsupportedBitsPerComponent { bits: usize },
-    /// The color space reported zero color components, which is invalid.
-    #[error("color space reports zero color components")]
-    ZeroColorComponents,
-    #[error("failed to decode image: expected at least {expected} bytes, got {actual} bytes")]
-    ImageDecodeFailed { expected: usize, actual: usize },
-}
+use crate::{error::PdfPagesError, resource_cache::ResourceCache, xobject::XObject};
+use pdf_color_space::{color_space::ColorSpace, indexed_color_space::IndexedColorSpace};
 
 /// Represents a PDF Image XObject, which is a self-contained raster image.
 ///
@@ -130,7 +84,7 @@ impl ImageXObject {
         stream_data: &StreamObject,
         objects: &dyn ObjectResolver,
         cache: &mut dyn ResourceCache,
-    ) -> Result<Self, ImageXObjectError> {
+    ) -> Result<Self, PdfPagesError> {
         // Extract required image properties from the dictionary.
         let width = dictionary
             .get_or_err("Width")?
@@ -140,7 +94,7 @@ impl ImageXObject {
             .try_number::<usize>(objects)?;
 
         if width == 0 || height == 0 {
-            return Err(ImageXObjectError::ZeroImageDimensions { width, height });
+            return Err(PdfPagesError::InvalidImageDimensions { width, height });
         }
 
         let bits_per_component = dictionary
@@ -149,9 +103,7 @@ impl ImageXObject {
 
         // Only 1-bit and 8-bit-per-component images are currently supported.
         if bits_per_component != 1 && bits_per_component != 8 {
-            return Err(ImageXObjectError::UnsupportedBitsPerComponent {
-                bits: bits_per_component,
-            });
+            return Err(PdfPagesError::UnsupportedImageBitsPerComponent { bits_per_component });
         }
 
         // Parse the optional `/ColorSpace` entry.
@@ -202,15 +154,15 @@ impl ImageXObject {
             };
 
         if num_color_components == 0 {
-            return Err(ImageXObjectError::ZeroColorComponents);
+            return Err(PdfPagesError::InvalidColorComponentCount);
         }
 
         let num_pixels = width.saturating_mul(height);
         let expected_bytes = num_pixels.saturating_mul(num_color_components);
         if image_data.len() < expected_bytes {
-            return Err(ImageXObjectError::ImageDecodeFailed {
-                expected: expected_bytes,
-                actual: image_data.len(),
+            return Err(PdfPagesError::TruncatedImageData {
+                expected_bytes,
+                actual_bytes: image_data.len(),
             });
         }
 
@@ -275,7 +227,7 @@ impl ImageXObject {
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
         cache: &mut dyn ResourceCache,
-    ) -> Result<Option<Box<ImageXObject>>, ImageXObjectError> {
+    ) -> Result<Option<Box<ImageXObject>>, PdfPagesError> {
         let Some(smask_obj) = dictionary.get("SMask") else {
             return Ok(None);
         };
@@ -284,14 +236,12 @@ impl ImageXObject {
         let stream = smask_obj.try_stream(objects)?;
 
         // Recursively parse the SMask as an XObject.
-        let smask_xobject = XObject::read_xobject(&stream.dictionary, stream, objects, cache)
-            .map_err(|e| ImageXObjectError::SMaskReadError {
-                source: Box::new(e),
-            })?;
+        let smask_xobject = XObject::read_xobject(&stream.dictionary, stream, objects, cache)?;
+
         // Ensure the SMask is actually an Image XObject.
         match smask_xobject {
             XObject::Image(img) => Ok(Some(Box::new(img))),
-            _ => Err(ImageXObjectError::SMaskNotImage),
+            _ => Err(PdfPagesError::InvalidSoftMaskXObject),
         }
     }
 

--- a/crates/pdf-page/src/lib.rs
+++ b/crates/pdf-page/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod color_stops;
+pub mod error;
 pub mod external_graphics_state;
 pub mod form;
 pub mod image;

--- a/crates/pdf-page/src/page.rs
+++ b/crates/pdf-page/src/page.rs
@@ -1,5 +1,5 @@
 use crate::{
-    media_box::MediaBox, pages::PdfPagesError, resource_cache::ResourceCache, resources::Resources,
+    error::PdfPagesError, media_box::MediaBox, resource_cache::ResourceCache, resources::Resources,
 };
 use pdf_content_stream::content_stream::ContentStream;
 use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};

--- a/crates/pdf-page/src/pages.rs
+++ b/crates/pdf-page/src/pages.rs
@@ -1,33 +1,8 @@
 use crate::{
-    page::PdfPage,
-    resource_cache::ResourceCache,
-    resources::{Resources, ResourcesError},
+    error::PdfPagesError, page::PdfPage, resource_cache::ResourceCache, resources::Resources,
 };
-use pdf_color_space::color_space::ColorSpaceError;
-use pdf_content_stream::error::PdfOperatorError;
-use pdf_function::function::FunctionInterpolationError;
-use pdf_object::{dictionary::Dictionary, error::ObjectError, object_resolver::ObjectResolver};
 
-use thiserror::Error;
-
-/// Errors that can occur during parsing of a PDF Pages object.
-#[derive(Error, Debug)]
-pub enum PdfPagesError {
-    #[error(
-        "Unexpected object type in `/Kids` array for an object: expected 'Page' or 'Pages', found '{found_type}'"
-    )]
-    UnexpectedObjectTypeInKids { found_type: String },
-    #[error("{0}")]
-    ObjectError(#[from] ObjectError),
-    #[error("Failed to parse content stream for page: {0}")]
-    ContentStreamParse(#[from] PdfOperatorError),
-    #[error("Failed to parse resources for page: {0}")]
-    ResourcesParse(#[from] ResourcesError),
-    #[error("{0}")]
-    ColorSpaceError(#[from] ColorSpaceError),
-    #[error("{0}")]
-    FunctionInterpolationError(#[from] FunctionInterpolationError),
-}
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 
 pub struct PdfPages;
 
@@ -80,7 +55,7 @@ impl PdfPages {
                 }
                 obj_type => {
                     // If the child has an unexpected type, return an error.
-                    return Err(PdfPagesError::UnexpectedObjectTypeInKids {
+                    return Err(PdfPagesError::InvalidKidsEntryType {
                         found_type: obj_type.to_string(),
                     });
                 }

--- a/crates/pdf-page/src/pattern.rs
+++ b/crates/pdf-page/src/pattern.rs
@@ -1,22 +1,11 @@
 use pdf_content_stream::content_stream::ContentStream;
 use pdf_graphics::{rect::Rect, transform::Transform};
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
-use thiserror::Error;
 
 use crate::{
-    external_graphics_state::ExternalGraphicsState,
-    matrix::Matrix,
-    resource_cache::ResourceCache,
-    resources::{Resources, ResourcesError},
-    shading::Shading,
+    error::PdfPagesError, external_graphics_state::ExternalGraphicsState, matrix::Matrix,
+    resource_cache::ResourceCache, resources::Resources, shading::Shading,
 };
-
-/// Defines errors that can occur while parsing a Pattern.
-#[derive(Debug, Error)]
-pub enum PatternError {
-    #[error("Invalid value for key '{key}': {value}")]
-    InvalidValue { key: &'static str, value: i32 },
-}
 
 /// PaintType for tiling patterns.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,16 +17,13 @@ pub enum PaintType {
 }
 
 impl TryFrom<i32> for PaintType {
-    type Error = PatternError;
+    type Error = PdfPagesError;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             1 => Ok(PaintType::Colored),
             2 => Ok(PaintType::Uncolored),
-            _ => Err(PatternError::InvalidValue {
-                key: "PaintType",
-                value,
-            }),
+            _ => Err(PdfPagesError::InvalidPaintType { value }),
         }
     }
 }
@@ -52,16 +38,13 @@ pub enum PatternType {
 }
 
 impl TryFrom<i32> for PatternType {
-    type Error = PatternError;
+    type Error = PdfPagesError;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             1 => Ok(PatternType::Tiling),
             2 => Ok(PatternType::Shading),
-            _ => Err(PatternError::InvalidValue {
-                key: "PatternType",
-                value,
-            }),
+            _ => Err(PdfPagesError::InvalidPatternType { value }),
         }
     }
 }
@@ -79,17 +62,14 @@ pub enum TilingType {
 }
 
 impl TryFrom<i32> for TilingType {
-    type Error = PatternError;
+    type Error = PdfPagesError;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             1 => Ok(TilingType::ConstantSpacing),
             2 => Ok(TilingType::NoDistortion),
             3 => Ok(TilingType::ConstantSpacingFast),
-            _ => Err(PatternError::InvalidValue {
-                key: "TilingType",
-                value,
-            }),
+            _ => Err(PdfPagesError::InvalidTilingType { value }),
         }
     }
 }
@@ -146,12 +126,12 @@ impl Pattern {
     ///
     /// # Returns
     ///
-    /// Returns a `Result` containing the constructed `Pattern` on success, or a `ResourcesError` if parsing fails.
+    /// Returns a `Result` containing the constructed `Pattern` on success, or a `PdfPagesError` if parsing fails.
     pub(crate) fn read(
         object: &ObjectVariant,
         objects: &dyn ObjectResolver,
         cache: &mut dyn ResourceCache,
-    ) -> Result<Pattern, ResourcesError> {
+    ) -> Result<Pattern, PdfPagesError> {
         let dictionary = object.try_dictionary(objects)?;
 
         let pattern_type = dictionary

--- a/crates/pdf-page/src/resources.rs
+++ b/crates/pdf-page/src/resources.rs
@@ -7,19 +7,14 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use pdf_font::font::{Font, FontError};
-use pdf_object::{dictionary::Dictionary, error::ObjectError, object_resolver::ObjectResolver};
-use thiserror::Error;
+use pdf_font::font::Font;
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 
 use crate::{
-    external_graphics_state::{ExternalGraphicsState, ExternalGraphicsStateError},
-    pattern::{Pattern, PatternError},
-    resource::Resource,
-    resource_cache::ResourceCache,
-    shading::{Shading, ShadingError},
-    xobject::{XObject, XObjectError},
+    error::PdfPagesError, external_graphics_state::ExternalGraphicsState, pattern::Pattern,
+    resource::Resource, resource_cache::ResourceCache, shading::Shading, xobject::XObject,
 };
-use pdf_color_space::color_space::{ColorSpace, ColorSpaceError};
+use pdf_color_space::color_space::ColorSpace;
 
 /// Contains all resources referenced by a PDF content stream, organized per PDF sub-dictionary.
 ///
@@ -43,27 +38,6 @@ pub struct Resources {
     pub color_spaces: HashMap<String, Resource>,
 }
 
-/// Errors that can occur while parsing a PDF Resources dictionary.
-#[derive(Debug, Error)]
-pub enum ResourcesError {
-    #[error("Error processing font: {0}")]
-    FontError(#[from] FontError),
-    #[error("External Graphics State parsing error: {0}")]
-    ExternalGraphicsStateError(#[from] ExternalGraphicsStateError),
-    #[error("XObject parsing error: {0}")]
-    XObjectError(#[from] XObjectError),
-    #[error("Pattern parsing error: {0}")]
-    PatternError(#[from] PatternError),
-    #[error("{0}")]
-    ObjectError(#[from] ObjectError),
-    #[error("{0}")]
-    ColorSpaceError(#[from] ColorSpaceError),
-    #[error("Shading parsing error: {0}")]
-    ShadingError(#[from] ShadingError),
-    #[error("Error parsing content stream: {0}")]
-    ContentStreamError(#[from] pdf_content_stream::error::PdfOperatorError),
-}
-
 /// Attempts to retrieve a sub-dictionary from the resources dictionary.
 ///
 /// # Parameters
@@ -80,7 +54,7 @@ fn get_sub_dictionary<'a>(
     resources: &'a Dictionary,
     key: &str,
     objects: &'a dyn ObjectResolver,
-) -> Result<Option<&'a Dictionary>, ResourcesError> {
+) -> Result<Option<&'a Dictionary>, PdfPagesError> {
     resources
         .get(key)
         .map(|entry| entry.try_dictionary(objects))
@@ -93,7 +67,7 @@ fn read_fonts(
     resources: &Dictionary,
     objects: &dyn ObjectResolver,
     cache: &mut dyn ResourceCache,
-) -> Result<HashMap<String, Resource>, ResourcesError> {
+) -> Result<HashMap<String, Resource>, PdfPagesError> {
     let Some(font_dict) = get_sub_dictionary(resources, Font::KEY, objects)? else {
         return Ok(HashMap::new());
     };
@@ -130,7 +104,7 @@ fn read_external_graphics_states(
     resources: &Dictionary,
     objects: &dyn ObjectResolver,
     cache: &mut dyn ResourceCache,
-) -> Result<HashMap<String, Resource>, ResourcesError> {
+) -> Result<HashMap<String, Resource>, PdfPagesError> {
     let Some(ext_gstate_dict) = get_sub_dictionary(resources, "ExtGState", objects)? else {
         return Ok(HashMap::new());
     };
@@ -161,7 +135,7 @@ fn read_patterns(
     resources: &Dictionary,
     objects: &dyn ObjectResolver,
     cache: &mut dyn ResourceCache,
-) -> Result<HashMap<String, Resource>, ResourcesError> {
+) -> Result<HashMap<String, Resource>, PdfPagesError> {
     let Some(pattern_dict) = get_sub_dictionary(resources, "Pattern", objects)? else {
         return Ok(HashMap::new());
     };
@@ -187,7 +161,7 @@ fn read_xobjects(
     resources: &Dictionary,
     objects: &dyn ObjectResolver,
     cache: &mut dyn ResourceCache,
-) -> Result<HashMap<String, Resource>, ResourcesError> {
+) -> Result<HashMap<String, Resource>, PdfPagesError> {
     let Some(xobject_dict) = get_sub_dictionary(resources, "XObject", objects)? else {
         return Ok(HashMap::new());
     };
@@ -217,7 +191,7 @@ fn read_shadings(
     resources: &Dictionary,
     objects: &dyn ObjectResolver,
     cache: &mut dyn ResourceCache,
-) -> Result<HashMap<String, Resource>, ResourcesError> {
+) -> Result<HashMap<String, Resource>, PdfPagesError> {
     let Some(shading_dict) = get_sub_dictionary(resources, "Shading", objects)? else {
         return Ok(HashMap::new());
     };
@@ -241,7 +215,7 @@ fn read_color_spaces(
     resources: &Dictionary,
     objects: &dyn ObjectResolver,
     cache: &mut dyn ResourceCache,
-) -> Result<HashMap<String, Resource>, ResourcesError> {
+) -> Result<HashMap<String, Resource>, PdfPagesError> {
     let Some(color_space_dict) = get_sub_dictionary(resources, "ColorSpace", objects)? else {
         return Ok(HashMap::new());
     };
@@ -386,12 +360,12 @@ impl Resources {
     ///
     /// # Errors
     ///
-    /// Returns a [`ResourcesError`] if any resource fails to parse or resolve.
+    /// Returns a [`PdfPagesError`] if any resource fails to parse or resolve.
     pub fn read(
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
         cache: &mut dyn ResourceCache,
-    ) -> Result<Option<Self>, ResourcesError> {
+    ) -> Result<Option<Self>, PdfPagesError> {
         const KEY: &str = "Resources";
 
         let Some(resources_entry) = dictionary.get(KEY) else {

--- a/crates/pdf-page/src/shading.rs
+++ b/crates/pdf-page/src/shading.rs
@@ -13,38 +13,13 @@
 
 use pdf_graphics::rect::Rect;
 use pdf_object::{
-    dictionary::Dictionary, error::ObjectError, object_resolver::ObjectResolver,
-    object_variant::ObjectVariant,
+    dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
 };
-use thiserror::Error;
 
 use crate::color_stops::ColorStops;
-use crate::pages::PdfPagesError;
-use pdf_color_space::color_space::{ColorSpace, ColorSpaceError};
-use pdf_function::function::{
-    Function, FunctionImpl, FunctionInterpolationError, FunctionReadError,
-};
-
-/// Errors that can occur while parsing or processing a Shading object.
-#[derive(Debug, Error)]
-pub enum ShadingError {
-    #[error("Missing required entry '{entry_name}'")]
-    MissingRequiredEntry { entry_name: &'static str },
-    #[error("Unsupported /ShadingType value: {0}")]
-    UnsupportedShadingType(ShadingType),
-    #[error("Unknown /ShadingType value: {0}")]
-    InvalidShadingType(i32),
-    #[error("Error parsing Function: {0}")]
-    FunctionReadError(#[from] FunctionReadError),
-    #[error("Error interpolating Function: {0}")]
-    FunctionInterpolationError(#[from] FunctionInterpolationError),
-    #[error("Error parsing Dictionary: {0}")]
-    ObjectError(#[from] ObjectError),
-    #[error("ColorSpace error: {0}")]
-    ColorSpaceError(#[from] ColorSpaceError),
-    #[error("Error computing color stops: {0}")]
-    ColorStopsError(Box<PdfPagesError>),
-}
+use crate::error::PdfPagesError;
+use pdf_color_space::color_space::ColorSpace;
+use pdf_function::function::{Function, FunctionImpl};
 
 /// Represents the PDF `/ShadingType` entry value.
 ///
@@ -88,13 +63,13 @@ impl std::fmt::Display for ShadingType {
 }
 
 impl TryFrom<i32> for ShadingType {
-    type Error = ShadingError;
+    type Error = PdfPagesError;
 
     /// Attempts to convert an integer to a `ShadingType`.
     ///
     /// # Errors
     ///
-    /// Returns [`ShadingError::InvalidShadingType`] if the value is not in the range 1-7.
+    /// Returns [`PdfPagesError::InvalidShadingType`] if the value is not in the range 1-7.
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
             1 => Ok(Self::FunctionBased),
@@ -104,7 +79,7 @@ impl TryFrom<i32> for ShadingType {
             5 => Ok(Self::LatticeFormTriangleMesh),
             6 => Ok(Self::CoonsPatchMesh),
             7 => Ok(Self::TensorProductPatchMesh),
-            _ => Err(ShadingError::InvalidShadingType(value)),
+            _ => Err(PdfPagesError::InvalidShadingType { value }),
         }
     }
 }
@@ -207,7 +182,7 @@ impl Shading {
     pub fn from_dictionary(
         object: &ObjectVariant,
         objects: &dyn ObjectResolver,
-    ) -> Result<Self, ShadingError> {
+    ) -> Result<Self, PdfPagesError> {
         // Extract and validate the required `/ShadingType` entry.
         let dictionary = object.try_dictionary(objects)?;
         let shading_type_value = dictionary
@@ -232,7 +207,7 @@ impl Shading {
     fn parse_function_based(
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
-    ) -> Result<Self, ShadingError> {
+    ) -> Result<Self, PdfPagesError> {
         // Read optional `/ColorSpace` entry.
         let color_space = ColorSpace::from_dictionary(dictionary, objects)?;
 
@@ -272,7 +247,7 @@ impl Shading {
     fn parse_axial(
         object: &ObjectVariant,
         objects: &dyn ObjectResolver,
-    ) -> Result<Self, ShadingError> {
+    ) -> Result<Self, PdfPagesError> {
         // Read required `/Coords` entry defining the gradient axis.
         let dictionary = object.try_dictionary(objects)?;
         let coords = dictionary
@@ -281,8 +256,8 @@ impl Shading {
 
         // Read required `/ColorSpace` entry.
         let color_space = ColorSpace::from_dictionary(dictionary, objects)?.ok_or(
-            ShadingError::MissingRequiredEntry {
-                entry_name: "ColorSpace",
+            PdfPagesError::MissingRequiredEntry {
+                entry: "ColorSpace",
             },
         )?;
 
@@ -291,8 +266,7 @@ impl Shading {
         let function = Function::parse(object, objects)?;
 
         // Pre-compute color stops.
-        let color_stops = ColorStops::from_function(&function, &color_space)
-            .map_err(|e| ShadingError::ColorStopsError(Box::new(e)))?;
+        let color_stops = ColorStops::from_function(&function, &color_space)?;
 
         Ok(Self::Axial {
             color_space,
@@ -305,7 +279,7 @@ impl Shading {
     fn parse_radial(
         object: &ObjectVariant,
         objects: &dyn ObjectResolver,
-    ) -> Result<Self, ShadingError> {
+    ) -> Result<Self, PdfPagesError> {
         // Read required `/Coords` entry defining the two circles.
         let dictionary = object.try_dictionary(objects)?;
         let coords = dictionary
@@ -314,8 +288,8 @@ impl Shading {
 
         // Read required `/ColorSpace` entry.
         let color_space = ColorSpace::from_dictionary(dictionary, objects)?.ok_or(
-            ShadingError::MissingRequiredEntry {
-                entry_name: "ColorSpace",
+            PdfPagesError::MissingRequiredEntry {
+                entry: "ColorSpace",
             },
         )?;
 
@@ -331,8 +305,7 @@ impl Shading {
         let function = Function::parse(object, objects)?;
 
         // Pre-compute color stops.
-        let color_stops = ColorStops::from_function(&function, &color_space)
-            .map_err(|e| ShadingError::ColorStopsError(Box::new(e)))?;
+        let color_stops = ColorStops::from_function(&function, &color_space)?;
 
         Ok(Self::Radial {
             color_space,
@@ -350,14 +323,14 @@ impl Shading {
     fn parse_functions(
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
-    ) -> Result<Vec<Function>, ShadingError> {
+    ) -> Result<Vec<Function>, PdfPagesError> {
         let function_obj = objects.resolve_object(dictionary.get_or_err("Function")?)?;
 
         if let ObjectVariant::Array(array) = function_obj {
             // Parse array of functions.
             array
                 .iter()
-                .map(|value| Function::parse(value, objects).map_err(ShadingError::from))
+                .map(|value| Function::parse(value, objects).map_err(PdfPagesError::from))
                 .collect()
         } else {
             // Parse single function.

--- a/crates/pdf-page/src/xobject.rs
+++ b/crates/pdf-page/src/xobject.rs
@@ -1,13 +1,7 @@
 use crate::{
-    form::{FormXObject, FormXObjectError},
-    image::{ImageXObject, ImageXObjectError},
-    resource_cache::ResourceCache,
+    error::PdfPagesError, form::FormXObject, image::ImageXObject, resource_cache::ResourceCache,
 };
-use pdf_object::{
-    dictionary::Dictionary, error::ObjectError, object_resolver::ObjectResolver,
-    stream::StreamObject,
-};
-use thiserror::Error;
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver, stream::StreamObject};
 
 /// Represents a PDF External Object (XObject).
 ///
@@ -22,25 +16,13 @@ pub enum XObject {
     Form(Box<FormXObject>),
 }
 
-#[derive(Debug, Error)]
-pub enum XObjectError {
-    #[error("Error parsing Image XObject: {0}")]
-    ImageReadError(#[from] ImageXObjectError),
-    #[error("Error parsing Form XObject: {0}")]
-    FormReadError(#[from] FormXObjectError),
-    #[error("Unsupported XObject type: '{subtype}'")]
-    UnsupportedXObjectType { subtype: String },
-    #[error("{0}")]
-    ObjectError(#[from] ObjectError),
-}
-
 impl XObject {
     pub fn read_xobject(
         dictionary: &Dictionary,
         stream_data: &StreamObject,
         objects: &dyn ObjectResolver,
         cache: &mut dyn ResourceCache,
-    ) -> Result<Self, XObjectError> {
+    ) -> Result<Self, PdfPagesError> {
         let subtype = dictionary.get_or_err("Subtype")?.try_str(objects)?;
 
         match subtype.as_ref() {
@@ -54,7 +36,7 @@ impl XObject {
                     FormXObject::read_xobject(dictionary, stream_data, objects, cache)?;
                 Ok(XObject::Form(Box::new(form_xobject)))
             }
-            other => Err(XObjectError::UnsupportedXObjectType {
+            other => Err(PdfPagesError::UnsupportedXObjectSubtype {
                 subtype: other.to_string(),
             }),
         }

--- a/crates/pdf-parser/src/error.rs
+++ b/crates/pdf-parser/src/error.rs
@@ -4,9 +4,7 @@ use thiserror::Error;
 
 use crate::{
     cross_reference_table::CrossReferenceTableError, header::HeaderError,
-    hex_string::HexStringError, indirect_object::IndirectObjectError,
     literal_string::LiteralStringObjectError, name::NameObjectError, number::NumberError,
-    stream::StreamParsingError,
 };
 
 #[derive(Error, Debug, PartialEq)]
@@ -21,8 +19,8 @@ pub enum ParserError {
     TokenizerError(#[from] TokenizerError),
     #[error("Cross-reference table error: {0}")]
     CrossReferenceTableError(#[from] CrossReferenceTableError),
-    #[error("Hex string error: {0}")]
-    HexStringError(#[from] HexStringError),
+    #[error("Invalid non-hex decimal character in the input: '{0}'")]
+    NotHexDecimal(char),
     #[error("Number error: {0}")]
     NumberError(#[from] NumberError),
     #[error("Name object error: {0}")]
@@ -39,12 +37,10 @@ pub enum ParserError {
     UnexpectedTokenAt { token: String, position: usize },
     #[error("Nesting depth exceeded")]
     NestingDepthExceeded,
-    #[error("Stream parsing error: {0}")]
-    StreamParsingError(#[from] StreamParsingError),
     #[error("Object error: {0}")]
     ObjectError(#[from] ObjectError),
-    #[error("Indirect object error: {0}")]
-    IndirectObjectError(#[from] IndirectObjectError),
+    #[error("Stream object found without a preceding dictionary")]
+    StreamObjectWithoutDictionary,
     #[error("Missing startxref marker in PDF")]
     MissingStartXref,
     #[error("Invalid cross-reference table at offset {offset}")]

--- a/crates/pdf-parser/src/hex_string.rs
+++ b/crates/pdf-parser/src/hex_string.rs
@@ -1,17 +1,5 @@
-use pdf_tokenizer::{PdfToken, error::TokenizerError};
-use thiserror::Error;
-
-use crate::parser::PdfParser;
-
-/// Represents an error that can occur while parsing a hex string object.
-#[derive(Debug, PartialEq, Error)]
-pub enum HexStringError {
-    /// Indicates that the input contains a non-hexadecimal character.
-    #[error("Invalid non-hex decimal character in the input: '{0}'")]
-    NotHexDecimal(char),
-    #[error("Tokenizer error: {0}")]
-    TokenizerError(#[from] TokenizerError),
-}
+use crate::{error::ParserError, parser::PdfParser};
+use pdf_tokenizer::PdfToken;
 
 impl PdfParser<'_> {
     /// Parses a hexadecimal string object from the current position in the input stream.
@@ -20,7 +8,7 @@ impl PdfParser<'_> {
     ///
     /// `String` containing the decoded string value or an error if invalid format
     /// or characters are encountered.
-    pub fn parse_hex_string(&mut self) -> Result<Vec<u8>, HexStringError> {
+    pub fn parse_hex_string(&mut self) -> Result<Vec<u8>, ParserError> {
         self.tokenizer.expect(PdfToken::LeftAngleBracket)?;
 
         // 1. Read until the closing `>` of the hex string.
@@ -35,7 +23,7 @@ impl PdfParser<'_> {
 
             // 2. Check if the character is a valid hex digit (0-9, a-f, A-F)
             if !b.is_ascii_hexdigit() {
-                return Err(HexStringError::NotHexDecimal(char::from(*b)));
+                return Err(ParserError::NotHexDecimal(char::from(*b)));
             }
             // 3. Append hex digits to the hex string.
             filtered.push(*b);

--- a/crates/pdf-parser/src/indirect_object.rs
+++ b/crates/pdf-parser/src/indirect_object.rs
@@ -3,16 +3,8 @@ use pdf_object::{
     object_variant::ObjectVariant, stream::StreamObject,
 };
 use pdf_tokenizer::PdfToken;
-use thiserror::Error;
 
 use crate::{error::ParserError, parser::PdfParser};
-
-/// Represents an error that can occur while parsing an indirect object or an object reference.
-#[derive(Error, Debug, PartialEq)]
-pub enum IndirectObjectError {
-    #[error("Stream object found without a preceding dictionary")]
-    StreamObjectWithoutDictionary,
-}
 
 impl PdfParser<'_> {
     /// Parses an indirect object or an object reference from the current position in the input stream.
@@ -58,7 +50,7 @@ impl PdfParser<'_> {
 
         if let Some(PdfToken::Alphabetic(b's')) = self.tokenizer.peek() {
             let ObjectVariant::Dictionary(dictionary) = object else {
-                return Err(IndirectObjectError::StreamObjectWithoutDictionary.into());
+                return Err(ParserError::StreamObjectWithoutDictionary);
             };
             let stream = self.parse_stream(&dictionary, objects)?;
 

--- a/crates/pdf-parser/src/name.rs
+++ b/crates/pdf-parser/src/name.rs
@@ -12,10 +12,6 @@ pub enum NameObjectError {
     IncompleteHexEscape,
     #[error("Invalid hex escape in name object: Non-hex character '{0}' found in sequence")]
     NonHexDigitInEscape(char),
-    #[error(
-        "Invalid hex escape in name object: Could not parse hex string '{hex_pair}'. Reason: {reason}"
-    )]
-    HexRadixError { hex_pair: String, reason: String },
     #[error("Invalid token in name object (e.g., empty name after '/')")]
     EmptyName,
     #[error("Tokenizer error: {0}")]

--- a/crates/pdf-parser/src/stream.rs
+++ b/crates/pdf-parser/src/stream.rs
@@ -1,14 +1,5 @@
-use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
-use thiserror::Error;
-
 use crate::{error::ParserError, parser::PdfParser};
-
-/// Errors that can occur while parsing a stream object.
-#[derive(Debug, PartialEq, Error)]
-pub enum StreamParsingError {
-    #[error("Stream dictionary missing /Length entry")]
-    MissingLength,
-}
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 
 impl PdfParser<'_> {
     /// Parses a PDF stream object from the input, using a pre-parsed dictionary.

--- a/examples/skia.rs
+++ b/examples/skia.rs
@@ -37,7 +37,7 @@ pub enum AppError {
         source: std::io::Error,
     },
     #[error("Failed to parse PDF: {0}")]
-    ParsePdf(#[from] pdf_document::reader::PdfReaderError),
+    ParsePdf(#[from] pdf_document::error::PdfReaderError),
     #[error("Failed to render PDF page: {0}")]
     PdfRendererError(#[from] pdf_renderer::PdfRendererError),
     #[error("Failed to create event loop: {0}")]


### PR DESCRIPTION
Move color space, function, font, page, document, and canvas errors into dedicated error modules so callers depend on crate-level error types instead of enums scattered across parsing and rendering code.

Rename several variants to describe required state and unsupported features more precisely, and update downstream code to propagate the shared errors through content stream parsing, page resources, XObjects, fonts, and document encryption handling.

This also simplifies parser errors by folding hex string, indirect object, and stream failures into ParserError and tightening validation around DeviceN, soft masks, and operand count reporting.