### PR TITLE
pdf-page: Treat /SMask /None as no soft mask

### DIFF
--- a/crates/pdf-document/src/reader.rs
+++ b/crates/pdf-document/src/reader.rs
@@ -766,6 +766,66 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_image_xobject_smask_name_none_loads_normally() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"%PDF-1.7\n");
+
+        // Object 1: Catalog
+        let obj1_offset = data.len();
+        data.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        // Object 2: Pages
+        let obj2_offset = data.len();
+        data.extend_from_slice(
+            b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 1 1] >>\nendobj\n",
+        );
+
+        // Object 3: Page with an image XObject resource.
+        let obj3_offset = data.len();
+        data.extend_from_slice(
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources 5 0 R /MediaBox [0 0 1 1] >>\nendobj\n",
+        );
+
+        // Object 4: Image XObject with `/SMask /None`.
+        let obj4_offset = data.len();
+        data.extend_from_slice(
+            b"4 0 obj\n<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceGray /BitsPerComponent 8 /Length 1 /SMask /None >>\nstream\nA\nendstream\nendobj\n",
+        );
+
+        // Object 5: Resources dictionary referencing the image.
+        let obj5_offset = data.len();
+        data.extend_from_slice(b"5 0 obj\n<< /XObject << /Im1 4 0 R >> >>\nendobj\n");
+
+        // Xref table
+        let xref_offset = data.len();
+        data.extend_from_slice(b"xref\n0 6\n");
+        data.extend_from_slice(format_xref_entry(0, 65535, false).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj1_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj2_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj3_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj4_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj5_offset, 0, true).as_bytes());
+
+        // Trailer
+        data.extend_from_slice(b"trailer\n<< /Size 6 /Root 1 0 R >>\n");
+        data.extend_from_slice(b"startxref\n");
+        data.extend_from_slice(format!("{}\n", xref_offset).as_bytes());
+        data.extend_from_slice(b"%%EOF");
+
+        let reader = PdfReader;
+        let result = reader.read_from_bytes(&data, None);
+
+        assert!(
+            result.is_ok(),
+            "Image XObject with /SMask /None should load: {:?}",
+            result.err()
+        );
+
+        let doc = result.unwrap();
+        assert_eq!(doc.page_count(), 1);
+    }
+
     /// A cyclic page tree (3→4→5→3) must not cause a stack overflow.
     /// Object 6 is the only valid leaf /Page and should be returned.
     #[test]

--- a/crates/pdf-page/src/image.rs
+++ b/crates/pdf-page/src/image.rs
@@ -11,7 +11,10 @@ use std::borrow::Cow;
 
 use pdf_content_stream::content_stream::ContentStreamIdAllocator;
 use pdf_graphics::PixelFormat;
-use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver, stream::StreamObject};
+use pdf_object::{
+    dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
+    stream::StreamObject,
+};
 
 use crate::{error::PdfPagesError, resource_cache::ResourceCache, xobject::XObject};
 use pdf_color_space::{color_space::ColorSpace, indexed_color_space::IndexedColorSpace};
@@ -235,8 +238,16 @@ impl ImageXObject {
             return Ok(None);
         };
 
+        let resolved = objects.resolve_object(smask_obj)?;
+
+        if let ObjectVariant::Name(name) = resolved
+            && name.as_slice() == b"None"
+        {
+            return Ok(None);
+        }
+
         // Resolve the SMask stream reference.
-        let stream = smask_obj.try_stream(objects)?;
+        let stream = resolved.try_stream(objects)?;
 
         // Recursively parse the SMask as an XObject.
         let smask_xobject =
@@ -368,6 +379,15 @@ impl ImageXObject {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use pdf_content_stream::content_stream::ContentStreamIdAllocator;
+    use pdf_object::{
+        dictionary::Dictionary, object_resolver::PassthroughResolver, object_variant::ObjectVariant,
+    };
+
+    use crate::resource_cache::DefaultResourceCache;
+
     use super::ImageXObject;
 
     #[test]
@@ -420,5 +440,24 @@ mod tests {
         // pixel 0: bits 7,6,5 → 1,1,0 → [0xFF,0xFF,0x00]
         // pixel 1: bits 4,3,2 → 1,1,0 → [0xFF,0xFF,0x00]
         assert_eq!(out, [0xFF, 0xFF, 0x00, 0xFF, 0xFF, 0x00]);
+    }
+
+    #[test]
+    fn parse_smask_name_none_is_treated_as_absent() {
+        let dictionary = Dictionary::new(BTreeMap::from([(
+            "SMask".to_string(),
+            ObjectVariant::Name(b"None".to_vec()),
+        )]));
+        let mut cache = DefaultResourceCache::default();
+        let mut ids = ContentStreamIdAllocator::new();
+
+        let smask =
+            ImageXObject::parse_smask(&dictionary, &PassthroughResolver, &mut cache, &mut ids)
+                .expect("name-valued /SMask should be accepted");
+
+        assert!(
+            smask.is_none(),
+            "/SMask /None should behave like no soft mask"
+        );
     }
 }


### PR DESCRIPTION
Accept name-valued image soft masks instead of forcing /SMask through stream resolution. This lets producer-quirky image XObjects parse without aborting page loading.

Add focused pdf-page and pdf-document regression tests covering the direct parser path and a minimal document with an image XObject that uses /SMask /None.