### PR TITLE
refactor: use render_content_stream in Type3FontRenderer

### DIFF
--- a/crates/pdf-canvas/src/pdf_canvas.rs
+++ b/crates/pdf-canvas/src/pdf_canvas.rs
@@ -153,7 +153,7 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
         mat: Option<Transform>,
         bbox: &Rect,
         resources: Option<&'a Resources>,
-        filter: Option<&(dyn Fn(&PdfOperatorVariant) -> bool + '_)>,
+        filter: Option<&mut (dyn FnMut(&PdfOperatorVariant) -> bool + '_)>,
     ) -> Result<(), PdfCanvasError> {
         // Calculate scale factors.
         let scale_x = recording_canvas.width() / bbox.width();
@@ -320,7 +320,7 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
 
                 // Uncolored patterns use the current color from the graphics state,
                 // so we filter out color-setting operators from the content stream.
-                const UNCOLORED_FILTER: fn(&PdfOperatorVariant) -> bool = |op| {
+                let mut uncolored_filter = |op: &PdfOperatorVariant| -> bool {
                     matches!(
                         op,
                         PdfOperatorVariant::SetNonStrokingColor(_)
@@ -334,9 +334,10 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
                     )
                 };
 
-                let filter: Option<&dyn Fn(&PdfOperatorVariant) -> bool> = match paint_type {
+                let filter: Option<&mut (dyn FnMut(&PdfOperatorVariant) -> bool)> = match paint_type
+                {
                     PaintType::Colored => None,
-                    PaintType::Uncolored => Some(&UNCOLORED_FILTER),
+                    PaintType::Uncolored => Some(&mut uncolored_filter),
                 };
 
                 // Create a recording canvas to render the tiling pattern.
@@ -530,7 +531,7 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
         mat: Option<Transform>,
         bbox: Option<&Rect>,
         resources: Option<&'a Resources>,
-        filter: Option<&(dyn Fn(&PdfOperatorVariant) -> bool + '_)>,
+        mut filter: Option<&mut (dyn FnMut(&PdfOperatorVariant) -> bool + '_)>,
     ) -> Result<(), PdfCanvasError> {
         self.save()?;
 
@@ -559,7 +560,7 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
         }
 
         for op in &content_stream.0 {
-            if filter.is_some_and(|filter| filter(op)) {
+            if filter.as_mut().is_some_and(|filter| filter(op)) {
                 continue;
             }
             op.call(self)?;
@@ -594,14 +595,6 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
         let _ = self.canvas_stack.pop();
 
         self.canvas.restore()
-    }
-
-    /// Replaces the current transformation matrix (CTM) with the given matrix.
-    ///
-    /// This sets the complete transformation from user space to device space.
-    pub(crate) fn set_matrix(&mut self, matrix: Transform) -> Result<(), PdfCanvasError> {
-        self.current_state_mut()?.transform = matrix;
-        Ok(())
     }
 
     /// Sets the current color space for stroking or filling operations.

--- a/crates/pdf-canvas/src/type3_font_renderer.rs
+++ b/crates/pdf-canvas/src/type3_font_renderer.rs
@@ -40,44 +40,34 @@ impl<B: CanvasBackend> TextRenderer for Type3FontRenderer<'_, '_, B> {
         &mut self,
         iter: impl Iterator<Item = u16>,
     ) -> Result<(), crate::error::PdfCanvasError> {
-        // 1. Iterate through each character code in the input text.
         for char_code_byte in iter {
             let state = self.canvas.current_state()?;
-            let text_rendering_matrix = {
+
+            // Compute a relative glyph matrix (Tm × S × FontMatrix) without the CTM.
+            // render_content_stream will post-concatenate this onto the current CTM,
+            // yielding the same absolute matrix: CTM × Tm × S × FontMatrix.
+            let glyph_matrix = {
                 let mut base = self.type3_font.font_matrix;
                 base.concat(&self.font_size_matrix);
-                state
-                    .text_state
-                    .compose_glyph_matrix(base, &state.transform)
+                base.concat(&state.text_state.matrix);
+                base
             };
 
-            // 2. Map character code to glyph name using the font's encoding.
             let glyph_name = state.text_state.glyph_name(char_code_byte);
             let Some(glyph_name) = glyph_name else {
                 continue;
             };
 
-            // 3. Look up the glyph's content stream from the `CharProcs` map.
             let Some(char_procs) = self.type3_font.char_procs.get(glyph_name) else {
-                // If the character code does not map to a glyph name via the font's encoding,
-                // this character is skipped.
                 continue;
             };
 
-            // 4. Save graphics state before drawing the glyph.
-            self.canvas.save()?;
+            // Type 3 fonts may carry their own resource dictionary for glyph procedures.
+            let type3_resources = state.text_state.resources;
 
-            // Override resources with Type 3 font's own resources for this glyph.
-            // Since save() cloned the state, this override is scoped to the glyph
-            // and restore() will pop it.
-            if let Some(type3_resources) = self.canvas.current_state()?.text_state.resources {
-                self.canvas.current_state_mut()?.resources = Some(type3_resources);
-            }
-
-            let mut glyph_width = None;
-
-            // 5. Set the transformation matrix for the glyph and execute its content stream.
-            // The CTM is temporarily replaced with the computed text rendering matrix.
+            // Intercept d0/d1 operators via the filter to capture glyph width.
+            // These operators are no-ops on the backend; the filter skips them
+            // while recording the width for text cursor advancement.
             //
             // Note: For clip rendering modes (TextRenderingMode 4–7), Type 3 glyph outlines
             // should also be accumulated into the text clip path (ISO 32000 §9.3.6). This
@@ -85,27 +75,30 @@ impl<B: CanvasBackend> TextRenderer for Type3FontRenderer<'_, '_, B> {
             // which is not yet implemented. Clip modes for Type 3 fonts are therefore a no-op
             // for the clip accumulation step; only the paint part (fill/stroke) takes effect
             // because the glyph's procedure calls standard painting operators directly.
-            self.canvas.set_matrix(text_rendering_matrix)?;
-
-            for op in char_procs {
-                // Check if this the `d1` operator. The `d1` operator is only used within the
-                // content stream of a Type 3 font's character procedure. It sets the width
-                // and bounding box of the character being defined.
-                // The backend is responsible for storing the width (`wx`, `wy`)
-                // so it can be used to advance the text matrix after the glyph is painted.
-                if let PdfOperatorVariant::SetCharWidthAndBoundingBox(op) = op {
-                    glyph_width = Some(op.wx);
-                } else if let PdfOperatorVariant::SetCharWidth(op) = op {
-                    glyph_width = Some(op.wx);
-                } else {
-                    op.call(self.canvas)?;
+            let mut glyph_width = None;
+            let mut filter = |op: &PdfOperatorVariant| -> bool {
+                match op {
+                    PdfOperatorVariant::SetCharWidthAndBoundingBox(d1) => {
+                        glyph_width = Some(d1.wx);
+                        true
+                    }
+                    PdfOperatorVariant::SetCharWidth(d0) => {
+                        glyph_width = Some(d0.wx);
+                        true
+                    }
+                    _ => false,
                 }
-            }
+            };
 
-            // 6. Restore the original graphics state.
-            self.canvas.restore()?;
+            self.canvas.render_content_stream(
+                char_procs,
+                Some(glyph_matrix),
+                None,
+                type3_resources,
+                Some(&mut filter),
+            )?;
 
-            // 7. Advance the text matrix (Tm) to position the next glyph.
+            // Advance the text matrix (Tm) to position the next glyph.
             if let Some(width) = glyph_width {
                 let text_state = &mut self.canvas.current_state_mut()?.text_state;
 

--- a/crates/pdf-font/src/type3_font.rs
+++ b/crates/pdf-font/src/type3_font.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use pdf_content_stream::pdf_operator::PdfOperatorVariant;
+use pdf_content_stream::content_stream::ContentStream;
 use pdf_graphics::{rect::Rect, transform::Transform};
 use pdf_object::{
     dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
@@ -19,7 +19,6 @@ use crate::{
 /// offer more flexibility in defining character shapes, allowing for complex
 /// graphical elements within glyphs.  However, they are less efficient and do not
 /// support advanced typographic features like hinting.
-#[derive(Debug)]
 pub struct Type3Font {
     /// A matrix that maps user space coordinates to glyph space coordinates.
     /// It is used to transform glyph outlines during rendering.
@@ -27,7 +26,7 @@ pub struct Type3Font {
     /// The bounding box of the font.
     pub bounds: Rect,
     /// A procedure defining any special actions to be taken before a character from this font is rendered.
-    pub char_procs: HashMap<String, Vec<PdfOperatorVariant>>,
+    pub char_procs: HashMap<String, ContentStream>,
     /// The font's encoding, specifying the mapping from character codes to glyph names.
     pub encoding: Option<Encoding>,
     /// Parsed ToUnicode CMap for char-code → Unicode mapping.
@@ -71,8 +70,8 @@ impl Type3Font {
 
         let mut char_procs = HashMap::new();
         for (name, value) in char_proc_dictionary.dictionary.iter() {
-            let data = value.try_stream(objects)?.data()?;
-            let operators = PdfOperatorVariant::parse(&data)?;
+            let data = value.try_stream(objects)?;
+            let operators = ContentStream::from_stream(data)?;
             char_procs.insert(name.to_owned(), operators);
         }
 


### PR DESCRIPTION
Replace the manual save/set_matrix/op-loop/restore sequence with a single render_content_stream() call per glyph:

- Compute a relative glyph matrix (Tm × S × FontMatrix) instead of an absolute one, letting render_content_stream's post_concat produce the correct CTM.
- Pass Type3 font resources directly via the resources parameter.
- Remove the now-unused PdfCanvas::set_matrix() helper.