### PR TITLE
pdf-parser: Parse empty names as empty values

### DIFF
--- a/crates/pdf-content-stream/src/pdf_operator/variants.rs
+++ b/crates/pdf-content-stream/src/pdf_operator/variants.rs
@@ -573,4 +573,19 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn parse_recovers_from_empty_name_operand_before_next_operator() {
+        let input = b"/ 12 Tf q";
+
+        let actual_ops = PdfOperatorVariant::parse(input).expect("stream should parse");
+
+        assert_eq!(
+            actual_ops,
+            vec![
+                PdfOperatorVariant::SetFont(SetFont::new(String::new(), 12.0)),
+                PdfOperatorVariant::SaveGraphicsState(SaveGraphicsState),
+            ]
+        );
+    }
 }

--- a/crates/pdf-parser/src/name.rs
+++ b/crates/pdf-parser/src/name.rs
@@ -12,8 +12,6 @@ pub enum NameObjectError {
     IncompleteHexEscape,
     #[error("Invalid hex escape in name object: Non-hex character '{0}' found in sequence")]
     NonHexDigitInEscape(char),
-    #[error("Invalid token in name object (e.g., empty name after '/')")]
-    EmptyName,
     #[error("Tokenizer error: {0}")]
     TokenizerError(#[from] TokenizerError),
 }
@@ -29,10 +27,6 @@ impl PdfParser<'_> {
         self.tokenizer.expect(PdfToken::Solidus)?;
 
         let name = self.tokenizer.read_while_u8(|b| !Self::is_pdf_delimiter(b));
-        if name.is_empty() {
-            return Err(NameObjectError::EmptyName);
-        }
-
         escape(name)
     }
 }
@@ -95,6 +89,9 @@ mod tests {
     #[test]
     fn test_name_object_valid() {
         let valid_inputs: Vec<(&[u8], &[u8])> = vec![
+            (b"/", b""),
+            (b"/ ", b""),
+            (b"/\n", b""),
             (b"/Name\n", b"Name"),
             (b"/Name\t", b"Name"),
             (b"/Name1 ", b"Name1"),


### PR DESCRIPTION
Treat a bare solidus in parse_name as an empty PDF name instead of raising an error. This lets malformed content streams such as "/ 12 Tf" keep parsing without a content-stream-specific workaround.

Remove the content-stream empty-name special case, add parser and content-stream regression tests, and add bug1669099.pdf so the viewer reproduction stays available.