### PR TITLE
Fix stack overflow from cyclic resource references in Type3 fonts

### DIFF
--- a/crates/pdf-document/src/reader.rs
+++ b/crates/pdf-document/src/reader.rs
@@ -16,7 +16,7 @@ use pdf_object::{
 use pdf_object_collection::object_collection::ObjectCollection;
 use pdf_page::page::PdfPage;
 use pdf_page::pages::PdfPages;
-use pdf_page::resource::Resource;
+use pdf_page::resource_cache::DefaultResourceCache;
 use pdf_parser::error::ParserError;
 use pdf_parser::parser::PdfParser;
 
@@ -115,7 +115,7 @@ fn extract_page_tree(
     // Get the page tree via the /Pages entry in the catalog
     let pages_dict = catalog.get_or_err("Pages")?.try_dictionary(objects)?;
 
-    let mut cache: HashMap<usize, Resource> = HashMap::new();
+    let mut cache = DefaultResourceCache::new();
     let pages = PdfPages::from_dictionary(pages_dict, objects, &mut cache)?;
     Ok(pages)
 }
@@ -742,5 +742,28 @@ mod tests {
             .expect("page should inherit MediaBox from parent /Pages");
         assert_eq!(mb.right, 595.0);
         assert_eq!(mb.top, 842.0);
+    }
+
+    /// Verifies that a PDF containing cyclic Type 3 font resource references
+    /// does not cause a stack overflow.
+    ///
+    /// The test file has: Font 6 (FType3A) → Font 9 (FType3B) → Pattern 12 →
+    /// Font 6 (cycle).  The cycle detection in resource parsing must break the
+    /// loop instead of recursing indefinitely.
+    ///
+    /// Note: the test file may produce non-fatal parsing errors for individual
+    /// resources.  What matters is that the process terminates normally.
+    ///
+    /// See ISO 32000-2:2020 §7.8.3: circular resource references are
+    /// non-conforming, but readers must handle them gracefully.
+    #[test]
+    fn cyclic_type3_resources_do_not_cause_stack_overflow() {
+        let data =
+            include_bytes!("../../../examples/assets/ContentStreamCycleType3insideType3.pdf");
+
+        let reader = PdfReader;
+        // The primary assertion is that this call returns (does not stack-overflow).
+        // A parsing error is acceptable; an infinite recursion is not.
+        let _result = reader.read_from_bytes(data, None);
     }
 }

--- a/crates/pdf-page/src/resource_cache.rs
+++ b/crates/pdf-page/src/resource_cache.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::resource::Resource;
 
@@ -9,6 +9,11 @@ use crate::resource::Resource;
 /// This allows efficient reuse and lookup of resources during PDF page processing.
 /// Implementors of this trait can define custom caching strategies for resource
 /// management.
+///
+/// The trait also provides cycle-detection hooks (`begin_read`, `end_read`,
+/// `is_being_read`) used during recursive resource parsing to break circular
+/// references.  Default implementations are no-ops, so existing implementors
+/// compile without changes but do not detect cycles.
 pub trait ResourceCache {
     /// Retrieves a reference to a `Resource` associated with the given object number,
     /// if it exists.
@@ -30,6 +35,26 @@ pub trait ResourceCache {
     /// - `obj_num`: The object number to associate with the resource.
     /// - `resource`: The `Resource` to insert into the cache.
     fn insert(&mut self, obj_num: usize, resource: Resource);
+
+    /// Marks `obj_num` as currently being read.
+    ///
+    /// Returns `true` if the object was **newly** marked (no cycle).
+    /// Returns `false` if it was **already** in-progress (cycle detected).
+    ///
+    /// Used by resource readers to detect circular references in resource
+    /// dictionaries (forbidden by ISO 32000-2:2020 §7.8.3).
+    fn begin_read(&mut self, _obj_num: usize) -> bool {
+        true
+    }
+
+    /// Clears the in-progress mark set by [`begin_read`](Self::begin_read).
+    fn end_read(&mut self, _obj_num: &usize) {}
+
+    /// Returns `true` if `obj_num` is currently being read in an ancestor
+    /// call frame.
+    fn is_being_read(&self, _obj_num: &usize) -> bool {
+        false
+    }
 }
 
 impl ResourceCache for HashMap<usize, Resource> {
@@ -39,5 +64,53 @@ impl ResourceCache for HashMap<usize, Resource> {
 
     fn insert(&mut self, obj_num: usize, resource: Resource) {
         HashMap::insert(self, obj_num, resource);
+    }
+}
+
+/// A resource cache with cycle detection.
+///
+/// Wraps a [`HashMap`]-based cache and adds an in-progress set that tracks
+/// which PDF objects are currently being parsed.  When a recursive read
+/// encounters an object already in the set, [`begin_read`](ResourceCache::begin_read)
+/// returns `false`, allowing callers to break the cycle gracefully.
+pub struct DefaultResourceCache {
+    cache: HashMap<usize, Resource>,
+    in_progress: HashSet<usize>,
+}
+
+impl DefaultResourceCache {
+    pub fn new() -> Self {
+        Self {
+            cache: HashMap::new(),
+            in_progress: HashSet::new(),
+        }
+    }
+}
+
+impl Default for DefaultResourceCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ResourceCache for DefaultResourceCache {
+    fn get(&self, obj_num: &usize) -> Option<&Resource> {
+        self.cache.get(obj_num)
+    }
+
+    fn insert(&mut self, obj_num: usize, resource: Resource) {
+        self.cache.insert(obj_num, resource);
+    }
+
+    fn begin_read(&mut self, obj_num: usize) -> bool {
+        self.in_progress.insert(obj_num)
+    }
+
+    fn end_read(&mut self, obj_num: &usize) {
+        self.in_progress.remove(obj_num);
+    }
+
+    fn is_being_read(&self, obj_num: &usize) -> bool {
+        self.in_progress.contains(obj_num)
     }
 }

--- a/crates/pdf-page/src/resources.rs
+++ b/crates/pdf-page/src/resources.rs
@@ -63,6 +63,17 @@ fn get_sub_dictionary<'a>(
 }
 
 /// Parses all font resources from the `/Font` sub-dictionary.
+///
+/// For Type 3 fonts whose dictionaries carry a nested `/Resources` entry, this
+/// function inserts a **sentinel** `Resource::Font { font, resources: None }`
+/// into the cache *before* reading the nested resources.  If the nested
+/// resource tree cycles back to the same font, the cache hit returns the
+/// sentinel — a usable font without infinite recursion.  Once the nested
+/// resources have been fully read, the sentinel is replaced with the complete
+/// resource.
+///
+/// See ISO 32000-2:2020 §7.8.3: circular resource references are non-conforming,
+/// but a robust reader must handle them gracefully.
 fn read_fonts(
     resources: &Dictionary,
     objects: &dyn ObjectResolver,
@@ -83,11 +94,27 @@ fn read_fonts(
             continue;
         }
 
+        // Parse the font first so we can insert a sentinel before recursing.
+        let font = Rc::new(Font::from_dictionary(dict, objects)?);
+
+        // Insert a sentinel with empty nested resources.  If the resource tree
+        // cycles back to this font, the cache lookup will return this sentinel,
+        // breaking the infinite recursion while still providing a usable font.
+        if let Some(num) = &dict.object_number {
+            cache.insert(
+                *num,
+                Resource::Font {
+                    font: Rc::clone(&font),
+                    resources: None,
+                },
+            );
+        }
+
         // Handle fonts that may have their own nested resources. This applies only to Type 3 fonts.
         let nested_resources = Resources::read(dict, objects, cache)?.map(Rc::new);
 
         let resource = Resource::Font {
-            font: Rc::new(Font::from_dictionary(dict, objects)?),
+            font,
             resources: nested_resources,
         };
 
@@ -131,6 +158,10 @@ fn read_external_graphics_states(
 }
 
 /// Parses all pattern resources from the `/Pattern` sub-dictionary.
+///
+/// Uses [`ResourceCache::begin_read`] / [`ResourceCache::end_read`] to detect
+/// cyclic references.  If a pattern is already being read in an ancestor frame,
+/// the cycle is broken by skipping the pattern entirely.
 fn read_patterns(
     resources: &Dictionary,
     objects: &dyn ObjectResolver,
@@ -147,9 +178,17 @@ fn read_patterns(
             result.insert(name.clone(), cached.clone());
             continue;
         }
+
+        // Cycle detection: skip this pattern if it is already being read
+        // in an ancestor call frame (ISO 32000-2:2020 §7.8.3).
+        if !cache.begin_read(object_number) {
+            continue;
+        }
+
         let pattern = Pattern::read(value, objects, cache)?;
         let resource = Resource::Pattern(Rc::new(pattern));
         cache.insert(object_number, resource.clone());
+        cache.end_read(&object_number);
 
         result.insert(name.clone(), resource);
     }
@@ -157,6 +196,10 @@ fn read_patterns(
 }
 
 /// Parses all XObject resources from the `/XObject` sub-dictionary.
+///
+/// Uses [`ResourceCache::begin_read`] / [`ResourceCache::end_read`] to detect
+/// cyclic references.  If an XObject is already being read in an ancestor
+/// frame, the cycle is broken by skipping the XObject entirely.
 fn read_xobjects(
     resources: &Dictionary,
     objects: &dyn ObjectResolver,
@@ -174,6 +217,12 @@ fn read_xobjects(
             continue;
         }
 
+        // Cycle detection: skip this XObject if it is already being read
+        // in an ancestor call frame (ISO 32000-2:2020 §7.8.3).
+        if !cache.begin_read(stream.object_number) {
+            continue;
+        }
+
         let resource = Resource::XObject(Rc::new(XObject::read_xobject(
             &stream.dictionary,
             stream,
@@ -181,6 +230,8 @@ fn read_xobjects(
             cache,
         )?));
         cache.insert(stream.object_number, resource.clone());
+        cache.end_read(&stream.object_number);
+
         result.insert(name.clone(), resource);
     }
     Ok(result)


### PR DESCRIPTION
Detect and break circular references in the PDF resource tree during parsing. This prevents infinite recursion when Type3 fonts, patterns, or XObjects reference each other cyclically.

- Add cycle-detection methods (begin_read/end_read/is_being_read) to the ResourceCache trait with default no-op implementations
- Create DefaultResourceCache with HashMap + HashSet in-progress tracking
- Use font sentinel strategy in read_fonts: insert Resource::Font with resources: None before recursing, so cyclic re-entry gets a usable font via cache hit
- Add begin_read/end_read guards in read_patterns and read_xobjects to skip resources already being read in an ancestor frame
- Add integration test with ContentStreamCycleType3insideType3.pdf

Cyclic resource references are non-conforming per ISO 32000-2:2020 §7.8.3, but a robust reader must handle them gracefully rather than crashing.