### PR TITLE
pdf-color-space: accept single-name color space arrays

### DIFF
--- a/crates/pdf-color-space/src/color_space_reader.rs
+++ b/crates/pdf-color-space/src/color_space_reader.rs
@@ -77,6 +77,10 @@ fn parse_color_space_array(
     arr: &[ObjectVariant],
     depth: usize,
 ) -> Result<ColorSpace, ColorSpaceError> {
+    if let [single] = arr {
+        return parse_color_space_name(single.try_str(objects)?.as_ref());
+    }
+
     // Get the color space type (first element)
     let cs_type = arr
         .first()
@@ -126,5 +130,76 @@ fn parse_color_space_name(name: &str) -> Result<ColorSpace, ColorSpaceError> {
         unknown => Err(ColorSpaceError::InvalidColorSpace {
             description: format!("unsupported color space name: /{unknown}"),
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pdf_object::{object_resolver::PassthroughResolver, object_variant::ObjectVariant};
+
+    use crate::{color_space::ColorSpace, error::ColorSpaceError};
+
+    fn name(value: &str) -> ObjectVariant {
+        ObjectVariant::Name(value.as_bytes().to_vec())
+    }
+
+    #[test]
+    fn parses_single_name_device_color_space_arrays() {
+        let cases = [
+            (ObjectVariant::Array(vec![name("DeviceGray")]), ColorSpace::DeviceGray),
+            (ObjectVariant::Array(vec![name("DeviceRGB")]), ColorSpace::DeviceRGB),
+            (ObjectVariant::Array(vec![name("DeviceCMYK")]), ColorSpace::DeviceCMYK),
+        ];
+
+        for (object, expected) in cases {
+            let parsed = ColorSpace::from_object(&object, &PassthroughResolver).unwrap();
+
+            match (parsed, expected) {
+                (ColorSpace::DeviceGray, ColorSpace::DeviceGray)
+                | (ColorSpace::DeviceRGB, ColorSpace::DeviceRGB)
+                | (ColorSpace::DeviceCMYK, ColorSpace::DeviceCMYK) => {}
+                (parsed, expected) => {
+                    panic!("expected {expected:?} for single-name array, got {parsed:?}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn parses_single_name_pattern_array() {
+        let parsed = ColorSpace::from_object(
+            &ObjectVariant::Array(vec![name("Pattern")]),
+            &PassthroughResolver,
+        )
+        .unwrap();
+
+        assert!(matches!(parsed, ColorSpace::Pattern(None)));
+    }
+
+    #[test]
+    fn rejects_empty_color_space_array() {
+        let error =
+            ColorSpace::from_object(&ObjectVariant::Array(Vec::new()), &PassthroughResolver)
+                .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ColorSpaceError::InvalidColorSpace { description } if description == "empty color space array"
+        ));
+    }
+
+    #[test]
+    fn rejects_unsupported_multi_element_color_space_array() {
+        let error = ColorSpace::from_object(
+            &ObjectVariant::Array(vec![name("DeviceGray"), ObjectVariant::Integer(1)]),
+            &PassthroughResolver,
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ColorSpaceError::InvalidColorSpace { description }
+                if description == "unsupported color space type: /DeviceGray (array with 2 elements)"
+        ));
     }
 }

--- a/crates/pdf-document/src/reader.rs
+++ b/crates/pdf-document/src/reader.rs
@@ -1105,4 +1105,67 @@ mod tests {
         let document = result.unwrap();
         assert_eq!(document.page_count(), 1);
     }
+
+    #[test]
+    fn test_sampled_function_shading_with_single_name_array_color_space_loads_normally() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"%PDF-1.7\n");
+
+        let obj1_offset = data.len();
+        data.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+        let obj2_offset = data.len();
+        data.extend_from_slice(
+            b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 100 100] >>\nendobj\n",
+        );
+
+        let obj3_offset = data.len();
+        data.extend_from_slice(
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources 4 0 R >>\nendobj\n",
+        );
+
+        let obj4_offset = data.len();
+        data.extend_from_slice(
+            b"4 0 obj\n<< /Shading << /Sh1 5 0 R >> /ColorSpace << /CS1 [ /DeviceGray ] >> >>\nendobj\n",
+        );
+
+        let obj5_offset = data.len();
+        data.extend_from_slice(
+            b"5 0 obj\n<< /ShadingType 2 /ColorSpace [ /DeviceGray ] /Coords [0 0 100 0] /Function 6 0 R >>\nendobj\n",
+        );
+
+        let obj6_offset = data.len();
+        data.extend_from_slice(
+            b"6 0 obj\n<< /FunctionType 0 /Domain [0 1] /Range [0 1] /Size [4] /BitsPerSample 8 /Length 4 >>\nstream\n",
+        );
+        data.extend_from_slice(&[0x00, 0x55, 0xAA, 0xFF]);
+        data.extend_from_slice(b"\nendstream\nendobj\n");
+
+        let xref_offset = data.len();
+        data.extend_from_slice(b"xref\n0 7\n");
+        data.extend_from_slice(format_xref_entry(0, 65535, false).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj1_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj2_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj3_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj4_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj5_offset, 0, true).as_bytes());
+        data.extend_from_slice(format_xref_entry(obj6_offset, 0, true).as_bytes());
+
+        data.extend_from_slice(b"trailer\n<< /Size 7 /Root 1 0 R >>\n");
+        data.extend_from_slice(b"startxref\n");
+        data.extend_from_slice(format!("{}\n", xref_offset).as_bytes());
+        data.extend_from_slice(b"%%EOF");
+
+        let reader = PdfReader;
+        let result = reader.read_from_bytes(&data, None);
+
+        assert!(
+            result.is_ok(),
+            "PDF with single-name array color space shading should load: {:?}",
+            result.err()
+        );
+
+        let document = result.unwrap();
+        assert_eq!(document.page_count(), 1);
+    }
 }


### PR DESCRIPTION
Treat one-element color space arrays as their named equivalents so shading dictionaries like [/DeviceGray] parse through the shared color-space reader instead of failing as unsupported array forms.

Add parser regression coverage for the accepted single-name arrays and keep empty or malformed multi-element arrays rejected.

Add a document-level shading regression in pdf-document that loads a sampled function shading using /ColorSpace [/DeviceGray].