### PR TITLE
pdf-filter: Add ASCIIHexDecode support

### DIFF
--- a/crates/pdf-filter/src/asciihex.rs
+++ b/crates/pdf-filter/src/asciihex.rs
@@ -1,0 +1,97 @@
+use crate::error::FilterError;
+
+/// Converts an ASCII hex digit to its numeric value (0–15).
+/// Caller must ensure the byte is a valid hex digit.
+fn hex_digit_value(byte: u8) -> Result<u8, FilterError> {
+    match byte {
+        b'0'..=b'9' => Ok(byte.saturating_sub(b'0')),
+        b'a' => Ok(10),
+        b'b' => Ok(11),
+        b'c' => Ok(12),
+        b'd' => Ok(13),
+        b'e' => Ok(14),
+        b'f' => Ok(15),
+        b'A' => Ok(10),
+        b'B' => Ok(11),
+        b'C' => Ok(12),
+        b'D' => Ok(13),
+        b'E' => Ok(14),
+        b'F' => Ok(15),
+        _ => Err(FilterError::Decompression(format!(
+            "ASCIIHex: invalid character 0x{byte:02X}"
+        ))),
+    }
+}
+
+/// Decodes ASCIIHexDecode-encoded stream data.
+///
+/// ASCIIHex encodes binary data as hexadecimal digits. ASCII whitespace is
+/// ignored, the `>` character marks end of data, and a final single nibble is
+/// treated as the high nibble of the last byte with a low nibble of `0`.
+///
+/// # Errors
+///
+/// Returns [`FilterError::Decompression`] if a non-whitespace, non-hexadecimal
+/// byte is encountered before the end-of-data marker.
+pub(crate) fn decode_ascii_hex(stream_data: &[u8]) -> Result<Vec<u8>, FilterError> {
+    let mut output = Vec::with_capacity(stream_data.len() / 2);
+    let mut high_nibble: Option<u8> = None;
+
+    for &byte in stream_data {
+        if byte == b'>' {
+            break;
+        }
+
+        if byte.is_ascii_whitespace() {
+            continue;
+        }
+
+        let nibble = hex_digit_value(byte)?;
+
+        match high_nibble.take() {
+            Some(high) => output.push((high << 4) | nibble),
+            None => high_nibble = Some(nibble),
+        }
+    }
+
+    if let Some(high) = high_nibble {
+        output.push(high << 4);
+    }
+
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_ascii_hex_basic() {
+        let decoded = decode_ascii_hex(b"48656c6c6f>").expect("decode failed");
+        assert_eq!(&decoded, b"Hello");
+    }
+
+    #[test]
+    fn test_decode_ascii_hex_whitespace_ignored() {
+        let decoded = decode_ascii_hex(b"48 65\n6c\t6c 6f>").expect("decode failed");
+        assert_eq!(&decoded, b"Hello");
+    }
+
+    #[test]
+    fn test_decode_ascii_hex_odd_nibble_is_padded() {
+        let decoded = decode_ascii_hex(b"6>").expect("decode failed");
+        assert_eq!(decoded, vec![0x60]);
+    }
+
+    #[test]
+    fn test_decode_ascii_hex_stops_at_end_marker() {
+        let decoded = decode_ascii_hex(b"48656c6c6f>garbage").expect("decode failed");
+        assert_eq!(&decoded, b"Hello");
+    }
+
+    #[test]
+    fn test_decode_ascii_hex_invalid_character_is_error() {
+        let result = decode_ascii_hex(b"48GG>");
+        assert!(result.is_err());
+    }
+}

--- a/crates/pdf-filter/src/error.rs
+++ b/crates/pdf-filter/src/error.rs
@@ -12,7 +12,7 @@ pub enum FilterError {
     /// The stream data could not be decompressed.
     ///
     /// This covers failures from zlib (FlateDecode), JPEG (DCTDecode),
-    /// JPEG 2000 (JPXDecode), and ASCII85Decode decoders.
+    /// JPEG 2000 (JPXDecode), ASCII85Decode, and ASCIIHexDecode decoders.
     #[error("decompression failed: {0}")]
     Decompression(String),
 

--- a/crates/pdf-filter/src/filter.rs
+++ b/crates/pdf-filter/src/filter.rs
@@ -43,6 +43,12 @@ pub enum Filter {
     /// bytes. The special character `z` represents four zero bytes. The
     /// end-of-data marker is `~>`.
     ASCII85Decode,
+    /// The ASCII hexadecimal filter, which decodes ASCIIHex-encoded stream data.
+    ///
+    /// ASCIIHex encodes arbitrary binary data as hexadecimal digits. ASCII
+    /// whitespace is ignored, `>` marks end-of-data, and a final single digit
+    /// is padded with a trailing `0` nibble.
+    ASCIIHexDecode,
     /// The LZW (Lempel-Ziv-Welch) filter, a lossless compression algorithm.
     ///
     /// Based on variable-length code substitution. This was used in older PDFs
@@ -63,6 +69,7 @@ impl From<Cow<'_, str>> for Filter {
             "JPXDecode" => Self::JPXDecode,
             "CCITTFaxDecode" => Self::CCITTFaxDecode,
             "ASCII85Decode" => Self::ASCII85Decode,
+            "ASCIIHexDecode" => Self::ASCIIHexDecode,
             "LZWDecode" => Self::LZWDecode,
             _ => Self::Unsupported(name.into_owned()),
         }
@@ -83,6 +90,7 @@ impl fmt::Display for Filter {
             Self::FlateDecode => f.write_str("FlateDecode"),
             Self::CCITTFaxDecode => f.write_str("CCITTFaxDecode"),
             Self::ASCII85Decode => f.write_str("ASCII85Decode"),
+            Self::ASCIIHexDecode => f.write_str("ASCIIHexDecode"),
             Self::LZWDecode => f.write_str("LZWDecode"),
             Self::Unsupported(name) => f.write_str(name),
         }
@@ -278,6 +286,10 @@ pub fn decode(stream: &StreamObject) -> Result<Cow<'_, [u8]>, FilterError> {
                 let decoded = crate::ascii85::decode_ascii85(&data)?;
                 data = Cow::Owned(decoded);
             }
+            Filter::ASCIIHexDecode => {
+                let decoded = crate::asciihex::decode_ascii_hex(&data)?;
+                data = Cow::Owned(decoded);
+            }
             Filter::CCITTFaxDecode => {
                 let ccitt_params = match params {
                     DecodeParms::CcittFax(p) => p,
@@ -363,4 +375,39 @@ fn parse_decode_params(
             _ => DecodeParms::None,
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{borrow::Cow, collections::BTreeMap};
+
+    use pdf_object::{dictionary::Dictionary, object_variant::ObjectVariant, stream::StreamObject};
+
+    use super::*;
+
+    #[test]
+    fn test_filter_name_round_trip_ascii_hex() {
+        let filter = Filter::from(Cow::Borrowed("ASCIIHexDecode"));
+        assert_eq!(filter, Filter::ASCIIHexDecode);
+        assert_eq!(filter.to_string(), "ASCIIHexDecode");
+    }
+
+    #[test]
+    fn test_decode_ascii_hex_stream() {
+        let mut dict = BTreeMap::new();
+        dict.insert(
+            "Filter".to_string(),
+            ObjectVariant::Name(b"ASCIIHexDecode".to_vec()),
+        );
+
+        let stream = StreamObject::new(
+            1,
+            0,
+            Box::new(Dictionary::new(dict)),
+            b"48 65 6c 6c 6f>ignored".to_vec(),
+        );
+
+        let decoded = decode(&stream).expect("decode failed");
+        assert_eq!(decoded.as_ref(), b"Hello");
+    }
 }

--- a/crates/pdf-filter/src/lib.rs
+++ b/crates/pdf-filter/src/lib.rs
@@ -9,12 +9,14 @@
 //! - **JPXDecode** — JPEG 2000
 //! - **CCITTFaxDecode** — Group 3 / Group 4 fax compression
 //! - **ASCII85Decode** — ASCII base-85 encoding
+//! - **ASCIIHexDecode** — ASCII hexadecimal encoding
 //!
 //! The main entry point is [`filter::decode`], which accepts a
 //! [`StreamObject`](pdf_object::stream::StreamObject) and applies the full
 //! filter chain declared in its `/Filter` dictionary entry.
 
 pub(crate) mod ascii85;
+pub(crate) mod asciihex;
 mod bitreader;
 pub(crate) mod ccitt;
 pub(crate) mod ccitt_fax_params;


### PR DESCRIPTION
Add a dedicated ASCIIHex decoder, wire it into the filter dispatch, and cover the public decode path with focused tests.

The decoder skips whitespace, stops at the end marker, pads a trailing nibble, and returns a decompression error for invalid bytes.