### PR TITLE
pdf-parser: recover from stale xref offsets

### DIFF
--- a/crates/pdf-font/src/glyph_widths_map.rs
+++ b/crates/pdf-font/src/glyph_widths_map.rs
@@ -122,9 +122,6 @@ impl GlyphWidthsMap {
         if widths_arr.is_empty() {
             return Err(GlyphWidthsMapError::EmptyWidthsArray { cid });
         }
-        if self.runs.contains_key(&cid) {
-            return Err(GlyphWidthsMapError::DuplicateCIDStart { cid });
-        }
         let widths = widths_arr
             .iter()
             .map(|v| v.try_number::<f32>(objects))
@@ -197,9 +194,6 @@ impl GlyphWidthsMap {
                 c_first: cid,
                 c_last,
             });
-        }
-        if self.runs.contains_key(&cid) {
-            return Err(GlyphWidthsMapError::DuplicateCIDStart { cid });
         }
 
         let overlapping_runs = self
@@ -634,8 +628,22 @@ mod tests {
         let result = GlyphWidthsMap::from_array(&input_array, &PassthroughResolver);
         assert!(matches!(
             result,
-            Err(GlyphWidthsMapError::DuplicateCIDStart { cid: 0 })
+            Err(GlyphWidthsMapError::OverlappingRange { cid: 0 })
         ));
+    }
+
+    #[test]
+    fn test_from_array_allows_duplicate_start_with_same_width() {
+        // [ 0 [500] 0 [500] ]
+        let input_array = vec![
+            num_i64(0),
+            arr(vec![num_f32(500.0)]),
+            num_i64(0),
+            arr(vec![num_f32(500.0)]),
+        ];
+        let glyph_widths_map =
+            GlyphWidthsMap::from_array(&input_array, &PassthroughResolver).unwrap();
+        assert_eq!(glyph_widths_map.get_width(0), Some(500.0));
     }
 
     #[test]

--- a/crates/pdf-parser/src/xref_builder.rs
+++ b/crates/pdf-parser/src/xref_builder.rs
@@ -9,37 +9,66 @@ use pdf_object::{
 use crate::{error::ParserError, parser::PdfParser};
 
 impl PdfParser<'_> {
-    /// Locates the cross-reference section via the trailing `startxref` marker,
-    /// then follows the `/Prev` chain to produce a fully-merged [`CrossReferenceTable`].
-    ///
-    /// # Note on linearized PDFs
-    ///
-    /// This implementation always scans for the *last* `startxref` in the file.
-    /// For linearized PDFs the last `startxref` points to the linearization
-    /// parameter dictionary, not the primary xref. Full linearized-PDF support
-    /// (using the *first* `startxref`) is not yet implemented.
-    /// TODO: handle linearized PDFs by using the first `startxref` offset instead.
+    /// Locates a cross-reference section via `startxref` markers, then follows
+    /// the `/Prev` chain to produce a fully-merged [`CrossReferenceTable`].
     pub fn build_xref_table(&mut self) -> Result<CrossReferenceTable, ParserError> {
-        let xref_offset = self.find_startxref_offset()?;
-        merge_xref_chain(self, xref_offset)
+        let xref_offsets = self.find_startxref_offsets()?;
+        let mut last_error = None;
+
+        for xref_offset in xref_offsets {
+            match merge_xref_chain(self, xref_offset)
+                .and_then(|table| validate_xref_table(self, table, xref_offset))
+            {
+                Ok(table) => return Ok(table),
+                Err(error) => last_error = Some(error),
+            }
+        }
+
+        Err(last_error.unwrap_or(ParserError::MissingStartXref))
     }
 
-    /// Scans backward through the input for the last `startxref` keyword and extracts
-    /// the byte offset that follows it.
-    fn find_startxref_offset(&mut self) -> Result<usize, ParserError> {
+    /// Scans backward through the input for `startxref` keywords and extracts
+    /// the byte offsets that follow them, newest first.
+    fn find_startxref_offsets(&mut self) -> Result<Vec<usize>, ParserError> {
         const STARTXREF_KEYWORD: &[u8] = b"startxref";
 
-        let startxref_pos = self
+        let positions: Vec<usize> = self
             .tokenizer
             .input
             .windows(STARTXREF_KEYWORD.len())
-            .rposition(|window| window == STARTXREF_KEYWORD)
-            .ok_or(ParserError::MissingStartXref)?;
+            .enumerate()
+            .filter_map(|(position, window)| {
+                if window == STARTXREF_KEYWORD {
+                    Some(position)
+                } else {
+                    None
+                }
+            })
+            .collect();
 
-        self.tokenizer.position = startxref_pos;
-        self.read_keyword(b"startxref")?;
-        self.read_number::<usize>(true)
-            .map_err(|_| ParserError::MissingStartXref)
+        if positions.is_empty() {
+            return Err(ParserError::MissingStartXref);
+        }
+
+        let mut offsets = Vec::with_capacity(positions.len());
+        let original_position = self.tokenizer.position;
+
+        for startxref_pos in positions.into_iter().rev() {
+            self.tokenizer.position = startxref_pos;
+            if self.read_keyword(b"startxref").is_ok()
+                && let Ok(offset) = self.read_number::<usize>(true)
+            {
+                offsets.push(offset);
+            }
+        }
+
+        self.tokenizer.position = original_position;
+
+        if offsets.is_empty() {
+            return Err(ParserError::MissingStartXref);
+        }
+
+        Ok(offsets)
     }
 }
 
@@ -250,6 +279,36 @@ fn repair_traditional_xref_offsets(
     }
 }
 
+fn validate_xref_table(
+    parser: &PdfParser,
+    table: CrossReferenceTable,
+    xref_offset: usize,
+) -> Result<CrossReferenceTable, ParserError> {
+    let input = parser.tokenizer.input;
+
+    for (&object_number, entry) in &table.entries {
+        let CrossReferenceEntryType::Normal {
+            byte_offset,
+            generation_number,
+        } = &entry.entry_type
+        else {
+            continue;
+        };
+
+        if *byte_offset == 0 {
+            continue;
+        }
+
+        if !matches_indirect_object_header(input, *byte_offset, object_number, *generation_number) {
+            return Err(ParserError::InvalidXrefAtOffset {
+                offset: xref_offset,
+            });
+        }
+    }
+
+    Ok(table)
+}
+
 fn parse_xref_section_with_recovery(
     parser: &mut PdfParser,
     declared_offset: usize,
@@ -456,6 +515,49 @@ mod tests {
             .try_number(&PassthroughResolver)
             .unwrap();
         assert_eq!(size, 2);
+    }
+
+    #[test]
+    fn test_build_xref_table_falls_back_from_invalid_newer_xref() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"%PDF-1.7\n");
+
+        let obj1_offset = data.len();
+        data.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        let obj2_offset = data.len();
+        data.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n");
+
+        let xref1_offset = data.len();
+        data.extend_from_slice(b"xref\n0 3\n");
+        data.extend_from_slice(format_xref_entry(0, 65535, false).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj1_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj2_offset, 0, true).as_bytes());
+        data.extend_from_slice(b"trailer\n<< /Size 3 /Root 1 0 R >>\n");
+        data.extend_from_slice(b"startxref\n");
+        data.extend_from_slice(format!("{}\n", xref1_offset).as_bytes());
+        data.extend_from_slice(b"%%EOF\n");
+
+        let invalid_obj2_offset = obj2_offset.saturating_add(2);
+        let xref2_offset = data.len();
+        data.extend_from_slice(b"xref\n0 3\n");
+        data.extend_from_slice(format_xref_entry(0, 65535, false).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj1_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(invalid_obj2_offset, 0, true).as_bytes());
+        data.extend_from_slice(b"trailer\n<< /Size 3 /Root 1 0 R /Prev ");
+        data.extend_from_slice(format!("{}", xref1_offset).as_bytes());
+        data.extend_from_slice(b" >>\n");
+        data.extend_from_slice(b"startxref\n");
+        data.extend_from_slice(format!("{}\n", xref2_offset).as_bytes());
+        data.extend_from_slice(b"%%EOF");
+
+        let mut parser = PdfParser::from(data.as_slice());
+        let table = parser
+            .build_xref_table()
+            .expect("invalid newer xref should fall back to older valid xref");
+
+        let entry2 = table.entries.get(&2).expect("obj 2 should exist");
+        assert_eq!(entry2.byte_offset(), Some(obj2_offset));
     }
 
     #[test]

--- a/examples/skia.rs
+++ b/examples/skia.rs
@@ -26,6 +26,10 @@ use pdf_document::{document::PdfDocument, reader::PdfReader};
 use pdf_graphics_skia::gpu_state::SkiaGpuState;
 use pdf_renderer::PdfRenderer;
 
+const DEFAULT_INITIAL_WINDOW_SIZE: (u32, u32) = (800, 600);
+const MAX_INITIAL_WINDOW_WIDTH: f32 = 1200.0;
+const MAX_INITIAL_WINDOW_HEIGHT: f32 = 900.0;
+
 /// Errors that can occur in the PDF viewer application.
 #[derive(Debug, Error)]
 pub enum AppError {
@@ -73,8 +77,23 @@ fn main() -> Result<(), AppError> {
 fn initial_window_size(doc: &PdfDocument) -> (u32, u32) {
     doc.get_page(0)
         .and_then(|p| p.media_box.as_ref())
-        .map(|mb| (mb.width().max(1.0) as u32, mb.height().max(1.0) as u32))
-        .unwrap_or((800, 600))
+        .map(|mb| fit_initial_window_size(mb.width(), mb.height()))
+        .unwrap_or(DEFAULT_INITIAL_WINDOW_SIZE)
+}
+
+fn fit_initial_window_size(width: f32, height: f32) -> (u32, u32) {
+    if !width.is_finite() || !height.is_finite() || width <= 0.0 || height <= 0.0 {
+        return DEFAULT_INITIAL_WINDOW_SIZE;
+    }
+
+    let scale = (MAX_INITIAL_WINDOW_WIDTH / width)
+        .min(MAX_INITIAL_WINDOW_HEIGHT / height)
+        .min(1.0);
+
+    (
+        (width * scale).round().max(1.0) as u32,
+        (height * scale).round().max(1.0) as u32,
+    )
 }
 
 struct Application {
@@ -227,7 +246,17 @@ fn run(document: PdfDocument) -> Result<(), AppError> {
     let window = window.ok_or_else(|| AppError::WindowCreation("no window created".into()))?;
     let raw_handle = window.window_handle()?.as_raw();
 
-    let (w, h): (u32, u32) = window.inner_size().into();
+    let initial_size = window.inner_size();
+    let w = if initial_size.width == 0 {
+        init_w
+    } else {
+        initial_size.width
+    };
+    let h = if initial_size.height == 0 {
+        init_h
+    } else {
+        initial_size.height
+    };
     let nz_w = NonZeroU32::new(w).ok_or(AppError::InvalidDimension)?;
     let nz_h = NonZeroU32::new(h).ok_or(AppError::InvalidDimension)?;
 


### PR DESCRIPTION
Try startxref candidates from newest to oldest and validate normal xref entries before accepting a merged table. This lets malformed trailing xrefs fall back to older valid tables instead of parsing from offsets inside object data.

Tolerate duplicate CID width entries when they repeat the same value, while preserving errors for conflicting overlaps. Cap the Skia example startup size and handle transient zero window dimensions during surface creation.