### PR TITLE
pdf-parser: Recover headerless PDFs with shifted xrefs

### DIFF
--- a/crates/pdf-document/src/reader.rs
+++ b/crates/pdf-document/src/reader.rs
@@ -30,7 +30,7 @@ impl PdfReader {
     /// Reads and parses a PDF document from raw bytes.
     ///
     /// This method performs the following steps:
-    /// 1. Parses the PDF header and validates the version
+    /// 1. Parses the PDF header when present and validates the version
     /// 2. Builds the cross-reference index to locate all objects
     /// 3. Checks for encryption and resolves the Encrypt dictionary first
     /// 4. Loads all objects referenced in the xref table
@@ -51,9 +51,10 @@ impl PdfReader {
     ) -> Result<PdfDocument, PdfReaderError> {
         let mut parser = PdfParser::from(input);
 
-        // Parse and validate PDF header
-        let version = parser.parse_header()?;
-        if version.major() != 1 {
+        // Parse and validate the PDF header when it is present near the start of the file.
+        if let Some(version) = parser.parse_header_in_opening_bytes()?
+            && version.major() != 1
+        {
             return Err(PdfReaderError::UnsupportedVersion(
                 version.major(),
                 version.minor(),
@@ -560,6 +561,105 @@ mod tests {
 
         let doc = result.unwrap();
         assert_eq!(doc.page_count(), 0);
+    }
+
+    #[test]
+    fn test_headerless_document_loads_normally() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"%\xe2\xe3\xcf\xd3\n");
+
+        // Object 1: Catalog
+        let obj1_offset = data.len();
+        data.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        // Object 2: Pages
+        let obj2_offset = data.len();
+        data.extend_from_slice(
+            b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 595 842] >>\nendobj\n",
+        );
+
+        // Object 3: Page
+        let obj3_offset = data.len();
+        data.extend_from_slice(b"3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n");
+
+        // Xref table
+        let xref_offset = data.len();
+        data.extend_from_slice(b"xref\n0 4\n");
+        data.extend_from_slice(format_xref_entry(0, 65535, false).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj1_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj2_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj3_offset, 0, true).as_bytes());
+
+        // Trailer
+        data.extend_from_slice(b"trailer\n<< /Size 4 /Root 1 0 R >>\n");
+        data.extend_from_slice(b"startxref\n");
+        data.extend_from_slice(format!("{}\n", xref_offset).as_bytes());
+        data.extend_from_slice(b"%%EOF");
+
+        let reader = PdfReader;
+        let result = reader.read_from_bytes(&data, None);
+
+        assert!(
+            result.is_ok(),
+            "Headerless document should load: {:?}",
+            result.err()
+        );
+
+        let doc = result.unwrap();
+        assert_eq!(doc.page_count(), 1);
+    }
+
+    #[test]
+    fn test_headerless_document_with_shifted_xref_offsets_loads_normally() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"%\xe2\xe3\xcf\xd3\n");
+
+        // Object 1: Catalog
+        let obj1_offset = data.len();
+        data.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        // Object 2: Pages
+        let obj2_offset = data.len();
+        data.extend_from_slice(
+            b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 595 842] >>\nendobj\n",
+        );
+
+        // Object 3: Page
+        let obj3_offset = data.len();
+        data.extend_from_slice(b"3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n");
+
+        // Xref table
+        let xref_offset = data.len();
+        data.extend_from_slice(b"xref\n0 4\n");
+        const STRIPPED_HEADER_DELTA: usize = 9;
+        data.extend_from_slice(format_xref_entry(0, 65535, false).as_bytes());
+        data.extend_from_slice(
+            format_xref_entry(obj1_offset + STRIPPED_HEADER_DELTA, 0, true).as_bytes(),
+        );
+        data.extend_from_slice(
+            format_xref_entry(obj2_offset + STRIPPED_HEADER_DELTA, 0, true).as_bytes(),
+        );
+        data.extend_from_slice(
+            format_xref_entry(obj3_offset + STRIPPED_HEADER_DELTA, 0, true).as_bytes(),
+        );
+
+        // Trailer
+        data.extend_from_slice(b"trailer\n<< /Size 4 /Root 1 0 R >>\n");
+        data.extend_from_slice(b"startxref\n");
+        data.extend_from_slice(format!("{}\n", xref_offset + STRIPPED_HEADER_DELTA).as_bytes());
+        data.extend_from_slice(b"%%EOF");
+
+        let reader = PdfReader;
+        let result = reader.read_from_bytes(&data, None);
+
+        assert!(
+            result.is_ok(),
+            "Headerless document with shifted xref offsets should load: {:?}",
+            result.err()
+        );
+
+        let doc = result.unwrap();
+        assert_eq!(doc.page_count(), 1);
     }
 
     #[test]

--- a/crates/pdf-parser/src/header.rs
+++ b/crates/pdf-parser/src/header.rs
@@ -61,6 +61,34 @@ impl PdfParser<'_> {
 
         Ok(Version::new(major, minor))
     }
+
+    /// Searches the opening bytes of the file for a `%PDF-` header and parses it when found.
+    ///
+    /// ISO 32000 permits the PDF header to appear somewhere within the first 1024 bytes.
+    /// This helper restores the parser position before returning so callers can probe for a
+    /// header without affecting later random-access parsing.
+    pub fn parse_header_in_opening_bytes(&mut self) -> Result<Option<Version>, ParserError> {
+        const HEADER_SEARCH_LIMIT: usize = 1024;
+        const PDF_HEADER_PREFIX: &[u8] = b"%PDF-";
+
+        let mark = self.tokenizer.position;
+        let search_len = self.tokenizer.input.len().min(HEADER_SEARCH_LIMIT);
+        let opening_bytes = self.tokenizer.input.get(..search_len).unwrap_or(&[]);
+        let header_position = opening_bytes
+            .windows(PDF_HEADER_PREFIX.len())
+            .position(|window| window == PDF_HEADER_PREFIX);
+
+        let version = match header_position {
+            Some(position) => {
+                self.tokenizer.position = position;
+                Some(self.parse_header()?)
+            }
+            None => None,
+        };
+
+        self.tokenizer.position = mark;
+        Ok(version)
+    }
 }
 
 #[cfg(test)]
@@ -84,5 +112,36 @@ mod tests {
         let mut parser = PdfParser::from(input.as_slice());
         let result = parser.parse_header();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_header_in_opening_bytes_valid() {
+        let input = b"%PDF-1.7\n";
+        let mut parser = PdfParser::from(input.as_slice());
+        let version = parser.parse_header_in_opening_bytes().unwrap();
+        let version = version.unwrap();
+        assert_eq!(version.major(), 1);
+        assert_eq!(version.minor(), 7);
+        assert_eq!(parser.tokenizer.position, 0);
+    }
+
+    #[test]
+    fn test_parse_header_in_opening_bytes_with_leading_junk() {
+        let input = b"garbage before header\n%PDF-1.4\n";
+        let mut parser = PdfParser::from(input.as_slice());
+        let version = parser.parse_header_in_opening_bytes().unwrap();
+        let version = version.unwrap();
+        assert_eq!(version.major(), 1);
+        assert_eq!(version.minor(), 4);
+        assert_eq!(parser.tokenizer.position, 0);
+    }
+
+    #[test]
+    fn test_parse_header_in_opening_bytes_missing_header() {
+        let input = b"%\xe2\xe3\xcf\xd3\n1 0 obj\n";
+        let mut parser = PdfParser::from(input.as_slice());
+        let version = parser.parse_header_in_opening_bytes().unwrap();
+        assert!(version.is_none());
+        assert_eq!(parser.tokenizer.position, 0);
     }
 }

--- a/crates/pdf-parser/src/xref_builder.rs
+++ b/crates/pdf-parser/src/xref_builder.rs
@@ -43,6 +43,103 @@ impl PdfParser<'_> {
     }
 }
 
+fn parse_xref_section_at_offset(
+    parser: &mut PdfParser,
+    offset: usize,
+) -> Result<CrossReferenceTable, ParserError> {
+    let parsed = parser.parse_object_at(offset, &PassthroughResolver)?;
+
+    match parsed {
+        ObjectVariant::CrossReferenceTable(table) => Ok(table),
+        ObjectVariant::IndirectObject(indirect) => match indirect.object {
+            Some(ObjectVariant::Stream(ref stream)) => {
+                crate::cross_reference_stream::parse_xref_stream(stream, &PassthroughResolver)
+            }
+            _ => Err(ParserError::InvalidXrefAtOffset { offset }),
+        },
+        ObjectVariant::Stream(ref stream) => {
+            crate::cross_reference_stream::parse_xref_stream(stream, &PassthroughResolver)
+        }
+        _ => Err(ParserError::InvalidXrefAtOffset { offset }),
+    }
+}
+
+fn recover_traditional_xref_offset(parser: &PdfParser, declared_offset: usize) -> Option<usize> {
+    const XREF_KEYWORD: &[u8] = b"xref";
+    const RECOVERY_WINDOW: usize = 1024;
+
+    let input = parser.tokenizer.input;
+    let search_start = declared_offset.saturating_sub(RECOVERY_WINDOW);
+    let search_end = declared_offset.min(input.len());
+    let haystack = input.get(search_start..search_end)?;
+
+    haystack
+        .windows(XREF_KEYWORD.len())
+        .rposition(|window| window == XREF_KEYWORD)
+        .and_then(|relative_position| search_start.checked_add(relative_position))
+        .filter(|&candidate| candidate != declared_offset)
+        .filter(|&candidate| {
+            let starts_on_line_boundary =
+                match candidate.checked_sub(1).and_then(|idx| input.get(idx)) {
+                    Some(previous) => PdfParser::is_pdf_whitespace(*previous),
+                    None => true,
+                };
+            let has_delimiter_after_keyword = match candidate
+                .checked_add(XREF_KEYWORD.len())
+                .and_then(|idx| input.get(idx))
+            {
+                Some(next) => PdfParser::is_pdf_whitespace(*next),
+                None => true,
+            };
+
+            starts_on_line_boundary && has_delimiter_after_keyword
+        })
+}
+
+fn normalize_traditional_xref_offsets(table: &mut CrossReferenceTable, offset_delta: usize) {
+    if offset_delta == 0 {
+        return;
+    }
+
+    for entry in table.entries.values_mut() {
+        let pdf_object::cross_reference_table::CrossReferenceEntryType::Normal {
+            byte_offset,
+            generation_number,
+        } = &entry.entry_type
+        else {
+            continue;
+        };
+
+        let adjusted_offset = byte_offset
+            .checked_sub(offset_delta)
+            .unwrap_or(*byte_offset);
+        *entry = CrossReferenceEntry::new_normal(adjusted_offset, *generation_number);
+    }
+}
+
+fn parse_xref_section_with_recovery(
+    parser: &mut PdfParser,
+    declared_offset: usize,
+) -> Result<CrossReferenceTable, ParserError> {
+    match parse_xref_section_at_offset(parser, declared_offset) {
+        Ok(table) => Ok(table),
+        Err(ParserError::InvalidXrefAtOffset { .. }) => {
+            let recovered_offset = recover_traditional_xref_offset(parser, declared_offset).ok_or(
+                ParserError::InvalidXrefAtOffset {
+                    offset: declared_offset,
+                },
+            )?;
+            let mut table = parse_xref_section_at_offset(parser, recovered_offset)?;
+            normalize_traditional_xref_offsets(
+                &mut table,
+                declared_offset.saturating_sub(recovered_offset),
+            );
+            Ok(table)
+        }
+        Err(error) => Err(error),
+    }
+}
+
 /// Follows the xref chain via `/Prev` entries and merges all cross-reference tables.
 ///
 /// Handles incremental PDF updates where each update adds a new xref section
@@ -63,29 +160,7 @@ fn merge_xref_chain(
             break;
         }
 
-        let parsed = parser.parse_object_at(current_offset, &PassthroughResolver)?;
-
-        let xref_table = match parsed {
-            ObjectVariant::CrossReferenceTable(table) => table,
-            ObjectVariant::IndirectObject(indirect) => match indirect.object {
-                Some(ObjectVariant::Stream(ref stream)) => {
-                    crate::cross_reference_stream::parse_xref_stream(stream, &PassthroughResolver)?
-                }
-                _ => {
-                    return Err(ParserError::InvalidXrefAtOffset {
-                        offset: current_offset,
-                    });
-                }
-            },
-            ObjectVariant::Stream(ref stream) => {
-                crate::cross_reference_stream::parse_xref_stream(stream, &PassthroughResolver)?
-            }
-            _ => {
-                return Err(ParserError::InvalidXrefAtOffset {
-                    offset: current_offset,
-                });
-            }
-        };
+        let xref_table = parse_xref_section_with_recovery(parser, current_offset)?;
 
         // Merge entries: newer entries (already present) take precedence over older ones.
         for (obj_num, entry) in xref_table.entries {
@@ -264,5 +339,45 @@ mod tests {
             "Failed circular xref test: {:?}",
             result.err()
         );
+    }
+
+    #[test]
+    fn test_build_xref_table_recovers_stripped_header_offsets() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"%\xe2\xe3\xcf\xd3\n");
+
+        let obj1_offset = data.len();
+        data.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        let obj2_offset = data.len();
+        data.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n");
+
+        let xref_offset = data.len();
+        data.extend_from_slice(b"xref\n0 3\n");
+
+        const STRIPPED_HEADER_DELTA: usize = 9;
+        data.extend_from_slice(format_xref_entry(0, 65535, false).as_bytes());
+        data.extend_from_slice(
+            format_xref_entry(obj1_offset + STRIPPED_HEADER_DELTA, 0, true).as_bytes(),
+        );
+        data.extend_from_slice(
+            format_xref_entry(obj2_offset + STRIPPED_HEADER_DELTA, 0, true).as_bytes(),
+        );
+
+        data.extend_from_slice(b"trailer\n<< /Size 3 /Root 1 0 R >>\n");
+        data.extend_from_slice(b"startxref\n");
+        data.extend_from_slice(format!("{}\n", xref_offset + STRIPPED_HEADER_DELTA).as_bytes());
+        data.extend_from_slice(b"%%EOF");
+
+        let mut parser = PdfParser::from(data.as_slice());
+        let table = parser
+            .build_xref_table()
+            .expect("xref recovery should work");
+
+        let entry1 = table.entries.get(&1).expect("obj 1 should exist");
+        assert_eq!(entry1.byte_offset(), Some(obj1_offset));
+
+        let entry2 = table.entries.get(&2).expect("obj 2 should exist");
+        assert_eq!(entry2.byte_offset(), Some(obj2_offset));
     }
 }


### PR DESCRIPTION
Allow the reader to continue when a PDF header is missing and recover traditional xref tables whose offsets still include the stripped header length.

Add parser and reader regression tests covering header discovery, headerless documents, and the shifted-xref layout.