### PR TITLE
pdf-cmap: accept real CMap metadata values

### DIFF
--- a/crates/pdf-cmap/src/cmap/parser.rs
+++ b/crates/pdf-cmap/src/cmap/parser.rs
@@ -82,7 +82,7 @@ impl<'a> CMapParser<'a> {
             }
             b'<' => self.parse_left_angle_token()?,
             b'>' => self.parse_right_angle_token(byte)?,
-            b'+' | b'-' | b'0'..=b'9' => self.parse_integer_token(byte)?,
+            b'+' | b'-' | b'0'..=b'9' => self.parse_number_token(byte)?,
             _ if PdfParser::is_pdf_regular_character(byte) => {
                 self.parse_keyword_token(allow_unknown_operators)?
             }
@@ -112,11 +112,12 @@ impl<'a> CMapParser<'a> {
         }
     }
 
-    fn parse_integer_token(&mut self, byte: u8) -> Result<CMapToken, CMapError> {
-        let ObjectVariant::Integer(value) = self.parser.parse_number()? else {
-            return Err(self.unexpected_token(byte).into());
-        };
-        Ok(CMapToken::Integer(value))
+    fn parse_number_token(&mut self, byte: u8) -> Result<CMapToken, CMapError> {
+        match self.parser.parse_number()? {
+            ObjectVariant::Integer(value) => Ok(CMapToken::Integer(value)),
+            ObjectVariant::Real(value) => Ok(CMapToken::Real(value)),
+            _ => Err(self.unexpected_token(byte).into()),
+        }
     }
 
     fn parse_keyword_token(
@@ -216,13 +217,14 @@ mod tests {
 
     #[test]
     fn parses_names_integers_and_brackets() {
-        let mut parser = CMapParser::from(b"/WMode -1 [ ]".as_slice());
+        let mut parser = CMapParser::from(b"/WMode -1 1.000 [ ]".as_slice());
 
         assert_eq!(
             parser.next_token().unwrap(),
             Some(CMapToken::Name(b"WMode".to_vec()))
         );
         assert_eq!(parser.next_token().unwrap(), Some(CMapToken::Integer(-1)));
+        assert_eq!(parser.next_token().unwrap(), Some(CMapToken::Real(1.0)));
         assert_eq!(
             parser.next_token().unwrap(),
             Some(CMapToken::LeftSquareBracket)

--- a/crates/pdf-cmap/src/cmap/token.rs
+++ b/crates/pdf-cmap/src/cmap/token.rs
@@ -1,7 +1,7 @@
 use crate::{cmap_support::bytes_to_u32, error::CMapError};
 
 /// Token kinds used by embedded font CMap streams.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 pub enum CMapToken {
     /// `begincmap`.
     BeginCMap,
@@ -37,6 +37,8 @@ pub enum CMapToken {
     Name(Vec<u8>),
     /// An integer literal.
     Integer(i64),
+    /// A real-number literal.
+    Real(f64),
     /// A PDF hex string decoded into raw bytes.
     HexString(Vec<u8>),
     /// A PDF literal string decoded into raw bytes.

--- a/crates/pdf-cmap/src/to_unicode.rs
+++ b/crates/pdf-cmap/src/to_unicode.rs
@@ -74,6 +74,34 @@ end
     }
 
     #[test]
+    fn parses_cmap_with_real_number_metadata() {
+        let map = ToUnicodeCMap::try_from(
+            br"
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CMapName /Uni-Utf8-H def
+/CMapVersion 1.000 def
+/CMapType 2 def
+1 begincodespacerange
+<00> <7F>
+endcodespacerange
+1 beginbfchar
+<41> <0042>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+"
+            .as_slice(),
+        )
+        .unwrap();
+
+        assert_eq!(map.map_char_code(0x41), Some(['B'].as_slice()));
+    }
+
+    #[test]
     fn parses_bfrange_array_and_sequential_entries() {
         let map = ToUnicodeCMap::try_from(
             br"

--- a/crates/pdf-cmap/src/type0/mod.rs
+++ b/crates/pdf-cmap/src/type0/mod.rs
@@ -192,6 +192,35 @@ mod tests {
     }
 
     #[test]
+    fn embedded_cmap_accepts_real_number_metadata() {
+        let data = br#"
+        /CIDInit /ProcSet findresource begin
+        12 dict begin
+        begincmap
+        /CMapName /Uni-Utf8-H def
+        /CMapVersion 1.000 def
+        /CMapType 1 def
+        /WMode 0 def
+        2 begincodespacerange
+        <00> <7F>
+        <E08080> <EFBFBF>
+        endcodespacerange
+        2 begincidchar
+        <20> 1
+        <e38081> 38
+        endcidchar
+        endcmap
+        CMapName currentdict /CMap defineresource pop
+        end
+        end
+        "#;
+
+        let cmap = Type0EncodingCMap::from_bytes(data).unwrap();
+
+        assert_eq!(cmap.decode(&[0x20, 0xE3, 0x80, 0x81]), vec![1, 38]);
+    }
+
+    #[test]
     fn embedded_cmap_uses_notdef_for_unmapped_or_invalid_codes() {
         let data = br#"
         begincmap


### PR DESCRIPTION
Preserve real-number tokens while parsing embedded CMap streams so metadata such as /CMapVersion 1.000 does not abort parsing before the useful sections are reached.

Keep integer-only CMap fields strict and add regression coverage for both Type0 encoding and ToUnicode CMaps.