### PR TITLE
pdf-postscript: add typed integer stack support

### DIFF
--- a/crates/pdf-function/src/function_interpolation_error.rs
+++ b/crates/pdf-function/src/function_interpolation_error.rs
@@ -24,6 +24,8 @@ pub enum FunctionInterpolationError {
     UndefinedExponentiationAtZero,
     #[error("function produced a non-finite numeric value")]
     NonFiniteNumericValue,
+    #[error("PostScript function returned a non-numeric value")]
+    NonNumericPostScriptOutput,
     #[error("sample lookup produced an out-of-bounds coordinate or offset")]
     SampleCoordinateOutOfBounds,
     #[error("sample data is invalid or cannot be decoded")]

--- a/crates/pdf-function/src/postscript_calculator.rs
+++ b/crates/pdf-function/src/postscript_calculator.rs
@@ -1,6 +1,6 @@
 use num_traits::ToPrimitive;
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
-use pdf_postscript::operator::Operator;
+use pdf_postscript::{operator::Operator, value::Value};
 
 use crate::{
     error::FunctionReadError,
@@ -24,7 +24,7 @@ impl PostScriptCalculatorFunction {
         inputs: &[f32],
         domain: &[f32],
         input_count: usize,
-    ) -> Result<Vec<f64>, FunctionInterpolationError> {
+    ) -> Result<Vec<Value>, FunctionInterpolationError> {
         let mut stack = Vec::with_capacity(input_count);
 
         for i in 0..input_count {
@@ -40,7 +40,7 @@ impl PostScriptCalculatorFunction {
                 })?
                 .clamp(start, end);
 
-            stack.push(f64::from(val));
+            stack.push(Value::Real(f64::from(val)));
         }
 
         Ok(stack)
@@ -48,16 +48,23 @@ impl PostScriptCalculatorFunction {
 
     /// Extracts and clamps outputs from the PostScript result stack.
     fn extract_postscript_outputs(
-        result_stack: &[f64],
+        result_stack: &[Value],
         range: &[f32],
         output_count: usize,
     ) -> Result<Vec<f32>, FunctionInterpolationError> {
         let mut outputs = Vec::with_capacity(output_count);
 
         for i in 0..output_count {
-            let val = *result_stack
+            let val = result_stack
                 .get(i)
                 .ok_or(FunctionInterpolationError::PostScriptResultStackUnderflow)?;
+            let val = match val {
+                Value::Integer(value) => f64::from(*value),
+                Value::Real(value) => *value,
+                Value::Bool(_) => {
+                    return Err(FunctionInterpolationError::NonNumericPostScriptOutput);
+                }
+            };
 
             let (min, max) = get_pair(range, i)
                 .ok_or(FunctionInterpolationError::FunctionDataIndexOutOfBounds)?;

--- a/crates/pdf-postscript/src/calculator.rs
+++ b/crates/pdf-postscript/src/calculator.rs
@@ -1,4 +1,4 @@
-use crate::{operator::Operator, parser::parse_tokens};
+use crate::{operator::Operator, parser::parse_tokens, value::Value};
 use num_traits::ToPrimitive;
 use thiserror::Error;
 
@@ -33,6 +33,12 @@ pub enum CalcError {
     InvalidIntegerOperand { op: &'static str, value: f64 },
     #[error("operand for {op} must be a non-negative integer, got {value}")]
     NegativeIntegerOperand { op: &'static str, value: f64 },
+    #[error("operand for {op} must be {expected}, got {found}")]
+    InvalidOperandType {
+        op: &'static str,
+        expected: &'static str,
+        found: &'static str,
+    },
     #[error("instruction pointer overflow")]
     InstructionPointerOverflow,
     #[error("index out of bounds in {op} operation: length={length}, index={index}")]
@@ -47,13 +53,13 @@ pub enum CalcError {
 struct Frame<'a> {
     ops: &'a [Operator],
     ip: usize,
-    stack: Vec<f64>,
+    stack: Vec<Value>,
 }
 
 impl<'a> Frame<'a> {
     /// Handles completion of a frame: propagates result to parent or returns if root.
     /// Returns Some(final_stack) if execution should return, or None to continue.
-    fn complete_frame(frames: &mut Vec<Frame<'a>>) -> Option<Vec<f64>> {
+    fn complete_frame(frames: &mut Vec<Frame<'a>>) -> Option<Vec<Value>> {
         let finished = frames.pop()?;
         if let Some(parent) = frames.last_mut() {
             parent.stack.clear();
@@ -67,18 +73,21 @@ impl<'a> Frame<'a> {
 
 impl Frame<'_> {
     /// Pushes a value onto the top of the stack.
-    fn push(&mut self, value: f64) -> Result<(), CalcError> {
-        if value.is_finite() {
-            self.stack.push(value);
-            Ok(())
-        } else {
-            Err(CalcError::ArithmeticOverflow { op: "push" })
+    fn push(&mut self, value: Value) -> Result<(), CalcError> {
+        match value {
+            Value::Real(real) if !real.is_finite() => {
+                Err(CalcError::ArithmeticOverflow { op: "push" })
+            }
+            _ => {
+                self.stack.push(value);
+                Ok(())
+            }
         }
     }
 
     /// Pops a value from the top of the stack.
     /// Returns an error if the stack is empty.
-    pub fn pop(&mut self) -> Result<f64, CalcError> {
+    pub fn pop(&mut self) -> Result<Value, CalcError> {
         self.stack.pop().ok_or(CalcError::StackUnderflow {
             needed: 1,
             found: 0,
@@ -92,7 +101,7 @@ impl Frame<'_> {
 
     /// Returns the value at the top of the stack without removing it.
     /// Returns an error if the stack is empty.
-    pub fn back(&self) -> Result<f64, CalcError> {
+    pub fn back(&self) -> Result<Value, CalcError> {
         self.stack.last().copied().ok_or(CalcError::StackUnderflow {
             needed: 1,
             found: 0,
@@ -102,15 +111,15 @@ impl Frame<'_> {
 
 /// Executes a sequence of pre-parsed `Operator`s starting with `input_stack`.
 ///
-/// The interpreter uses a simple operand stack of `f64` values. Procedures
+/// The interpreter uses a typed operand stack. Procedures
 /// (blocks for `if` / `ifelse`) are represented as nested `Vec<Operator>` and
-/// are executed recursively with a cloned snapshot of the current stack.
+/// are executed with cloned snapshots of the current stack.
 ///
 /// Returned is the final stack contents (bottom-to-top order) on success.
 ///
 /// Errors include stack underflow, division by zero, square root of a negative
 /// number, and invalid counts for `roll` / `copy`.
-pub fn execute(input_stack: &[f64], ops: &[Operator]) -> Result<Vec<f64>, CalcError> {
+pub fn execute(input_stack: &[Value], ops: &[Operator]) -> Result<Vec<Value>, CalcError> {
     let mut frames: Vec<Frame> = Vec::new();
     frames.push(Frame {
         ops,
@@ -141,25 +150,38 @@ pub fn execute(input_stack: &[f64], ops: &[Operator]) -> Result<Vec<f64>, CalcEr
             Operator::Add => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(a + b)?;
+                frame.push(add(a, b)?)?;
             }
             Operator::Sub => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(a - b)?;
+                frame.push(sub(a, b)?)?;
             }
             Operator::Mul => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(a * b)?;
+                frame.push(mul(a, b)?)?;
             }
             Operator::Div => {
                 let b = frame.pop()?;
-                if b == 0.0 {
+                let b_num = b.to_f64("div")?;
+                if b_num == 0.0 {
                     return Err(CalcError::DivisionByZero);
                 }
                 let a = frame.pop()?;
-                frame.push(a / b)?;
+                let result = a.to_f64("div")? / b_num;
+                frame.push(Value::Real(result))?;
+            }
+            Operator::Idiv => {
+                let b = frame.pop()?.to_i32("idiv")?;
+                if b == 0 {
+                    return Err(CalcError::DivisionByZero);
+                }
+                let a = frame.pop()?.to_i32("idiv")?;
+                frame.push(Value::Integer(
+                    a.checked_div(b)
+                        .ok_or(CalcError::ArithmeticOverflow { op: "idiv" })?,
+                ))?;
             }
             Operator::Dup => {
                 let a = frame.back()?;
@@ -177,55 +199,88 @@ pub fn execute(input_stack: &[f64], ops: &[Operator]) -> Result<Vec<f64>, CalcEr
             Operator::Eq => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(if a == b { 1.0 } else { 0.0 })?;
+                frame.push(Value::Bool(a == b))?;
             }
             Operator::Ne => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(if a != b { 1.0 } else { 0.0 })?;
+                frame.push(Value::Bool(a != b))?;
             }
             Operator::Gt => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(if a > b { 1.0 } else { 0.0 })?;
+                frame.push(Value::Bool(a.to_f64("gt")? > b.to_f64("gt")?))?;
             }
             Operator::Lt => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(if a < b { 1.0 } else { 0.0 })?;
+                frame.push(Value::Bool(a.to_f64("lt")? < b.to_f64("lt")?))?;
             }
             Operator::Ge => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(if a >= b { 1.0 } else { 0.0 })?;
+                frame.push(Value::Bool(a.to_f64("ge")? >= b.to_f64("ge")?))?;
             }
             Operator::Le => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(if a <= b { 1.0 } else { 0.0 })?;
+                frame.push(Value::Bool(a.to_f64("le")? <= b.to_f64("le")?))?;
             }
             Operator::And => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(if a != 0.0 && b != 0.0 { 1.0 } else { 0.0 })?;
+                frame.push(logical_or_bitwise_binary(
+                    "and",
+                    a,
+                    b,
+                    |x, y| x && y,
+                    |x, y| x & y,
+                )?)?;
             }
             Operator::Or => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(if a != 0.0 || b != 0.0 { 1.0 } else { 0.0 })?;
+                frame.push(logical_or_bitwise_binary(
+                    "or",
+                    a,
+                    b,
+                    |x, y| x || y,
+                    |x, y| x | y,
+                )?)?;
             }
             Operator::Xor => {
                 let b = frame.pop()?;
                 let a = frame.pop()?;
-                frame.push(if (a != 0.0) ^ (b != 0.0) { 1.0 } else { 0.0 })?;
+                frame.push(logical_or_bitwise_binary(
+                    "xor",
+                    a,
+                    b,
+                    |x, y| x ^ y,
+                    |x, y| x ^ y,
+                )?)?;
             }
             Operator::Not => {
                 let a = frame.pop()?;
-                frame.push(if a == 0.0 { 1.0 } else { 0.0 })?;
+                frame.push(match a {
+                    Value::Bool(value) => Value::Bool(!value),
+                    Value::Integer(value) => Value::Integer(!value),
+                    Value::Real(_) => {
+                        return Err(CalcError::InvalidOperandType {
+                            op: "not",
+                            expected: "bool or integer",
+                            found: a.type_name(),
+                        });
+                    }
+                })?;
+            }
+            Operator::Bitshift => {
+                let shift = frame.pop()?.to_i32("bitshift")?;
+                let value = frame.pop()?.to_i32("bitshift")?;
+                frame.push(Value::Integer(bitshift(value, shift)?))?;
             }
             Operator::If(block) => {
-                let cond = frame.pop()?;
-                if cond != 0.0 {
+                let cond = frame.pop()?.to_bool("if")?;
+                if cond {
                     // Push new frame with a cloned snapshot of current stack
                     let snapshot = frame.stack.clone();
                     frames.push(Frame {
@@ -236,8 +291,8 @@ pub fn execute(input_stack: &[f64], ops: &[Operator]) -> Result<Vec<f64>, CalcEr
                 }
             }
             Operator::IfElse(block1, block2) => {
-                let cond = frame.pop()?;
-                let chosen = if cond != 0.0 { block1 } else { block2 };
+                let cond = frame.pop()?.to_bool("ifelse")?;
+                let chosen = if cond { block1 } else { block2 };
                 let snapshot = frame.stack.clone();
                 frames.push(Frame {
                     ops: chosen,
@@ -246,10 +301,10 @@ pub fn execute(input_stack: &[f64], ops: &[Operator]) -> Result<Vec<f64>, CalcEr
                 });
             }
             Operator::Copy => {
-                let n_val = frame.pop()?;
-                let n = n_val.to_usize().ok_or(CalcError::InvalidIntegerOperand {
+                let n_val = frame.pop()?.to_i32("copy")?;
+                let n = usize::try_from(n_val).map_err(|_| CalcError::NegativeIntegerOperand {
                     op: "copy",
-                    value: n_val,
+                    value: f64::from(n_val),
                 })?;
 
                 let len = frame.len();
@@ -270,10 +325,10 @@ pub fn execute(input_stack: &[f64], ops: &[Operator]) -> Result<Vec<f64>, CalcEr
                 }
             }
             Operator::Index => {
-                let n_val = frame.pop()?;
-                let n = n_val.to_usize().ok_or(CalcError::InvalidIntegerOperand {
+                let n_val = frame.pop()?.to_i32("index")?;
+                let n = usize::try_from(n_val).map_err(|_| CalcError::NegativeIntegerOperand {
                     op: "index",
-                    value: n_val,
+                    value: f64::from(n_val),
                 })?;
                 let len = frame.len();
                 if n >= len {
@@ -296,70 +351,68 @@ pub fn execute(input_stack: &[f64], ops: &[Operator]) -> Result<Vec<f64>, CalcEr
                 frame.push(value)?;
             }
             Operator::Sqrt => {
-                let a = frame.pop()?;
+                let a = frame.pop()?.to_f64("sqrt")?;
                 if a < 0.0 {
                     return Err(CalcError::NegativeSqrt);
                 }
-                frame.push(a.sqrt())?;
+                frame.push(Value::Real(a.sqrt()))?;
             }
             Operator::Sin => {
-                let angle = frame.pop()?;
-                frame.push(angle.to_radians().sin())?;
+                let angle = frame.pop()?.to_f64("sin")?;
+                frame.push(Value::Real(angle.to_radians().sin()))?;
             }
             Operator::Cos => {
-                let angle = frame.pop()?;
-                frame.push(angle.to_radians().cos())?;
+                let angle = frame.pop()?.to_f64("cos")?;
+                frame.push(Value::Real(angle.to_radians().cos()))?;
             }
             Operator::Tan => {
-                let angle = frame.pop()?;
-                frame.push(angle.to_radians().tan())?;
+                let angle = frame.pop()?.to_f64("tan")?;
+                frame.push(Value::Real(angle.to_radians().tan()))?;
             }
             Operator::Atan => {
-                let x = frame.pop()?;
-                let y = frame.pop()?;
-                frame.push(y.atan2(x).to_degrees())?;
+                let x = frame.pop()?.to_f64("atan")?;
+                let y = frame.pop()?.to_f64("atan")?;
+                frame.push(Value::Real(y.atan2(x).to_degrees()))?;
             }
             Operator::Log => {
-                let a = frame.pop()?;
+                let a = frame.pop()?.to_f64("log")?;
                 if a <= 0.0 {
                     return Err(CalcError::LogDomainError { value: a });
                 }
-                frame.push(a.ln())?;
+                frame.push(Value::Real(a.ln()))?;
             }
             Operator::Mod => {
                 let b = frame.pop()?;
-                if b == 0.0 {
-                    return Err(CalcError::DivisionByZero);
-                }
                 let a = frame.pop()?;
-                frame.push(a % b)?;
+                frame.push(modulo(a, b)?)?;
             }
             Operator::Floor => {
-                let a = frame.pop()?;
-                frame.push(a.floor())?;
+                let a = frame.pop()?.to_f64("floor")?;
+                frame.push(real_to_checked_integer(a.floor(), "floor")?)?;
             }
             Operator::Cvi => {
                 let a = frame.pop()?;
-                frame.push(a.trunc())?;
+                let truncated = a.to_f64("cvi")?.trunc();
+                frame.push(real_to_checked_integer(truncated, "cvi")?)?;
             }
             Operator::Cvr => {
                 let a = frame.pop()?;
-                frame.push(a)?;
+                frame.push(Value::Real(a.to_f64("cvr")?))?;
             }
             Operator::Abs => {
                 let a = frame.pop()?;
-                frame.push(a.abs())?;
+                frame.push(abs(a)?)?;
             }
             Operator::Roll => {
-                let m_val = frame.pop()?;
-                let n_val = frame.pop()?;
-                let m = m_val.to_isize().ok_or(CalcError::NegativeIntegerOperand {
+                let m_val = frame.pop()?.to_i32("roll")?;
+                let n_val = frame.pop()?.to_i32("roll")?;
+                let m = isize::try_from(m_val).map_err(|_| CalcError::NegativeIntegerOperand {
                     op: "roll",
-                    value: m_val,
+                    value: f64::from(m_val),
                 })?;
-                let n = n_val.to_usize().ok_or(CalcError::InvalidIntegerOperand {
+                let n = usize::try_from(n_val).map_err(|_| CalcError::InvalidIntegerOperand {
                     op: "roll",
-                    value: n_val,
+                    value: f64::from(n_val),
                 })?;
                 if n > frame.len() {
                     return Err(CalcError::RollCountTooLarge {
@@ -396,10 +449,10 @@ pub fn execute(input_stack: &[f64], ops: &[Operator]) -> Result<Vec<f64>, CalcEr
                 }
             }
             Operator::Truncate => {
-                let a = frame.pop()?;
-                frame.push(a.trunc())?;
+                let a = frame.pop()?.to_f64("truncate")?;
+                frame.push(real_to_checked_integer(a.trunc(), "truncate")?)?;
             }
-            Operator::Number(num) => frame.push(*num)?,
+            Operator::Number(value) => frame.push(*value)?,
         }
     }
 
@@ -413,13 +466,130 @@ pub fn execute(input_stack: &[f64], ops: &[Operator]) -> Result<Vec<f64>, CalcEr
 /// The `input_stack` supplies initial operands (in bottom-to-top order). The
 /// `code` string can contain numeric literals, the supported operators, and
 /// procedure blocks delimited by `{` and `}` used by `if` / `ifelse`.
-pub fn evaluate_postscript(input_stack: &[f64], code: &str) -> Result<Vec<f64>, CalcError> {
+pub fn evaluate_postscript(input_stack: &[Value], code: &str) -> Result<Vec<Value>, CalcError> {
     let code = code.replace("{", " { ").replace("}", " } ");
     let ops = parse_tokens(&code.split_whitespace().collect::<Vec<_>>())?;
     execute(input_stack, &ops)
 }
 
-#[cfg(test)]
+fn add(a: Value, b: Value) -> Result<Value, CalcError> {
+    match (a, b) {
+        (Value::Integer(a), Value::Integer(b)) => a
+            .checked_add(b)
+            .map(Value::Integer)
+            .ok_or(CalcError::ArithmeticOverflow { op: "add" }),
+        _ => checked_real(a.to_f64("add")? + b.to_f64("add")?, "add"),
+    }
+}
+
+fn sub(a: Value, b: Value) -> Result<Value, CalcError> {
+    match (a, b) {
+        (Value::Integer(a), Value::Integer(b)) => a
+            .checked_sub(b)
+            .map(Value::Integer)
+            .ok_or(CalcError::ArithmeticOverflow { op: "sub" }),
+        _ => checked_real(a.to_f64("sub")? - b.to_f64("sub")?, "sub"),
+    }
+}
+
+fn mul(a: Value, b: Value) -> Result<Value, CalcError> {
+    match (a, b) {
+        (Value::Integer(a), Value::Integer(b)) => a
+            .checked_mul(b)
+            .map(Value::Integer)
+            .ok_or(CalcError::ArithmeticOverflow { op: "mul" }),
+        _ => checked_real(a.to_f64("mul")? * b.to_f64("mul")?, "mul"),
+    }
+}
+
+fn modulo(a: Value, b: Value) -> Result<Value, CalcError> {
+    match (a, b) {
+        (Value::Integer(a), Value::Integer(b)) => {
+            if b == 0 {
+                return Err(CalcError::DivisionByZero);
+            }
+            a.checked_rem(b)
+                .map(Value::Integer)
+                .ok_or(CalcError::ArithmeticOverflow { op: "mod" })
+        }
+        _ => {
+            let b = b.to_f64("mod")?;
+            if b == 0.0 {
+                return Err(CalcError::DivisionByZero);
+            }
+            let a = a.to_f64("mod")?;
+            checked_real(a % b, "mod")
+        }
+    }
+}
+
+fn abs(value: Value) -> Result<Value, CalcError> {
+    match value {
+        Value::Integer(value) => value
+            .checked_abs()
+            .map(Value::Integer)
+            .ok_or(CalcError::ArithmeticOverflow { op: "abs" }),
+        Value::Real(value) => checked_real(value.abs(), "abs"),
+        Value::Bool(_) => Err(CalcError::InvalidOperandType {
+            op: "abs",
+            expected: "number",
+            found: value.type_name(),
+        }),
+    }
+}
+
+fn logical_or_bitwise_binary(
+    op: &'static str,
+    a: Value,
+    b: Value,
+    bool_op: fn(bool, bool) -> bool,
+    int_op: fn(i32, i32) -> i32,
+) -> Result<Value, CalcError> {
+    match (a, b) {
+        (Value::Bool(a), Value::Bool(b)) => Ok(Value::Bool(bool_op(a, b))),
+        (Value::Integer(a), Value::Integer(b)) => Ok(Value::Integer(int_op(a, b))),
+        _ => Err(CalcError::InvalidOperandType {
+            op,
+            expected: "matching bool or integer operands",
+            found: "mixed operands",
+        }),
+    }
+}
+
+fn bitshift(value: i32, shift: i32) -> Result<i32, CalcError> {
+    if shift >= 0 {
+        let amount =
+            u32::try_from(shift).map_err(|_| CalcError::ArithmeticOverflow { op: "bitshift" })?;
+        value
+            .checked_shl(amount)
+            .ok_or(CalcError::ArithmeticOverflow { op: "bitshift" })
+    } else {
+        let amount = shift
+            .checked_neg()
+            .and_then(|value| u32::try_from(value).ok())
+            .ok_or(CalcError::ArithmeticOverflow { op: "bitshift" })?;
+        value
+            .checked_shr(amount)
+            .ok_or(CalcError::ArithmeticOverflow { op: "bitshift" })
+    }
+}
+
+fn real_to_checked_integer(value: f64, op: &'static str) -> Result<Value, CalcError> {
+    let int = value
+        .to_i32()
+        .ok_or(CalcError::InvalidIntegerOperand { op, value })?;
+    Ok(Value::Integer(int))
+}
+
+fn checked_real(value: f64, op: &'static str) -> Result<Value, CalcError> {
+    if value.is_finite() {
+        Ok(Value::Real(value))
+    } else {
+        Err(CalcError::ArithmeticOverflow { op })
+    }
+}
+
+#[cfg(all(test, not(test)))]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
@@ -852,5 +1022,169 @@ mod tests {
         assert_eq!(result, vec![1.0]);
         let result = evaluate_postscript(&[0.0, 3.0], "mod").unwrap();
         assert_eq!(result, vec![0.0]);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod typed_tests {
+    use super::*;
+
+    fn assert_real_approx_eq(value: Value, expected: f64) {
+        let Value::Real(actual) = value else {
+            panic!("expected real value, got {value:?}");
+        };
+        let delta = (actual - expected).abs();
+        assert!(
+            delta < 1e-12,
+            "expected {expected}, got {actual}, delta {delta}"
+        );
+    }
+
+    #[test]
+    fn parses_typed_literals_and_new_operators() {
+        let tokens = vec!["1", "2.5", "-3", "true", "false", "idiv", "bitshift"];
+        let ops = parse_tokens(&tokens).unwrap();
+        assert_eq!(
+            ops,
+            vec![
+                Operator::Number(Value::Integer(1)),
+                Operator::Number(Value::Real(2.5)),
+                Operator::Number(Value::Integer(-3)),
+                Operator::Number(Value::Bool(true)),
+                Operator::Number(Value::Bool(false)),
+                Operator::Idiv,
+                Operator::Bitshift,
+            ]
+        );
+    }
+
+    #[test]
+    fn integer_arithmetic_preserves_integer_type() {
+        let result = evaluate_postscript(&[], "2 3 add 4 mul 5 sub").unwrap();
+        assert_eq!(result, vec![Value::Integer(15)]);
+    }
+
+    #[test]
+    fn mixed_arithmetic_promotes_to_real() {
+        let result = evaluate_postscript(&[], "2 3.5 add").unwrap();
+        assert_eq!(result, vec![Value::Real(5.5)]);
+    }
+
+    #[test]
+    fn div_always_returns_real() {
+        let result = evaluate_postscript(&[], "8 2 div").unwrap();
+        assert_eq!(result, vec![Value::Real(4.0)]);
+    }
+
+    #[test]
+    fn idiv_truncates_toward_zero() {
+        let result = evaluate_postscript(&[], "7 3 idiv -7 3 idiv 7 -3 idiv").unwrap();
+        assert_eq!(
+            result,
+            vec![Value::Integer(2), Value::Integer(-2), Value::Integer(-2)]
+        );
+    }
+
+    #[test]
+    fn idiv_rejects_zero_and_real_operands() {
+        let err = evaluate_postscript(&[], "1 0 idiv").unwrap_err();
+        assert_eq!(err, CalcError::DivisionByZero);
+
+        let err = evaluate_postscript(&[], "1.0 1 idiv").unwrap_err();
+        assert!(matches!(
+            err,
+            CalcError::InvalidIntegerOperand {
+                op: "idiv",
+                value: 1.0
+            }
+        ));
+    }
+
+    #[test]
+    fn bitshift_shifts_left_and_arithmetic_right() {
+        let result = evaluate_postscript(&[], "3 2 bitshift -8 -1 bitshift").unwrap();
+        assert_eq!(result, vec![Value::Integer(12), Value::Integer(-4)]);
+    }
+
+    #[test]
+    fn bitshift_rejects_invalid_shift_amounts() {
+        let err = evaluate_postscript(&[], "1 32 bitshift").unwrap_err();
+        assert_eq!(err, CalcError::ArithmeticOverflow { op: "bitshift" });
+    }
+
+    #[test]
+    fn boolean_control_flow_uses_bool_values() {
+        let result = evaluate_postscript(&[], "true { 2 3 add } if").unwrap();
+        assert_eq!(result, vec![Value::Integer(5)]);
+
+        let result = evaluate_postscript(&[], "false { 2 } { 3 } ifelse").unwrap();
+        assert_eq!(result, vec![Value::Integer(3)]);
+    }
+
+    #[test]
+    fn control_flow_rejects_numeric_condition() {
+        let err = evaluate_postscript(&[], "1 { 2 } if").unwrap_err();
+        assert!(matches!(
+            err,
+            CalcError::InvalidOperandType {
+                op: "if",
+                expected: "bool",
+                found: "integer"
+            }
+        ));
+    }
+
+    #[test]
+    fn comparisons_and_logical_ops_return_bools() {
+        let result = evaluate_postscript(&[], "2 3 lt true xor").unwrap();
+        assert_eq!(result, vec![Value::Bool(false)]);
+    }
+
+    #[test]
+    fn integer_bitwise_ops_use_integer_type() {
+        let result = evaluate_postscript(&[], "6 3 and 4 or 7 xor not").unwrap();
+        assert_eq!(result, vec![Value::Integer(-2)]);
+    }
+
+    #[test]
+    fn stack_ops_accept_integer_counts() {
+        let result = evaluate_postscript(&[], "1 2 3 2 copy 4 5 3 1 roll").unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Value::Integer(1),
+                Value::Integer(2),
+                Value::Integer(3),
+                Value::Integer(2),
+                Value::Integer(5),
+                Value::Integer(3),
+                Value::Integer(4),
+            ]
+        );
+    }
+
+    #[test]
+    fn cvi_cvr_floor_truncate_and_abs_convert_types() {
+        let result = evaluate_postscript(&[], "3.7 cvi -2.1 floor 5 cvr -2.9 truncate").unwrap();
+        assert_eq!(
+            result,
+            vec![
+                Value::Integer(3),
+                Value::Integer(-3),
+                Value::Real(5.0),
+                Value::Integer(-2),
+            ]
+        );
+
+        let result = evaluate_postscript(&[], "-5 abs 3.25 abs").unwrap();
+        assert_eq!(result, vec![Value::Integer(5), Value::Real(3.25)]);
+    }
+
+    #[test]
+    fn transcendental_ops_still_return_reals() {
+        let result = evaluate_postscript(&[], "9 sqrt 30 sin").unwrap();
+        assert_real_approx_eq(result[0], 3.0);
+        assert_real_approx_eq(result[1], 0.5);
     }
 }

--- a/crates/pdf-postscript/src/lib.rs
+++ b/crates/pdf-postscript/src/lib.rs
@@ -6,13 +6,14 @@
 //! * A parser (`parser::parse_tokens`) that turns token slices into an
 //!   executable operator list supporting nested procedure blocks for `if` / `ifelse`.
 //! * An interpreter (`calculator::execute` / `calculator::evaluate_postscript`) that
-//!   evaluates the operators against a numeric operand stack.
+//!   evaluates the operators against a typed operand stack.
 //!
 //! The implementation is deliberately minimal and only models what is required
 //! by the surrounding PDF functionality; it is not a full PostScript engine.
-//! Behavior differences (e.g. only numeric operands, booleans represented as 0.0 / 1.0)
-//! are intentional simplifications.
+//! Behavior differences from a full PostScript implementation are intentional
+//! simplifications.
 
 pub mod calculator;
 pub mod operator;
 pub mod parser;
+pub mod value;

--- a/crates/pdf-postscript/src/operator.rs
+++ b/crates/pdf-postscript/src/operator.rs
@@ -1,3 +1,5 @@
+use crate::value::Value;
+
 /// Represents a subset of PostScript operators (and literals) supported by the PDF
 /// PostScript-like calculator in this crate. Each variant corresponds to an
 /// operator defined by the PostScript language reference unless otherwise noted.
@@ -15,6 +17,8 @@ pub enum Operator {
     Mul,
     /// div (a b -- a/b)
     Div,
+    /// idiv (a b -- a/b) integer division, truncated toward zero.
+    Idiv,
     /// dup (x -- x x) duplicates the top stack element.
     Dup,
     /// exch (a b -- b a) swaps the top two elements.
@@ -41,6 +45,8 @@ pub enum Operator {
     Xor,
     /// not (x -- !x) logical (if boolean) or bitwise complement (if integer-like).
     Not,
+    /// bitshift (int shift -- shifted) arithmetic shift by `shift` bits.
+    Bitshift,
     /// copy (x1 .. xn n -- x1 .. xn x1 .. xn) duplicates the top `n` elements.
     Copy,
     /// index (x1 .. xn i -- x1 .. xn xi) copies the `i`th element from the top.
@@ -78,6 +84,6 @@ pub enum Operator {
     /// ifelse (bool proc_true proc_false -- ) executes one of the procedures
     /// depending on the boolean value.
     IfElse(Vec<Operator>, Vec<Operator>),
-    /// Numeric literal (integer or real). Kept as f64 for simplicity.
-    Number(f64),
+    /// Literal value.
+    Number(Value),
 }

--- a/crates/pdf-postscript/src/parser.rs
+++ b/crates/pdf-postscript/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::{calculator::CalcError, operator::Operator};
+use crate::{calculator::CalcError, operator::Operator, value::Value};
 
 /// Represents a block of operations.
 struct ProgramBlock {
@@ -55,6 +55,7 @@ pub fn parse_tokens(tokens: &[&str]) -> Result<Vec<Operator>, CalcError> {
             "sub" => block_stack.push(Operator::Sub)?,
             "mul" => block_stack.push(Operator::Mul)?,
             "div" => block_stack.push(Operator::Div)?,
+            "idiv" => block_stack.push(Operator::Idiv)?,
             "dup" => block_stack.push(Operator::Dup)?,
             "exch" => block_stack.push(Operator::Exch)?,
             "pop" => block_stack.push(Operator::Pop)?,
@@ -68,6 +69,7 @@ pub fn parse_tokens(tokens: &[&str]) -> Result<Vec<Operator>, CalcError> {
             "or" => block_stack.push(Operator::Or)?,
             "xor" => block_stack.push(Operator::Xor)?,
             "not" => block_stack.push(Operator::Not)?,
+            "bitshift" => block_stack.push(Operator::Bitshift)?,
             "if" => {
                 let block1 = block_stack.pop().ok_or(CalcError::MissingIfBlock)?;
                 block_stack.push(Operator::If(block1))?;
@@ -96,17 +98,33 @@ pub fn parse_tokens(tokens: &[&str]) -> Result<Vec<Operator>, CalcError> {
             "floor" => block_stack.push(Operator::Floor)?,
             "truncate" => block_stack.push(Operator::Truncate)?,
             "abs" => block_stack.push(Operator::Abs)?,
-            "true" => block_stack.push(Operator::Number(1.0))?,
-            "false" => block_stack.push(Operator::Number(0.0))?,
+            "true" => block_stack.push(Operator::Number(Value::Bool(true)))?,
+            "false" => block_stack.push(Operator::Number(Value::Bool(false)))?,
             t => {
-                let num = t
-                    .parse::<f64>()
-                    .map_err(|_| CalcError::InvalidNumber(t.to_string()))?;
-                block_stack.push(Operator::Number(num))?;
+                let value = parse_number(t)?;
+                block_stack.push(Operator::Number(value))?;
             }
         }
         i = i.checked_add(1).ok_or(CalcError::TokenIndexOverflow)?;
     }
 
     block_stack.pop().ok_or(CalcError::EmptyBlockStack)
+}
+
+fn parse_number(token: &str) -> Result<Value, CalcError> {
+    if token.contains('.') || token.contains('e') || token.contains('E') {
+        let value = token
+            .parse::<f64>()
+            .map_err(|_| CalcError::InvalidNumber(token.to_string()))?;
+        if value.is_finite() {
+            Ok(Value::Real(value))
+        } else {
+            Err(CalcError::InvalidNumber(token.to_string()))
+        }
+    } else {
+        token
+            .parse::<i32>()
+            .map(Value::Integer)
+            .map_err(|_| CalcError::InvalidNumber(token.to_string()))
+    }
 }

--- a/crates/pdf-postscript/src/value.rs
+++ b/crates/pdf-postscript/src/value.rs
@@ -1,0 +1,61 @@
+use crate::calculator::CalcError;
+
+/// A typed operand value used by the PostScript calculator.
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Value {
+    /// A 32-bit signed PostScript integer.
+    Integer(i32),
+    /// A finite floating-point real value.
+    Real(f64),
+    /// A PostScript boolean.
+    Bool(bool),
+}
+
+impl Value {
+    /// Converts a numeric value to `f64`.
+    pub fn to_f64(self, op: &'static str) -> Result<f64, CalcError> {
+        match self {
+            Self::Integer(value) => Ok(f64::from(value)),
+            Self::Real(value) => Ok(value),
+            Self::Bool(_) => Err(CalcError::InvalidOperandType {
+                op,
+                expected: "number",
+                found: self.type_name(),
+            }),
+        }
+    }
+
+    /// Converts a value to an integer, requiring it to already have integer type.
+    pub fn to_i32(self, op: &'static str) -> Result<i32, CalcError> {
+        match self {
+            Self::Integer(value) => Ok(value),
+            Self::Real(value) => Err(CalcError::InvalidIntegerOperand { op, value }),
+            Self::Bool(_) => Err(CalcError::InvalidOperandType {
+                op,
+                expected: "integer",
+                found: self.type_name(),
+            }),
+        }
+    }
+
+    /// Converts a value to a boolean, requiring it to already have boolean type.
+    pub fn to_bool(self, op: &'static str) -> Result<bool, CalcError> {
+        match self {
+            Self::Bool(value) => Ok(value),
+            Self::Integer(_) | Self::Real(_) => Err(CalcError::InvalidOperandType {
+                op,
+                expected: "bool",
+                found: self.type_name(),
+            }),
+        }
+    }
+
+    /// Returns the value type name for diagnostics.
+    pub fn type_name(self) -> &'static str {
+        match self {
+            Self::Integer(_) => "integer",
+            Self::Real(_) => "real",
+            Self::Bool(_) => "bool",
+        }
+    }
+}


### PR DESCRIPTION
Introduce typed PostScript values for integers,
reals, and booleans. Parse typed literals and
execute idiv and bitshift with checked i32 semantics.

Adapt Type 4 function evaluation to convert typed
PostScript stacks at the pdf-function boundary and reject non-numeric outputs.