### PR TITLE
pdf-content-stream: best-effort parse corrupted streams

### DIFF
--- a/crates/pdf-content-stream/src/content_stream.rs
+++ b/crates/pdf-content-stream/src/content_stream.rs
@@ -24,8 +24,12 @@ impl ContentStream {
     /// decoding and parsing each stream in order into the same operator buffer
     /// without concatenating the decoded bytes first.
     ///
-    /// A content-stream ID is allocated only after parsing succeeds. If
-    /// parsing fails, the allocator is left unchanged.
+    /// Content-stream syntax is parsed best-effort: malformed operators or
+    /// operands are skipped and any recoverable operators are returned.
+    ///
+    /// A content-stream ID is allocated only after the content object resolves
+    /// and decoded bytes are parsed. If resolution or decoding fails, the
+    /// allocator is left unchanged.
     ///
     /// # Parameters
     ///
@@ -42,8 +46,8 @@ impl ContentStream {
     ///
     /// # Errors
     ///
-    /// Returns [`PdfOperatorError`] if parsing fails or if the ID allocator is
-    /// exhausted.
+    /// Returns [`PdfOperatorError`] if content resolution/decoding fails or if
+    /// the ID allocator is exhausted.
     pub fn new(
         content: &ObjectVariant,
         objects: &dyn ObjectResolver,
@@ -89,7 +93,7 @@ impl ContentStream {
     /// - missing `/Contents` returns `Ok(None)` without consuming an ID
     /// - a single stream is parsed directly
     /// - an array of streams is parsed in order without concatenating the
-    ///   decoded bytes first
+    ///   decoded bytes first, skipping malformed content syntax best-effort
     /// - any other resolved type produces a type-mismatch error
     ///
     /// # Parameters
@@ -106,8 +110,8 @@ impl ContentStream {
     ///
     /// # Errors
     ///
-    /// Returns [`PdfOperatorError`] if resolution, decoding, or parsing fails,
-    /// or if `/Contents` resolves to a non-stream, non-array value.
+    /// Returns [`PdfOperatorError`] if resolution or decoding fails, or if
+    /// `/Contents` resolves to a non-stream, non-array value.
     pub fn from_dictionary(
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
@@ -324,19 +328,23 @@ mod tests {
     }
 
     #[test]
-    fn content_stream_new_failure_does_not_consume_an_id() {
+    fn content_stream_new_skips_malformed_inline_image_and_consumes_an_id() {
         let mut ids = ContentStreamIdAllocator::new();
-        let err = match ContentStream::new(
-            &ObjectVariant::Stream(stream_object(1, b"BI /W 1 /H 1 ID abc")),
+        let parsed = ContentStream::new(
+            &ObjectVariant::Stream(stream_object(1, b"BI /W 1 /H 1 ID abc Q")),
             &PassthroughResolver,
             &mut ids,
-        ) {
-            Ok(_) => panic!("malformed inline image should fail"),
-            Err(err) => err,
-        };
+        )
+        .expect("malformed inline image should be skipped");
 
-        assert!(matches!(err, PdfOperatorError::ParserError(_)));
-        assert_eq!(ids.next_id().expect("id should still be zero"), 0);
+        assert_eq!(parsed.id, 0);
+        assert_eq!(
+            parsed.operators,
+            vec![PdfOperatorVariant::RestoreGraphicsState(
+                RestoreGraphicsState
+            )]
+        );
+        assert_eq!(ids.next_id().expect("next id should advance"), 1);
     }
 
     #[test]

--- a/crates/pdf-content-stream/src/operator_stream_parser.rs
+++ b/crates/pdf-content-stream/src/operator_stream_parser.rs
@@ -43,13 +43,24 @@ impl<'a, 'out> OperatorStreamParser<'a, 'out> {
             return Ok(false);
         };
 
-        if next_item_is_operator(next_byte) {
-            self.parse_operator_from_stream()?;
+        let start_position = self.parser.tokenizer.position;
+        let result = if next_item_is_operator(next_byte) {
+            self.parse_operator_from_stream().map(|()| true)
         } else {
-            return self.parse_operand_or_stop();
-        }
+            self.parse_operand_or_stop()
+        };
 
-        Ok(true)
+        match result {
+            Ok(parsed) => Ok(parsed),
+            Err(error) if is_truncated_operand_error(&error) => {
+                self.operands.clear();
+                Ok(false)
+            }
+            Err(_) => {
+                self.recover_after_malformed_item(start_position);
+                Ok(true)
+            }
+        }
     }
 
     /// Skips inter-token whitespace and comments before reading the next item.
@@ -116,6 +127,15 @@ impl<'a, 'out> OperatorStreamParser<'a, 'out> {
     fn push_if_parsed(&mut self, operator: Option<PdfOperatorVariant>) {
         if let Some(operator) = operator {
             self.out.push(operator);
+        }
+    }
+
+    /// Drops malformed syntax and guarantees the parser can try the next byte.
+    fn recover_after_malformed_item(&mut self, start_position: usize) {
+        self.operands.clear();
+
+        if self.parser.tokenizer.position <= start_position {
+            let _ = self.parser.tokenizer.read_exactly(1);
         }
     }
 }
@@ -366,6 +386,78 @@ mod tests {
         assert!(matches!(
             parser.out.get(1),
             Some(PdfOperatorVariant::SetLineCapStyle(_))
+        ));
+    }
+
+    #[test]
+    fn parse_next_item_recovers_from_leading_invalid_delimiter() {
+        let mut out = Vec::new();
+        let mut parser = OperatorStreamParser::new(b") q", &mut out);
+
+        while parser
+            .parse_next_item()
+            .expect("invalid delimiter should be skipped")
+        {}
+
+        assert!(parser.operands.is_empty());
+        assert_eq!(parser.out.len(), 1);
+        assert!(matches!(
+            parser.out.first(),
+            Some(PdfOperatorVariant::SaveGraphicsState(_))
+        ));
+    }
+
+    #[test]
+    fn parse_next_item_recovers_from_corrupt_operand_before_valid_operator() {
+        let mut out = Vec::new();
+        let mut parser = OperatorStreamParser::new(b"[ ) 0 J", &mut out);
+
+        while parser
+            .parse_next_item()
+            .expect("corrupt operand should be skipped")
+        {}
+
+        assert!(parser.operands.is_empty());
+        assert_eq!(parser.out.len(), 1);
+        assert!(matches!(
+            parser.out.first(),
+            Some(PdfOperatorVariant::SetLineCapStyle(_))
+        ));
+    }
+
+    #[test]
+    fn parse_next_item_recovers_from_invalid_operator_operand_value() {
+        let mut out = Vec::new();
+        let mut parser = OperatorStreamParser::new(b"9 J q", &mut out);
+
+        while parser
+            .parse_next_item()
+            .expect("invalid operator operand should be skipped")
+        {}
+
+        assert!(parser.operands.is_empty());
+        assert_eq!(parser.out.len(), 1);
+        assert!(matches!(
+            parser.out.first(),
+            Some(PdfOperatorVariant::SaveGraphicsState(_))
+        ));
+    }
+
+    #[test]
+    fn parse_next_item_recovers_from_malformed_inline_image() {
+        let mut out = Vec::new();
+        let mut parser = OperatorStreamParser::new(b"BI /W 1 /H 1 ID abc Q", &mut out);
+
+        while parser
+            .parse_next_item()
+            .expect("malformed inline image should be skipped")
+        {}
+
+        assert!(parser.operands.is_empty());
+        assert_eq!(parser.out.len(), 1);
+        assert!(matches!(
+            parser.out.first(),
+            Some(PdfOperatorVariant::RestoreGraphicsState(_))
         ));
     }
 }

--- a/crates/pdf-content-stream/tests/parser_api.rs
+++ b/crates/pdf-content-stream/tests/parser_api.rs
@@ -4,7 +4,7 @@ use pdf_content_stream::{ContentStream, ContentStreamIdAllocator};
 use pdf_content_stream_operators::{
     TextElement,
     compatibility_operators::{BeginCompatibility, EndCompatibility},
-    graphics_state_operators::SaveGraphicsState,
+    graphics_state_operators::{RestoreGraphicsState, SaveGraphicsState},
     path_operators::{LineTo, MoveTo},
     recording_pdf_operator_backend::{RecordedOperation, RecordingBackend},
     text_showing_operators::ShowTextArray,
@@ -220,22 +220,23 @@ fn content_stream_new_rejects_non_stream_array_entries() {
 }
 
 #[test]
-fn content_stream_new_failure_does_not_consume_an_id() {
+fn content_stream_new_skips_malformed_inline_image_and_consumes_an_id() {
     let mut ids = ContentStreamIdAllocator::new();
-    let err = match ContentStream::new(
-        &ObjectVariant::Stream(stream_object(1, b"BI /W 1 /H 1 ID abc")),
+    let parsed = ContentStream::new(
+        &ObjectVariant::Stream(stream_object(1, b"BI /W 1 /H 1 ID abc Q")),
         &PassthroughResolver,
         &mut ids,
-    ) {
-        Ok(_) => panic!("malformed inline image should fail"),
-        Err(err) => err,
-    };
+    )
+    .expect("malformed inline image should be skipped");
 
-    assert!(matches!(
-        err,
-        pdf_content_stream_operators::error::PdfOperatorError::ParserError(_)
-    ));
-    assert_eq!(ids.next_id().expect("id should still be zero"), 0);
+    assert_eq!(parsed.id, 0);
+    assert_eq!(
+        parsed.operators,
+        vec![PdfOperatorVariant::RestoreGraphicsState(
+            RestoreGraphicsState
+        )]
+    );
+    assert_eq!(ids.next_id().expect("next id should advance"), 1);
 }
 
 #[test]


### PR DESCRIPTION
Make content-stream parsing recover from malformed tokens, operator syntax, and inline images without aborting the full stream. Recovery now clears pending operands, guarantees cursor progress, and lets later operators parse normally.

Update the content-stream API docs and tests to reflect that syntax corruption is skipped best-effort, while resolution and decoding errors remain fatal.