### PR TITLE
pdf-parser: Recover malformed xrefs and stream lengths

### DIFF
--- a/crates/pdf-document/src/reader.rs
+++ b/crates/pdf-document/src/reader.rs
@@ -442,6 +442,69 @@ mod tests {
         format!("{:010} {:05} {} \n", offset, generation, kind)
     }
 
+    fn build_issue139_like_pdf() -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"%PDF-1.4\n");
+
+        let obj6_offset = data.len();
+        data.extend_from_slice(b"6 0 obj\n<<\n /Type /Catalog\n /Pages 5 0 R\n>>\nendobj\n\n");
+
+        let obj1_offset = data.len();
+        data.extend_from_slice(
+            b"1 0 obj\n<<\n /Type /Page\n /Parent 5 0 R\n /MediaBox [ 0 0 612 792 ]\n /Resources 3 0 R\n /Contents 2 0 R\n>>\nendobj\n\n",
+        );
+
+        let obj4_offset = data.len();
+        data.extend_from_slice(
+            b"4 0 obj\n<<\n /Type /Font\n /Subtype /Type1\n /Name /F1\n /BaseFont/Helvetica\n>>\nendobj\n\n",
+        );
+
+        let _obj2_offset = data.len();
+        data.extend_from_slice(
+            b"2 0 obj\n<<\n /Length 53\n>>\nstream\ntoString\nendstream\nendobj\n\n",
+        );
+
+        let obj5_offset = data.len();
+        data.extend_from_slice(
+            b"5 0 obj\n<<\n /Type /Pages\n /Kids [ 1 0 R ]\n /Count 1\n>>\nendobj\n\n",
+        );
+
+        let obj3_offset = data.len();
+        data.extend_from_slice(
+            b"3 0 obj\n<<\n /ProcSet[/PDF/Text]\n /Font <</F1 4 0 R >>\n>>\nendobj\n\n",
+        );
+
+        let stream_payload_offset = data
+            .windows(b"toString".len())
+            .position(|window| window == b"toString")
+            .expect("stream payload should exist");
+
+        let xref_offset = data.len();
+        data.extend_from_slice(b"xref\n0 7\n");
+        data.extend_from_slice(format_xref_entry(0, 65535, false).as_bytes());
+        data.extend_from_slice(
+            format_xref_entry(obj1_offset.saturating_sub(8), 0, true).as_bytes(),
+        );
+        data.extend_from_slice(format_xref_entry(stream_payload_offset, 0, true).as_bytes());
+        data.extend_from_slice(
+            format_xref_entry(obj3_offset.saturating_add(4), 0, true).as_bytes(),
+        );
+        data.extend_from_slice(
+            format_xref_entry(obj4_offset.saturating_sub(3), 0, true).as_bytes(),
+        );
+        data.extend_from_slice(
+            format_xref_entry(obj5_offset.saturating_add(9), 0, true).as_bytes(),
+        );
+        data.extend_from_slice(format_xref_entry(obj6_offset, 0, true).as_bytes());
+
+        data.extend_from_slice(b"trailer\n<< /Size 7 /Root 6 0 R >>\n");
+        data.extend_from_slice(b"startxref\n");
+        data.extend_from_slice(format!("{}\n", xref_offset.saturating_add(36)).as_bytes());
+        data.extend_from_slice(b"%%EOF");
+
+        data
+    }
+
     #[test]
     fn test_encrypted_document_detection() {
         let mut data = Vec::new();
@@ -655,6 +718,22 @@ mod tests {
         assert!(
             result.is_ok(),
             "Headerless document with shifted xref offsets should load: {:?}",
+            result.err()
+        );
+
+        let doc = result.unwrap();
+        assert_eq!(doc.page_count(), 1);
+    }
+
+    #[test]
+    fn test_issue139_pdf_loads_normally() {
+        let reader = PdfReader;
+        let data = build_issue139_like_pdf();
+        let result = reader.read_from_bytes(&data, None);
+
+        assert!(
+            result.is_ok(),
+            "issue139.pdf should load after xref recovery: {:?}",
             result.err()
         );
 

--- a/crates/pdf-parser/src/stream.rs
+++ b/crates/pdf-parser/src/stream.rs
@@ -1,5 +1,6 @@
 use crate::{error::ParserError, parser::PdfParser};
 use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
+use pdf_tokenizer::error::TokenizerError;
 
 impl PdfParser<'_> {
     /// Parses a PDF stream object from the input, using a pre-parsed dictionary.
@@ -31,16 +32,128 @@ impl PdfParser<'_> {
             .get_or_err("Length")?
             .try_number::<usize>(objects)?;
 
+        let stream_data_start = self.tokenizer.position;
+        let declared_stream_end = stream_data_start
+            .saturating_add(length)
+            .min(self.tokenizer.input.len());
+
         // Read the stream data
-        let stream_data = self.tokenizer.read_exactly(length)?.to_vec();
+        let stream_data = match self.tokenizer.read_exactly(length) {
+            Ok(stream_data) => stream_data.to_vec(),
+            Err(TokenizerError::UnexpectedEndOfFile(_, _)) => {
+                if let Some((recovered_data_end, recovered_endstream_offset)) =
+                    find_nearby_endstream(
+                        self.tokenizer.input,
+                        stream_data_start,
+                        declared_stream_end,
+                    )
+                {
+                    let recovered_data = self
+                        .tokenizer
+                        .input
+                        .get(stream_data_start..recovered_data_end)
+                        .unwrap_or(&[])
+                        .to_vec();
+                    self.tokenizer.position = recovered_endstream_offset;
+                    self.read_keyword(STREAM_END)?;
+                    return Ok(recovered_data);
+                }
+
+                return Err(TokenizerError::UnexpectedEndOfFile(
+                    length,
+                    self.tokenizer.input.len().saturating_sub(stream_data_start),
+                )
+                .into());
+            }
+            Err(error) => return Err(error.into()),
+        };
 
         // There should be an end-of-line marker after the data and before `endstream`.
         self.try_read_end_of_line_marker();
 
         // Read the `endstream` keyword .
-        self.read_keyword(STREAM_END)?;
+        if let Err(original_error) = self.read_keyword(STREAM_END) {
+            if let Some((recovered_data_end, recovered_endstream_offset)) =
+                find_nearby_endstream(self.tokenizer.input, stream_data_start, declared_stream_end)
+            {
+                let recovered_data = self
+                    .tokenizer
+                    .input
+                    .get(stream_data_start..recovered_data_end)
+                    .unwrap_or(&[])
+                    .to_vec();
+                self.tokenizer.position = recovered_endstream_offset;
+                self.read_keyword(STREAM_END)?;
+                return Ok(recovered_data);
+            }
+
+            return Err(original_error);
+        }
 
         Ok(stream_data)
+    }
+}
+
+fn find_nearby_endstream(
+    input: &[u8],
+    stream_data_start: usize,
+    declared_stream_end: usize,
+) -> Option<(usize, usize)> {
+    const STREAM_END: &[u8] = b"endstream";
+
+    let mut best_candidate = None;
+
+    for (relative_offset, window) in input
+        .get(stream_data_start..)?
+        .windows(STREAM_END.len())
+        .enumerate()
+    {
+        if window != STREAM_END {
+            continue;
+        }
+
+        let endstream_offset = stream_data_start.saturating_add(relative_offset);
+        if let Some(next) = input
+            .get(endstream_offset.saturating_add(STREAM_END.len()))
+            .copied()
+            && !PdfParser::is_pdf_delimiter(next)
+        {
+            continue;
+        }
+
+        let stream_data_end = trim_stream_data_end(input, stream_data_start, endstream_offset);
+        let distance = endstream_offset.abs_diff(declared_stream_end);
+        match best_candidate {
+            Some((best_offset, _, best_distance))
+                if best_distance < distance
+                    || (best_distance == distance && best_offset <= endstream_offset) => {}
+            _ => {
+                best_candidate = Some((endstream_offset, stream_data_end, distance));
+            }
+        }
+    }
+
+    best_candidate.map(|(endstream_offset, stream_data_end, _)| (stream_data_end, endstream_offset))
+}
+
+fn trim_stream_data_end(input: &[u8], stream_data_start: usize, endstream_offset: usize) -> usize {
+    if endstream_offset <= stream_data_start {
+        return endstream_offset;
+    }
+
+    let last_byte_offset = endstream_offset.saturating_sub(1);
+    match input.get(last_byte_offset).copied() {
+        Some(b'\n') => match last_byte_offset
+            .checked_sub(1)
+            .and_then(|idx| input.get(idx))
+        {
+            Some(b'\r') if last_byte_offset.saturating_sub(1) >= stream_data_start => {
+                last_byte_offset.saturating_sub(1)
+            }
+            _ => last_byte_offset,
+        },
+        Some(b'\r') => last_byte_offset,
+        _ => endstream_offset,
     }
 }
 
@@ -95,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_stream_incorrect_length() {
+    fn test_parse_stream_recovers_incorrect_length_too_short() {
         let dictionary = Dictionary::new(
             vec![("Length".to_string(), ObjectVariant::Integer(5))] // Incorrect length
                 .into_iter()
@@ -106,21 +219,21 @@ mod tests {
         let mut parser = PdfParser::from(input.as_slice());
 
         let result = parser.parse_stream(&dictionary, &PassthroughResolver);
-        assert!(result.is_err());
+        assert_eq!(result.unwrap(), b"Hello World");
     }
 
     #[test]
-    fn test_parse_stream_with_extra_whitespace() {
+    fn test_parse_stream_recovers_incorrect_length_too_long() {
         let dictionary = Dictionary::new(
-            vec![("Length".to_string(), ObjectVariant::Integer(11))]
+            vec![("Length".to_string(), ObjectVariant::Integer(53))]
                 .into_iter()
                 .collect(),
         );
 
-        let input = b"stream\n   Hello World   \nendstream";
+        let input = b"stream\ntoString\nendstream\n";
         let mut parser = PdfParser::from(input.as_slice());
 
         let result = parser.parse_stream(&dictionary, &PassthroughResolver);
-        assert!(result.is_err()); // Extra whitespace should cause an error
+        assert_eq!(result.unwrap(), b"toString");
     }
 }

--- a/crates/pdf-parser/src/xref_builder.rs
+++ b/crates/pdf-parser/src/xref_builder.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashSet};
 
 use pdf_object::{
-    cross_reference_table::{CrossReferenceEntry, CrossReferenceTable},
+    cross_reference_table::{CrossReferenceEntry, CrossReferenceEntryType, CrossReferenceTable},
     object_resolver::PassthroughResolver,
     object_variant::ObjectVariant,
 };
@@ -96,13 +96,118 @@ fn recover_traditional_xref_offset(parser: &PdfParser, declared_offset: usize) -
         })
 }
 
-fn normalize_traditional_xref_offsets(table: &mut CrossReferenceTable, offset_delta: usize) {
+fn matches_indirect_object_header(
+    input: &[u8],
+    offset: usize,
+    object_number: usize,
+    generation_number: usize,
+) -> bool {
+    let object_number = object_number.to_string();
+    let generation_number = generation_number.to_string();
+    let object_number = object_number.as_bytes();
+    let generation_number = generation_number.as_bytes();
+
+    let Some(data) = input.get(offset..) else {
+        return false;
+    };
+    if !data.starts_with(object_number) {
+        return false;
+    }
+
+    let mut position = object_number.len();
+    position = match skip_required_whitespace(data, position) {
+        Some(position) => position,
+        None => return false,
+    };
+
+    let Some(remaining) = data.get(position..) else {
+        return false;
+    };
+    if !remaining.starts_with(generation_number) {
+        return false;
+    }
+
+    position = position.saturating_add(generation_number.len());
+    position = match skip_required_whitespace(data, position) {
+        Some(position) => position,
+        None => return false,
+    };
+
+    let Some(keyword) = data.get(position..position.saturating_add(3)) else {
+        return false;
+    };
+    if keyword != b"obj" {
+        return false;
+    }
+
+    match data.get(position.saturating_add(3)).copied() {
+        Some(next) => PdfParser::is_pdf_delimiter(next),
+        None => true,
+    }
+}
+
+fn skip_required_whitespace(input: &[u8], start: usize) -> Option<usize> {
+    let mut position = start;
+    let mut consumed = false;
+
+    while let Some(byte) = input.get(position).copied() {
+        if !PdfParser::is_pdf_whitespace(byte) {
+            break;
+        }
+        consumed = true;
+        position = position.saturating_add(1);
+    }
+
+    consumed.then_some(position)
+}
+
+fn find_nearby_indirect_object_offset(
+    input: &[u8],
+    object_number: usize,
+    generation_number: usize,
+    declared_offset: usize,
+    search_radius: usize,
+) -> Option<usize> {
+    let search_start = declared_offset.saturating_sub(search_radius);
+    let search_end = declared_offset
+        .saturating_add(search_radius)
+        .saturating_add(1)
+        .min(input.len());
+    let mut best_candidate = None;
+
+    for candidate in search_start..search_end {
+        if !matches_indirect_object_header(input, candidate, object_number, generation_number) {
+            continue;
+        }
+
+        let distance = candidate.abs_diff(declared_offset);
+        match best_candidate {
+            Some((best_offset, best_distance))
+                if best_distance < distance
+                    || (best_distance == distance && best_offset <= candidate) => {}
+            _ => best_candidate = Some((candidate, distance)),
+        }
+    }
+
+    best_candidate.map(|(candidate, _)| candidate)
+}
+
+fn repair_traditional_xref_offsets(
+    parser: &PdfParser,
+    table: &mut CrossReferenceTable,
+    offset_delta: usize,
+) {
+    const MIN_SEARCH_RADIUS: usize = 64;
+
     if offset_delta == 0 {
         return;
     }
 
-    for entry in table.entries.values_mut() {
-        let pdf_object::cross_reference_table::CrossReferenceEntryType::Normal {
+    let input = parser.tokenizer.input;
+    let search_radius = offset_delta.max(MIN_SEARCH_RADIUS);
+
+    for (&object_number, entry) in &mut table.entries {
+        let CrossReferenceEntryType::Normal {
             byte_offset,
             generation_number,
         } = &entry.entry_type
@@ -110,10 +215,38 @@ fn normalize_traditional_xref_offsets(table: &mut CrossReferenceTable, offset_de
             continue;
         };
 
-        let adjusted_offset = byte_offset
-            .checked_sub(offset_delta)
-            .unwrap_or(*byte_offset);
-        *entry = CrossReferenceEntry::new_normal(adjusted_offset, *generation_number);
+        if *byte_offset == 0
+            || matches_indirect_object_header(
+                input,
+                *byte_offset,
+                object_number,
+                *generation_number,
+            )
+        {
+            continue;
+        }
+
+        if let Some(adjusted_offset) = byte_offset.checked_sub(offset_delta)
+            && matches_indirect_object_header(
+                input,
+                adjusted_offset,
+                object_number,
+                *generation_number,
+            )
+        {
+            *entry = CrossReferenceEntry::new_normal(adjusted_offset, *generation_number);
+            continue;
+        }
+
+        if let Some(recovered_offset) = find_nearby_indirect_object_offset(
+            input,
+            object_number,
+            *generation_number,
+            *byte_offset,
+            search_radius,
+        ) {
+            *entry = CrossReferenceEntry::new_normal(recovered_offset, *generation_number);
+        }
     }
 }
 
@@ -130,7 +263,8 @@ fn parse_xref_section_with_recovery(
                 },
             )?;
             let mut table = parse_xref_section_at_offset(parser, recovered_offset)?;
-            normalize_traditional_xref_offsets(
+            repair_traditional_xref_offsets(
+                parser,
                 &mut table,
                 declared_offset.saturating_sub(recovered_offset),
             );
@@ -195,12 +329,87 @@ fn merge_xref_chain(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use super::*;
     use pdf_object::object_resolver::PassthroughResolver;
 
     fn format_xref_entry(offset: usize, generation: u16, used: bool) -> String {
         let kind = if used { 'n' } else { 'f' };
         format!("{:010} {:05} {} \n", offset, generation, kind)
+    }
+
+    fn build_issue139_like_pdf() -> (Vec<u8>, BTreeMap<usize, usize>) {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"%PDF-1.4\n");
+
+        let obj6_offset = data.len();
+        data.extend_from_slice(b"6 0 obj\n<<\n /Type /Catalog\n /Pages 5 0 R\n>>\nendobj\n\n");
+
+        let obj1_offset = data.len();
+        data.extend_from_slice(
+            b"1 0 obj\n<<\n /Type /Page\n /Parent 5 0 R\n /MediaBox [ 0 0 612 792 ]\n /Resources 3 0 R\n /Contents 2 0 R\n>>\nendobj\n\n",
+        );
+
+        let obj4_offset = data.len();
+        data.extend_from_slice(
+            b"4 0 obj\n<<\n /Type /Font\n /Subtype /Type1\n /Name /F1\n /BaseFont/Helvetica\n>>\nendobj\n\n",
+        );
+
+        let obj2_offset = data.len();
+        data.extend_from_slice(
+            b"2 0 obj\n<<\n /Length 53\n>>\nstream\ntoString\nendstream\nendobj\n\n",
+        );
+
+        let obj5_offset = data.len();
+        data.extend_from_slice(
+            b"5 0 obj\n<<\n /Type /Pages\n /Kids [ 1 0 R ]\n /Count 1\n>>\nendobj\n\n",
+        );
+
+        let obj3_offset = data.len();
+        data.extend_from_slice(
+            b"3 0 obj\n<<\n /ProcSet[/PDF/Text]\n /Font <</F1 4 0 R >>\n>>\nendobj\n\n",
+        );
+
+        let stream_payload_offset = data
+            .windows(b"toString".len())
+            .position(|window| window == b"toString")
+            .expect("stream payload should exist");
+
+        let xref_offset = data.len();
+        data.extend_from_slice(b"xref\n0 7\n");
+        data.extend_from_slice(format_xref_entry(0, 65535, false).as_bytes());
+        data.extend_from_slice(
+            format_xref_entry(obj1_offset.saturating_sub(8), 0, true).as_bytes(),
+        );
+        data.extend_from_slice(format_xref_entry(stream_payload_offset, 0, true).as_bytes());
+        data.extend_from_slice(
+            format_xref_entry(obj3_offset.saturating_add(4), 0, true).as_bytes(),
+        );
+        data.extend_from_slice(
+            format_xref_entry(obj4_offset.saturating_sub(3), 0, true).as_bytes(),
+        );
+        data.extend_from_slice(
+            format_xref_entry(obj5_offset.saturating_add(9), 0, true).as_bytes(),
+        );
+        data.extend_from_slice(format_xref_entry(obj6_offset, 0, true).as_bytes());
+
+        data.extend_from_slice(b"trailer\n<< /Size 7 /Root 6 0 R >>\n");
+        data.extend_from_slice(b"startxref\n");
+        data.extend_from_slice(format!("{}\n", xref_offset.saturating_add(36)).as_bytes());
+        data.extend_from_slice(b"%%EOF");
+
+        (
+            data,
+            BTreeMap::from([
+                (1, obj1_offset),
+                (2, obj2_offset),
+                (3, obj3_offset),
+                (4, obj4_offset),
+                (5, obj5_offset),
+                (6, obj6_offset),
+            ]),
+        )
     }
 
     #[test]
@@ -379,5 +588,36 @@ mod tests {
 
         let entry2 = table.entries.get(&2).expect("obj 2 should exist");
         assert_eq!(entry2.byte_offset(), Some(obj2_offset));
+    }
+
+    #[test]
+    fn test_build_xref_table_repairs_issue139_offsets() {
+        let (data, expected_offsets) = build_issue139_like_pdf();
+        let mut parser = PdfParser::from(data.as_slice());
+        let table = parser
+            .build_xref_table()
+            .expect("xref recovery should repair nearby object offsets");
+
+        for object_number in 1..=6 {
+            let entry = table
+                .entries
+                .get(&object_number)
+                .expect("expected normal object entry");
+            let expected_offset = expected_offsets
+                .get(&object_number)
+                .copied()
+                .expect("expected known object offset");
+            let byte_offset = entry
+                .byte_offset()
+                .expect("entry should have a byte offset");
+            assert_eq!(
+                byte_offset, expected_offset,
+                "object {object_number} should recover its true offset"
+            );
+            assert!(
+                matches_indirect_object_header(data.as_slice(), byte_offset, object_number, 0),
+                "object {object_number} should point to its indirect object header, got offset {byte_offset}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Repair recovered traditional xref tables entry-by-entry instead of applying one global offset delta, so malformed startxref values do not redirect objects into stream data.

Recover nearby endstream markers when stream /Length is wrong.