### PR TITLE
pdf-parser: Parse malformed glued number tokens

### DIFF
--- a/crates/pdf-parser/src/error.rs
+++ b/crates/pdf-parser/src/error.rs
@@ -31,8 +31,14 @@ pub enum ParserError {
     HeaderError(#[from] HeaderError),
     #[error("Error while reading a keyword. Expected '{0}' got '{1}'")]
     InvalidKeyword(String, String),
-    #[error("Expected delimiter after keyword, found: {0:?}")]
-    MissingDelimiterAfterKeyword(u8),
+    #[error(
+        "Expected delimiter after keyword '{keyword}' at byte offset {position}, found: {found:?}"
+    )]
+    MissingDelimiterAfterKeyword {
+        keyword: String,
+        found: u8,
+        position: usize,
+    },
     #[error("Unexpected token '{token}' at position {position}")]
     UnexpectedTokenAt { token: String, position: usize },
     #[error("Nesting depth exceeded")]

--- a/crates/pdf-parser/src/indirect_object.rs
+++ b/crates/pdf-parser/src/indirect_object.rs
@@ -123,4 +123,27 @@ mod tests {
             panic!("Expected Stream variant");
         }
     }
+
+    #[test]
+    fn test_indirect_object_allows_compact_integer_before_endobj() {
+        let input = b"1501 0 obj\n61endobj\n";
+        let mut parser = PdfParser::from(input.as_slice());
+
+        if let Some(ObjectVariant::IndirectObject(indirect_object)) =
+            parser.parse_indirect_object(&PassthroughResolver).unwrap()
+        {
+            let IndirectObject {
+                object_number,
+                generation_number,
+                object,
+                ..
+            } = indirect_object.as_ref();
+
+            assert_eq!(*object_number, 1501);
+            assert_eq!(*generation_number, 0);
+            assert_eq!(*object, Some(ObjectVariant::Integer(61)));
+        } else {
+            panic!("Expected IndirectObject variant");
+        }
+    }
 }

--- a/crates/pdf-parser/src/number.rs
+++ b/crates/pdf-parser/src/number.rs
@@ -16,8 +16,6 @@ pub enum NumberError {
     },
     #[error("Numeric value overflow")]
     NumericValueOverflow,
-    #[error("Missing delimiter after number, found '{0}'")]
-    MissingDelimiterAfterNumber(char),
 }
 
 impl PdfParser<'_> {
@@ -95,11 +93,6 @@ impl PdfParser<'_> {
             let value = integer_part as f64 + frac_value;
             let number = if has_minus { -value } else { value };
 
-            if let Some(d) = self.tokenizer.data().first().copied()
-                && !Self::is_pdf_delimiter(d)
-            {
-                return Err(NumberError::MissingDelimiterAfterNumber(char::from(d)).into());
-            }
             self.skip_whitespace();
             Ok(ObjectVariant::Real(number))
         } else {
@@ -167,11 +160,9 @@ mod tests {
     #[test]
     fn test_parse_number_invalid() {
         let invalid_inputs: Vec<&[u8]> = vec![
-            b"--42",    // double minus
-            b"++17",    // double plus
-            b"+-5",     // invalid combination
-            b"4,200",   // comma not allowed
-            b"123abc ", // Mixed numeric and non-numeric characters
+            b"--42", // double minus
+            b"++17", // double plus
+            b"+-5",  // invalid combination
             b".", b"-.",
         ];
 
@@ -184,5 +175,15 @@ mod tests {
                 String::from_utf8_lossy(input)
             );
         }
+    }
+
+    #[test]
+    fn test_parse_number_keeps_trailing_bytes_for_best_effort() {
+        let mut parser = PdfParser::from(b"61endobj".as_slice());
+
+        let result = parser.parse_number().unwrap();
+
+        assert_eq!(result, ObjectVariant::Integer(61));
+        assert_eq!(parser.tokenizer.data(), b"endobj");
     }
 }

--- a/crates/pdf-parser/src/parser.rs
+++ b/crates/pdf-parser/src/parser.rs
@@ -136,7 +136,9 @@ impl PdfParser<'_> {
 
     /// Reads a sequence of ASCII digits and parses them into type `T`.
     ///
-    /// Validates that a delimiter or decimal point follows the digits.
+    /// Best-effort parsing intentionally stops at the first non-digit byte instead of enforcing a
+    /// trailing token delimiter. Higher-level parsers decide whether the remaining bytes form a
+    /// meaningful continuation.
     /// Optionally skips trailing whitespace when `skip_whitespace` is true.
     pub fn read_number<T: FromStr>(&mut self, skip_whitespace: bool) -> Result<T, ParserError> {
         let number_bytes = self.tokenizer.read_while_u8(|b| b.is_ascii_digit());
@@ -151,15 +153,6 @@ impl PdfParser<'_> {
         let number = number_str
             .parse::<T>()
             .map_err(|_| ParserError::InvalidNumber(number_str.to_owned()))?;
-
-        // Check that the following character after the number is a valid delimiter
-        // or a dot (potential decimal number).
-        if let Some(d) = self.tokenizer.data().first().copied()
-            && !Self::is_pdf_delimiter(d)
-            && d != b'.'
-        {
-            return Err(ParserError::MissingDelimiterAfterKeyword(d));
-        }
 
         if skip_whitespace {
             self.skip_whitespace();
@@ -184,7 +177,11 @@ impl PdfParser<'_> {
         if let Some(d) = self.tokenizer.data().first().copied()
             && !Self::is_pdf_delimiter(d)
         {
-            return Err(ParserError::MissingDelimiterAfterKeyword(d));
+            return Err(ParserError::MissingDelimiterAfterKeyword {
+                keyword: String::from_utf8_lossy(keyword).into_owned(),
+                found: d,
+                position: self.tokenizer.position,
+            });
         }
 
         // Consume trailing EOL if present (keywords in arrays/dicts may not have one).
@@ -303,6 +300,32 @@ mod tests {
         let mut parser = PdfParser::from(input.as_slice());
         let result = parser.parse_object(&PassthroughResolver);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_read_number_stops_at_first_non_digit_for_best_effort() {
+        let mut parser = PdfParser::from(b"123abc".as_slice());
+
+        let number = parser.read_number::<usize>(false).unwrap();
+
+        assert_eq!(number, 123);
+        assert_eq!(parser.tokenizer.data(), b"abc");
+    }
+
+    #[test]
+    fn test_read_keyword_error_reports_keyword_and_offset() {
+        let mut parser = PdfParser::from(b"truefalse".as_slice());
+
+        let error = parser.read_keyword(b"true").unwrap_err();
+
+        assert_eq!(
+            error,
+            ParserError::MissingDelimiterAfterKeyword {
+                keyword: "true".to_string(),
+                found: b'f',
+                position: 4,
+            }
+        );
     }
 
     mod skip_whitespace_and_comments {


### PR DESCRIPTION
Make numeric parsing best-effort so malformed inputs such as 61endobj keep parsing without a number-specific keyword whitelist.

Keep the keyword delimiter error descriptive, add parser regression tests for best-effort number parsing and compact indirect objects, and add the new viewer reproduction PDFs under examples/assets.