### PR TITLE
pdf-filter: add RunLengthDecode stream support

### DIFF
--- a/crates/pdf-filter/src/filter.rs
+++ b/crates/pdf-filter/src/filter.rs
@@ -54,6 +54,11 @@ pub enum Filter {
     /// Based on variable-length code substitution. This was used in older PDFs
     /// before FlateDecode became the standard. See PDF spec §7.4.4.
     LZWDecode,
+    /// The RunLength filter, a simple byte-oriented compression algorithm.
+    ///
+    /// This filter stores either literal runs or repeated bytes, terminated by
+    /// a dedicated end-of-data marker. See PDF spec §7.4.5.
+    RunLengthDecode,
     /// A filter that is not currently supported by this implementation.
     ///
     /// The contained string holds the original filter name from the PDF,
@@ -75,6 +80,8 @@ impl From<Cow<'_, str>> for Filter {
             "ASCIIHexDecode" => Self::ASCIIHexDecode,
             "LZWDecode" => Self::LZWDecode,
             "LZW" => Self::LZWDecode,
+            "RunLengthDecode" => Self::RunLengthDecode,
+            "RL" => Self::RunLengthDecode,
             _ => Self::Unsupported(name.into_owned()),
         }
     }
@@ -96,6 +103,7 @@ impl fmt::Display for Filter {
             Self::ASCII85Decode => f.write_str("ASCII85Decode"),
             Self::ASCIIHexDecode => f.write_str("ASCIIHexDecode"),
             Self::LZWDecode => f.write_str("LZWDecode"),
+            Self::RunLengthDecode => f.write_str("RunLengthDecode"),
             Self::Unsupported(name) => f.write_str(name),
         }
     }
@@ -296,6 +304,10 @@ pub fn decode_with_resolver<'a>(
                 let decoded = crate::asciihex::decode_ascii_hex(&data)?;
                 data = Cow::Owned(decoded);
             }
+            Filter::RunLengthDecode => {
+                let decoded = crate::runlength::decode_run_length(&data)?;
+                data = Cow::Owned(decoded);
+            }
             Filter::CCITTFaxDecode => {
                 let ccitt_params = match params {
                     DecodeParms::CcittFax(p) => p,
@@ -445,6 +457,13 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_name_round_trip_run_length() {
+        let filter = Filter::from(Cow::Borrowed("RunLengthDecode"));
+        assert_eq!(filter, Filter::RunLengthDecode);
+        assert_eq!(filter.to_string(), "RunLengthDecode");
+    }
+
+    #[test]
     fn test_decode_ascii_hex_stream() {
         let mut dict = BTreeMap::new();
         dict.insert(
@@ -510,5 +529,35 @@ mod tests {
 
         let decoded = decode_with_resolver(&stream, &resolver).expect("decode failed");
         assert_eq!(decoded.as_ref(), b"hello");
+    }
+
+    #[test]
+    fn test_decode_run_length_stream() {
+        let mut dict = BTreeMap::new();
+        dict.insert(
+            "Filter".to_string(),
+            ObjectVariant::Name(b"RunLengthDecode".to_vec()),
+        );
+
+        let stream = StreamObject::new(
+            1,
+            0,
+            Box::new(Dictionary::new(dict)),
+            vec![2, b'A', b'B', b'C', 255, b'!', 128],
+        );
+
+        let decoded = decode(&stream).expect("decode failed");
+        assert_eq!(decoded.as_ref(), b"ABC!!");
+    }
+
+    #[test]
+    fn test_decode_rl_alias_stream() {
+        let mut dict = BTreeMap::new();
+        dict.insert("Filter".to_string(), ObjectVariant::Name(b"RL".to_vec()));
+
+        let stream = StreamObject::new(1, 0, Box::new(Dictionary::new(dict)), vec![0, b'X', 128]);
+
+        let decoded = decode(&stream).expect("decode failed");
+        assert_eq!(decoded.as_ref(), b"X");
     }
 }

--- a/crates/pdf-filter/src/lib.rs
+++ b/crates/pdf-filter/src/lib.rs
@@ -10,6 +10,7 @@
 //! - **CCITTFaxDecode** — Group 3 / Group 4 fax compression
 //! - **ASCII85Decode** — ASCII base-85 encoding
 //! - **ASCIIHexDecode** — ASCII hexadecimal encoding
+//! - **RunLengthDecode** — PDF run-length encoding
 //!
 //! The main entry point is [`filter::decode`], which accepts a
 //! [`StreamObject`](pdf_object::stream::StreamObject) and applies the full
@@ -25,3 +26,4 @@ pub mod error;
 pub mod filter;
 pub(crate) mod lzw;
 pub(crate) mod predictor;
+pub(crate) mod runlength;

--- a/crates/pdf-filter/src/runlength.rs
+++ b/crates/pdf-filter/src/runlength.rs
@@ -1,0 +1,91 @@
+use crate::error::FilterError;
+
+/// Decodes RunLengthDecode-compressed stream data.
+///
+/// PDF RunLength data is organized into packets prefixed by a single header
+/// byte. Literal packets use header values `0..=127` and copy the next
+/// `header + 1` bytes verbatim. Repeat packets use header values `129..=255`
+/// and repeat the following byte `257 - header` times. Header value `128`
+/// terminates the stream.
+///
+/// # Errors
+///
+/// Returns [`FilterError::Decompression`] when a packet is truncated and the
+/// decoder cannot read the bytes required by its header.
+pub(crate) fn decode_run_length(stream_data: &[u8]) -> Result<Vec<u8>, FilterError> {
+    let mut output = Vec::new();
+    let mut index = 0usize;
+
+    while let Some(&header) = stream_data.get(index) {
+        index = index.saturating_add(1);
+
+        match header {
+            128 => break,
+            0..=127 => {
+                let literal_len = usize::from(header).saturating_add(1);
+                let end = index.saturating_add(literal_len);
+                let Some(bytes) = stream_data.get(index..end) else {
+                    return Err(FilterError::Decompression(
+                        "RunLengthDecode: truncated literal run".to_string(),
+                    ));
+                };
+                output.extend_from_slice(bytes);
+                index = end;
+            }
+            129..=255 => {
+                let repeat_len = 257usize.saturating_sub(usize::from(header));
+                let Some(&byte) = stream_data.get(index) else {
+                    return Err(FilterError::Decompression(
+                        "RunLengthDecode: truncated repeat run".to_string(),
+                    ));
+                };
+                output.extend(std::iter::repeat_n(byte, repeat_len));
+                index = index.saturating_add(1);
+            }
+        }
+    }
+
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decode_run_length_literal_run() {
+        let decoded = decode_run_length(&[2, b'A', b'B', b'C', 128]).expect("decode failed");
+        assert_eq!(decoded, b"ABC");
+    }
+
+    #[test]
+    fn test_decode_run_length_repeat_run() {
+        let decoded = decode_run_length(&[254, b'Z', 128]).expect("decode failed");
+        assert_eq!(decoded, b"ZZZ");
+    }
+
+    #[test]
+    fn test_decode_run_length_mixed_runs() {
+        let decoded = decode_run_length(&[2, b'A', b'B', b'C', 255, b'!', 0, b'?', 128])
+            .expect("decode failed");
+        assert_eq!(decoded, b"ABC!!?");
+    }
+
+    #[test]
+    fn test_decode_run_length_stops_at_eod() {
+        let decoded = decode_run_length(&[0, b'A', 128, 0, b'B']).expect("decode failed");
+        assert_eq!(decoded, b"A");
+    }
+
+    #[test]
+    fn test_decode_run_length_truncated_literal_run_is_error() {
+        let result = decode_run_length(&[2, b'A', b'B']);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decode_run_length_truncated_repeat_run_is_error() {
+        let result = decode_run_length(&[255]);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
Recognize both /RunLengthDecode and /RL in the shared filter pipeline and decode them through a dedicated run-length implementation used by stream and image decoding paths.

Document the new filter in the crate overview and add unit coverage for literal and repeat packets,
end-of-data handling, truncation errors, and
filter-level stream decoding.