### PR TITLE
pdf-cmap: tolerate CMap resource wrappers

### DIFF
--- a/crates/pdf-cmap/src/cmap/parser.rs
+++ b/crates/pdf-cmap/src/cmap/parser.rs
@@ -177,7 +177,7 @@ impl<'a> CMapParser<'a> {
     /// Parse and return the ToUnicode mappings from this parser.
     pub fn into_unicode_map(mut self) -> Result<HashMap<u16, Vec<char>>, CMapError> {
         loop {
-            let token = self.next_token()?;
+            let token = self.next_token_lenient()?;
 
             match token {
                 Some(CMapToken::BeginBfChar) => {

--- a/crates/pdf-cmap/src/to_unicode.rs
+++ b/crates/pdf-cmap/src/to_unicode.rs
@@ -46,6 +46,34 @@ endbfchar
     }
 
     #[test]
+    fn parses_cmap_wrapped_in_postscript_resource_boilerplate() {
+        let map = ToUnicodeCMap::try_from(
+            br"
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo <</Registry (Adobe) /Ordering (Identity) /Supplement 0>> def
+/CMapName /Adobe-Identity def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+1 beginbfchar
+<0041> <0042>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+"
+            .as_slice(),
+        )
+        .unwrap();
+
+        assert_eq!(map.map_char_code(0x41), Some(['B'].as_slice()));
+    }
+
+    #[test]
     fn parses_bfrange_array_and_sequential_entries() {
         let map = ToUnicodeCMap::try_from(
             br"

--- a/crates/pdf-cmap/src/type0/embedded.rs
+++ b/crates/pdf-cmap/src/type0/embedded.rs
@@ -71,7 +71,7 @@ impl TryFrom<&[u8]> for EmbeddedCMap {
     fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
         let mut state = EmbeddedCMapBuilder::from(data);
 
-        while let Some(token) = state.parser.next_token()? {
+        while let Some(token) = state.parser.next_token_lenient()? {
             match token {
                 CMapToken::BeginCodeSpaceRange => {
                     state.parse_codespace_ranges()?;

--- a/crates/pdf-cmap/src/type0/mod.rs
+++ b/crates/pdf-cmap/src/type0/mod.rs
@@ -167,6 +167,31 @@ mod tests {
     }
 
     #[test]
+    fn embedded_cmap_accepts_postscript_resource_boilerplate() {
+        let data = br#"
+        /CIDInit /ProcSet findresource begin
+        12 dict begin
+        begincmap
+        /WMode 0 def
+        1 begincodespacerange
+        <0000> <00FF>
+        endcodespacerange
+        1 begincidchar
+        <0041> 7
+        endcidchar
+        endcmap
+        CMapName currentdict /CMap defineresource pop
+        end
+        end
+        "#;
+
+        let cmap = Type0EncodingCMap::from_bytes(data).unwrap();
+
+        assert_eq!(cmap.decode(&[0x00, 0x41]), vec![7]);
+        assert_eq!(cmap.writing_mode(), WritingMode::Horizontal);
+    }
+
+    #[test]
     fn embedded_cmap_uses_notdef_for_unmapped_or_invalid_codes() {
         let data = br#"
         begincmap


### PR DESCRIPTION
Parse top-level ToUnicode and embedded Type0 CMap streams with the lenient tokenizer so standard PostScript resource boilerplate does not abort parsing before CMap sections are reached.

Keep section parsing strict and add regression coverage for wrapped CMaps.