### PR TITLE
pdf-jbig2: add refinement decode support

### DIFF
--- a/crates/pdf-jbig2/src/arith_decoder/context.rs
+++ b/crates/pdf-jbig2/src/arith_decoder/context.rs
@@ -139,6 +139,12 @@ impl JBig2ArithDecoder<'_, '_> {
             JBig2ArithIntegerContext::SymbolHeightDelta => &mut self.iadh_contexts,
             JBig2ArithIntegerContext::SymbolWidthDelta => &mut self.iadw_contexts,
             JBig2ArithIntegerContext::SymbolExportRunLength => &mut self.iaex_contexts,
+            JBig2ArithIntegerContext::RefinementAggregateInstances => &mut self.iaai_contexts,
+            JBig2ArithIntegerContext::RefinementDeltaWidth => &mut self.iardw_contexts,
+            JBig2ArithIntegerContext::RefinementDeltaHeight => &mut self.iardh_contexts,
+            JBig2ArithIntegerContext::RefinementDeltaX => &mut self.iardx_contexts,
+            JBig2ArithIntegerContext::RefinementDeltaY => &mut self.iardy_contexts,
+            JBig2ArithIntegerContext::RefinementInstance => &mut self.iari_contexts,
         }
     }
 
@@ -154,6 +160,12 @@ impl JBig2ArithDecoder<'_, '_> {
                 JBig2ArithIntegerContext::SymbolHeightDelta => &self.iadh_contexts,
                 JBig2ArithIntegerContext::SymbolWidthDelta => &self.iadw_contexts,
                 JBig2ArithIntegerContext::SymbolExportRunLength => &self.iaex_contexts,
+                JBig2ArithIntegerContext::RefinementAggregateInstances => &self.iaai_contexts,
+                JBig2ArithIntegerContext::RefinementDeltaWidth => &self.iardw_contexts,
+                JBig2ArithIntegerContext::RefinementDeltaHeight => &self.iardh_contexts,
+                JBig2ArithIntegerContext::RefinementDeltaX => &self.iardx_contexts,
+                JBig2ArithIntegerContext::RefinementDeltaY => &self.iardy_contexts,
+                JBig2ArithIntegerContext::RefinementInstance => &self.iari_contexts,
             },
             PoolSelector::Iaid => &self.iaid_contexts,
         }
@@ -171,6 +183,12 @@ impl JBig2ArithDecoder<'_, '_> {
                 JBig2ArithIntegerContext::SymbolHeightDelta => &mut self.iadh_contexts,
                 JBig2ArithIntegerContext::SymbolWidthDelta => &mut self.iadw_contexts,
                 JBig2ArithIntegerContext::SymbolExportRunLength => &mut self.iaex_contexts,
+                JBig2ArithIntegerContext::RefinementAggregateInstances => &mut self.iaai_contexts,
+                JBig2ArithIntegerContext::RefinementDeltaWidth => &mut self.iardw_contexts,
+                JBig2ArithIntegerContext::RefinementDeltaHeight => &mut self.iardh_contexts,
+                JBig2ArithIntegerContext::RefinementDeltaX => &mut self.iardx_contexts,
+                JBig2ArithIntegerContext::RefinementDeltaY => &mut self.iardy_contexts,
+                JBig2ArithIntegerContext::RefinementInstance => &mut self.iari_contexts,
             },
             PoolSelector::Iaid => &mut self.iaid_contexts,
         }

--- a/crates/pdf-jbig2/src/arith_decoder/decoder.rs
+++ b/crates/pdf-jbig2/src/arith_decoder/decoder.rs
@@ -52,6 +52,18 @@ pub(crate) struct JBig2ArithDecoder<'stream, 'data> {
     pub(super) iadw_contexts: Vec<JBig2ArithCtx>,
     /// `IAEX` contexts for symbol export run-length arithmetic integers.
     pub(super) iaex_contexts: Vec<JBig2ArithCtx>,
+    /// `IAAI` contexts for refinement aggregate instance counts.
+    pub(super) iaai_contexts: Vec<JBig2ArithCtx>,
+    /// `IARDW` contexts for refinement width deltas.
+    pub(super) iardw_contexts: Vec<JBig2ArithCtx>,
+    /// `IARDH` contexts for refinement height deltas.
+    pub(super) iardh_contexts: Vec<JBig2ArithCtx>,
+    /// `IARDX` contexts for refinement x deltas.
+    pub(super) iardx_contexts: Vec<JBig2ArithCtx>,
+    /// `IARDY` contexts for refinement y deltas.
+    pub(super) iardy_contexts: Vec<JBig2ArithCtx>,
+    /// `IARI` contexts for refinement instance flags.
+    pub(super) iari_contexts: Vec<JBig2ArithCtx>,
     /// Annex A.3 IAID context tree.
     pub(super) iaid_contexts: Vec<JBig2ArithCtx>,
     /// Code length used to size the current Annex A.3 IAID context tree.
@@ -102,6 +114,12 @@ impl<'stream, 'data> JBig2ArithDecoder<'stream, 'data> {
             iadh_contexts: Vec::new(),
             iadw_contexts: Vec::new(),
             iaex_contexts: Vec::new(),
+            iaai_contexts: Vec::new(),
+            iardw_contexts: Vec::new(),
+            iardh_contexts: Vec::new(),
+            iardx_contexts: Vec::new(),
+            iardy_contexts: Vec::new(),
+            iari_contexts: Vec::new(),
             iaid_contexts: Vec::new(),
             iaid_code_length: None,
         };

--- a/crates/pdf-jbig2/src/arith_decoder/integer.rs
+++ b/crates/pdf-jbig2/src/arith_decoder/integer.rs
@@ -79,6 +79,18 @@ pub(crate) enum JBig2ArithIntegerContext {
     SymbolWidthDelta,
     /// `IAEX`: symbol export run lengths from T.88 section 6.5.8.
     SymbolExportRunLength,
+    /// `IAAI`: refinement aggregate instance counts from T.88 refinement procedures.
+    RefinementAggregateInstances,
+    /// `IARDW`: refinement bitmap width deltas.
+    RefinementDeltaWidth,
+    /// `IARDH`: refinement bitmap height deltas.
+    RefinementDeltaHeight,
+    /// `IARDX`: refinement bitmap x deltas.
+    RefinementDeltaX,
+    /// `IARDY`: refinement bitmap y deltas.
+    RefinementDeltaY,
+    /// `IARI`: text-region refinement flags.
+    RefinementInstance,
 }
 
 impl JBig2ArithDecoder<'_, '_> {

--- a/crates/pdf-jbig2/src/generic_refinement_region.rs
+++ b/crates/pdf-jbig2/src/generic_refinement_region.rs
@@ -132,7 +132,16 @@ pub(crate) fn decode_generic_refinement_region_segment(
     let body = context.remaining_body(GENERIC_REFINEMENT_BODY)?;
     let mut stream = pdf_utils::BitReader::new(body);
     let mut decoder = JBig2ArithDecoder::new(&mut stream);
-    let image = header.decode(reference, &mut decoder)?;
+    let image = GenericRefinementRegionDecode::new(
+        header.region.width,
+        header.region.height,
+        header.template,
+        header.tpgron,
+        header.at,
+        0,
+        0,
+    )
+    .decode(reference, &mut decoder)?;
 
     Ok(DecodedGenericRefinementRegionSegment {
         image,
@@ -178,6 +187,41 @@ impl GenericRefinementRegionHeader {
             at,
         })
     }
+}
+
+/// Arithmetic generic-refinement bitmap decode parameters.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GenericRefinementRegionDecode {
+    width: u16,
+    height: u16,
+    template: RefinementTemplate,
+    tpgron: bool,
+    at: RefinementAdaptiveTemplate,
+    reference_dx: i32,
+    reference_dy: i32,
+}
+
+impl GenericRefinementRegionDecode {
+    /// Create generic-refinement bitmap decode parameters.
+    pub(crate) fn new(
+        width: u16,
+        height: u16,
+        template: RefinementTemplate,
+        tpgron: bool,
+        at: RefinementAdaptiveTemplate,
+        reference_dx: i32,
+        reference_dy: i32,
+    ) -> Self {
+        Self {
+            width,
+            height,
+            template,
+            tpgron,
+            at,
+            reference_dx,
+            reference_dy,
+        }
+    }
 
     /// Decode the refinement bitmap using a referenced bitmap.
     ///
@@ -185,22 +229,22 @@ impl GenericRefinementRegionHeader {
     /// as arithmetic decoding from context bits drawn from the current bitmap
     /// and a reference bitmap. The `TPGRON` row prediction branch is explicitly
     /// rejected until supported.
-    fn decode(
+    pub(crate) fn decode(
         self,
         reference: &JBig2Image,
         decoder: &mut JBig2ArithDecoder<'_, '_>,
     ) -> Result<JBig2Image, Jbig2Error> {
-        if !JBig2Image::is_valid_image_size(self.region.width, self.region.height) {
-            return JBig2Image::try_new(self.region.width, self.region.height, None);
+        if !JBig2Image::is_valid_image_size(self.width, self.height) {
+            return JBig2Image::try_new(self.width, self.height, None);
         }
         if self.tpgron {
             return Err(Jbig2Error::UnsupportedFeature(GENERIC_REFINEMENT_TPGRON));
         }
 
         decoder.ensure_generic_region_contexts()?;
-        let mut image = JBig2Image::try_new(self.region.width, self.region.height, None)?;
-        for y in 0..self.region.height {
-            for x in 0..self.region.width {
+        let mut image = JBig2Image::try_new(self.width, self.height, None)?;
+        for y in 0..self.height {
+            for x in 0..self.width {
                 let context = self.context_label(&image, reference, x, y);
                 let pixel = decoder.decode_prepared_generic_context(context)?;
                 image.set_pixel(x, y, pixel);
@@ -220,7 +264,14 @@ impl GenericRefinementRegionHeader {
             label = (label << 1) | offset.pixel_from(image, x, y);
         }
         for offset in self.template.reference_offsets(self.at) {
-            label = (label << 1) | offset.pixel_from(reference, x, y);
+            label = (label << 1)
+                | offset.pixel_from_with_origin(
+                    reference,
+                    x,
+                    y,
+                    self.reference_dx,
+                    self.reference_dy,
+                );
         }
         label
     }
@@ -231,7 +282,7 @@ impl GenericRefinementRegionHeader {
 /// T.88 / ISO/IEC 14492 section 7.4.7.2 selects between the two generic
 /// refinement templates used by the section 6.3.2 arithmetic context.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RefinementTemplate {
+pub(crate) enum RefinementTemplate {
     /// Template 0, which can include adaptive-template pixels.
     ///
     /// T.88 / ISO/IEC 14492 section 6.3.2 defines this as the default generic
@@ -249,7 +300,7 @@ impl RefinementTemplate {
     ///
     /// T.88 / ISO/IEC 14492 section 7.4.7.2 defines `GRTEMPLATE = 0` as
     /// template 0 and `GRTEMPLATE = 1` as template 1.
-    fn from_flag(template_flag: bool) -> Self {
+    pub(crate) fn from_flag(template_flag: bool) -> Self {
         if template_flag {
             Self::Template1
         } else {
@@ -296,7 +347,7 @@ impl RefinementTemplate {
 /// for generic refinement template 0; section 6.3.2 uses those coordinates as
 /// additional arithmetic context pixels.
 #[derive(Debug, Clone, Copy)]
-struct RefinementAdaptiveTemplate {
+pub(crate) struct RefinementAdaptiveTemplate {
     /// Optional current-region adaptive context pixel from section 7.4.7.
     coding: Option<RefinementOffset>,
     /// Optional reference-image adaptive context pixel from section 7.4.7.
@@ -304,11 +355,25 @@ struct RefinementAdaptiveTemplate {
 }
 
 impl RefinementAdaptiveTemplate {
+    /// Return the default adaptive template values used outside segment syntax.
+    pub(crate) fn default_for(template: RefinementTemplate) -> Self {
+        match template {
+            RefinementTemplate::Template0 => Self {
+                coding: Some(RefinementOffset { x: -1, y: -1 }),
+                reference: Some(RefinementOffset { x: -1, y: -1 }),
+            },
+            RefinementTemplate::Template1 => Self {
+                coding: None,
+                reference: None,
+            },
+        }
+    }
+
     /// Parse template-dependent adaptive-template coordinates.
     ///
     /// T.88 / ISO/IEC 14492 section 7.4.7 includes adaptive-template bytes for
     /// template 0 only; template 1 has no adaptive bytes.
-    fn parse(
+    pub(crate) fn parse(
         stream: &mut pdf_utils::BitReader<'_>,
         template: RefinementTemplate,
     ) -> Result<Self, Jbig2Error> {
@@ -382,11 +447,40 @@ impl RefinementOffset {
     fn pixel_from(self, image: &JBig2Image, x: u16, y: u16) -> usize {
         usize::from(image.pixel_at_offset(x, y, self.x, self.y))
     }
+
+    /// Read the template pixel after applying a signed reference-image origin.
+    fn pixel_from_with_origin(
+        self,
+        image: &JBig2Image,
+        x: u16,
+        y: u16,
+        origin_x: i32,
+        origin_y: i32,
+    ) -> usize {
+        let Some(x) = i32::from(x)
+            .checked_add(origin_x)
+            .and_then(|value| value.checked_add(i32::from(self.x)))
+            .and_then(|value| u16::try_from(value).ok())
+        else {
+            return 0;
+        };
+        let Some(y) = i32::from(y)
+            .checked_add(origin_y)
+            .and_then(|value| value.checked_add(i32::from(self.y)))
+            .and_then(|value| u16::try_from(value).ok())
+        else {
+            return 0;
+        };
+        usize::from(image.get_pixel(x, y))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{GENERIC_REFINEMENT_TPGRON, GenericRefinementRegionHeader, RefinementTemplate};
+    use super::{
+        GENERIC_REFINEMENT_TPGRON, GenericRefinementRegionDecode, GenericRefinementRegionHeader,
+        RefinementTemplate,
+    };
     use crate::{error::Jbig2Error, image::JBig2Image};
     use pdf_utils::BitReader;
 
@@ -433,9 +527,17 @@ mod tests {
         let mut body = BitReader::new(&[0xff]);
         let mut decoder = crate::arith_decoder::JBig2ArithDecoder::new(&mut body);
 
-        let err = header
-            .decode(&JBig2Image::new(1, 1), &mut decoder)
-            .expect_err("tpgron error");
+        let err = GenericRefinementRegionDecode::new(
+            header.region.width,
+            header.region.height,
+            header.template,
+            header.tpgron,
+            header.at,
+            0,
+            0,
+        )
+        .decode(&JBig2Image::new(1, 1), &mut decoder)
+        .expect_err("tpgron error");
 
         assert_eq!(
             err,

--- a/crates/pdf-jbig2/src/symbol_dictionary/arithmetic.rs
+++ b/crates/pdf-jbig2/src/symbol_dictionary/arithmetic.rs
@@ -1,18 +1,37 @@
 use crate::{
     arith_decoder::{JBig2ArithDecoder, JBig2ArithIntegerContext},
+    compose_op::ComposeOp,
     error::Jbig2Error,
+    generic_refinement_region::{
+        GenericRefinementRegionDecode, RefinementAdaptiveTemplate, RefinementTemplate,
+    },
     generic_region::{GenericRegion, GenericRegionTemplate},
     image::JBig2Image,
     symbol_dictionary::{
         export::{fill_export_flag_run, total_symbol_count},
+        flags::SymbolDictionaryFlagBits,
         header::ParsedSymbolDictionaryHeader,
     },
-    util::i32_to_usize,
+    text_region::{
+        geometry::{TextRegionGeometry, TextRegionRefCorner},
+        state::{TextRegionDecodeState, advance_curs_by_delta_s},
+    },
+    util::{
+        INTEGER_CONVERSION_OVERFLOW, ceil_log2, i32_to_usize, refined_dimension,
+        refinement_reference_offset,
+    },
 };
 
 const ARITHMETIC_SYMBOL_HEIGHT: &str = "arithmetic symbol height";
 const ARITHMETIC_SYMBOL_WIDTH: &str = "arithmetic symbol width";
-const INTEGER_CONVERSION_OVERFLOW: &str = "integer conversion overflow";
+const AGGREGATE_SYMBOL_DELTA_T: &str = "aggregate symbol delta t";
+const AGGREGATE_SYMBOL_FIRST_S_DELTA: &str = "aggregate symbol first-s delta";
+const REFINEMENT_AGGREGATE_INSTANCES: &str = "refinement aggregate instances";
+const REFINEMENT_SYMBOL_ID: &str = "refinement symbol id";
+const REFINEMENT_SYMBOL_WIDTH: &str = "refinement symbol width";
+const REFINEMENT_SYMBOL_HEIGHT: &str = "refinement symbol height";
+const REFINEMENT_SYMBOL_X: &str = "refinement symbol x";
+const REFINEMENT_SYMBOL_Y: &str = "refinement symbol y";
 const SYMBOL_DICTIONARY_AT_DATA: &str = "symbol dictionary AT data";
 const SYMBOL_DICTIONARY_HEIGHT_DELTA: &str = "symbol dictionary height delta";
 const SYMBOL_DICTIONARY_WIDTH_RUN: &str = "symbol dictionary width run";
@@ -25,9 +44,11 @@ const SYMBOL_EXPORT_RUN_LENGTH: &str = "symbol export run length";
 /// as a generic region using the dictionary's `SDTEMPLATE`.
 pub(super) fn decode_arithmetic_symbol_dictionary(
     header: &ParsedSymbolDictionaryHeader,
+    input_symbols: &[JBig2Image],
     decoder: &mut JBig2ArithDecoder<'_, '_>,
 ) -> Result<Vec<JBig2Image>, Jbig2Error> {
     let mut new_symbols = Vec::with_capacity(header.num_new_symbols);
+    let symbol_code_length = ceil_log2(input_symbols.len().saturating_add(header.num_new_symbols))?;
     let mut height = 0i32;
 
     while new_symbols.len() < header.num_new_symbols {
@@ -40,7 +61,14 @@ pub(super) fn decode_arithmetic_symbol_dictionary(
             .ok_or(Jbig2Error::Overflow(INTEGER_CONVERSION_OVERFLOW))?;
         let height = u16::try_from(height)
             .map_err(|_| Jbig2Error::InvalidState(ARITHMETIC_SYMBOL_HEIGHT))?;
-        decode_arithmetic_symbol_width_run(header, height, decoder, &mut new_symbols)?;
+        decode_arithmetic_symbol_width_run(
+            header,
+            input_symbols,
+            symbol_code_length,
+            height,
+            decoder,
+            &mut new_symbols,
+        )?;
     }
 
     Ok(new_symbols)
@@ -52,6 +80,8 @@ pub(super) fn decode_arithmetic_symbol_dictionary(
 /// out-of-band result from the symbol width delta arithmetic integer context.
 fn decode_arithmetic_symbol_width_run(
     header: &ParsedSymbolDictionaryHeader,
+    input_symbols: &[JBig2Image],
+    symbol_code_length: u8,
     height: u16,
     decoder: &mut JBig2ArithDecoder<'_, '_>,
     new_symbols: &mut Vec<JBig2Image>,
@@ -72,14 +102,26 @@ fn decode_arithmetic_symbol_width_run(
             .ok_or(Jbig2Error::Overflow(INTEGER_CONVERSION_OVERFLOW))?;
         let width =
             u16::try_from(width).map_err(|_| Jbig2Error::InvalidState(ARITHMETIC_SYMBOL_WIDTH))?;
-        let image = GenericRegion::new_arithmetic(
-            width,
-            height,
-            GenericRegionTemplate::try_from(header.flags.sdtemplate())?,
-            false,
-            generic_at,
-        )?
-        .decode_arithmetic_with_decoder(decoder, None)?;
+        let image = if header.flags.contains(SymbolDictionaryFlagBits::SDREFAGG) {
+            decode_refined_symbol(
+                header,
+                input_symbols,
+                new_symbols,
+                symbol_code_length,
+                width,
+                height,
+                decoder,
+            )?
+        } else {
+            GenericRegion::new_arithmetic(
+                width,
+                height,
+                GenericRegionTemplate::try_from(header.flags.sdtemplate())?,
+                false,
+                generic_at,
+            )?
+            .decode_arithmetic_with_decoder(decoder, None)?
+        };
         new_symbols.push(image);
         if new_symbols.len() > header.num_new_symbols {
             return Err(Jbig2Error::InvalidState(SYMBOL_DICTIONARY_WIDTH_RUN));
@@ -87,6 +129,240 @@ fn decode_arithmetic_symbol_width_run(
     }
 
     Ok(())
+}
+
+/// Decode one single-instance refinement-coded symbol dictionary entry.
+fn decode_refined_symbol(
+    header: &ParsedSymbolDictionaryHeader,
+    input_symbols: &[JBig2Image],
+    new_symbols: &[JBig2Image],
+    symbol_code_length: u8,
+    width: u16,
+    height: u16,
+    decoder: &mut JBig2ArithDecoder<'_, '_>,
+) -> Result<JBig2Image, Jbig2Error> {
+    let aggregate_instances = decoder.decode_required_integer(
+        JBig2ArithIntegerContext::RefinementAggregateInstances,
+        REFINEMENT_AGGREGATE_INSTANCES,
+    )?;
+    if aggregate_instances > 1 {
+        let symbols = CurrentSymbolSet {
+            input_symbols,
+            new_symbols,
+        };
+        let template = RefinementTemplate::from_flag(
+            header
+                .flags
+                .contains(SymbolDictionaryFlagBits::SDR_TEMPLATE),
+        );
+        let at = header
+            .refinement_at
+            .unwrap_or_else(|| RefinementAdaptiveTemplate::default_for(template));
+        return decode_aggregate_refined_symbol(
+            width,
+            height,
+            aggregate_instances,
+            AggregateRefinementParams {
+                symbols,
+                symbol_code_length,
+                template,
+                at,
+            },
+            decoder,
+        );
+    }
+    if aggregate_instances != 1 {
+        return Err(Jbig2Error::InvalidState(REFINEMENT_AGGREGATE_INSTANCES));
+    }
+
+    let symbol_id = usize::try_from(decoder.decode_iaid(symbol_code_length)?)
+        .map_err(|_| Jbig2Error::Overflow(INTEGER_CONVERSION_OVERFLOW))?;
+    let reference = referenced_symbol(input_symbols, new_symbols, symbol_id)?;
+    let delta_x = decoder.decode_required_integer(
+        JBig2ArithIntegerContext::RefinementDeltaX,
+        REFINEMENT_SYMBOL_X,
+    )?;
+    let delta_y = decoder.decode_required_integer(
+        JBig2ArithIntegerContext::RefinementDeltaY,
+        REFINEMENT_SYMBOL_Y,
+    )?;
+    let template = RefinementTemplate::from_flag(
+        header
+            .flags
+            .contains(SymbolDictionaryFlagBits::SDR_TEMPLATE),
+    );
+    let reference_dx = delta_x;
+    let reference_dy = delta_y;
+
+    GenericRefinementRegionDecode::new(
+        width,
+        height,
+        template,
+        false,
+        header
+            .refinement_at
+            .unwrap_or_else(|| RefinementAdaptiveTemplate::default_for(template)),
+        reference_dx,
+        reference_dy,
+    )
+    .decode(reference, decoder)
+}
+
+fn decode_aggregate_refined_symbol(
+    width: u16,
+    height: u16,
+    aggregate_instances: i32,
+    params: AggregateRefinementParams<'_>,
+    decoder: &mut JBig2ArithDecoder<'_, '_>,
+) -> Result<JBig2Image, Jbig2Error> {
+    let symbol_instances = u32::try_from(aggregate_instances)
+        .map_err(|_| Jbig2Error::InvalidState(REFINEMENT_AGGREGATE_INSTANCES))?;
+    let geometry = TextRegionGeometry::new(false, TextRegionRefCorner::TopLeft);
+    let mut image = JBig2Image::try_new(width, height, None)?;
+    let initial_stript = decoder.decode_required_integer(
+        JBig2ArithIntegerContext::TextDeltaT,
+        AGGREGATE_SYMBOL_DELTA_T,
+    )?;
+    let mut state = TextRegionDecodeState::from_initial_delta(initial_stript, 1)?;
+
+    while !state.is_complete(symbol_instances) {
+        decode_aggregate_symbol_strip(
+            &mut image,
+            params,
+            geometry,
+            decoder,
+            &mut state,
+            symbol_instances,
+        )?;
+    }
+
+    Ok(image)
+}
+
+fn decode_aggregate_symbol_strip(
+    image: &mut JBig2Image,
+    params: AggregateRefinementParams<'_>,
+    geometry: TextRegionGeometry,
+    decoder: &mut JBig2ArithDecoder<'_, '_>,
+    state: &mut TextRegionDecodeState,
+    symbol_instances: u32,
+) -> Result<(), Jbig2Error> {
+    let delta_t = decoder.decode_required_integer(
+        JBig2ArithIntegerContext::TextDeltaT,
+        AGGREGATE_SYMBOL_DELTA_T,
+    )?;
+    state.advance_strip(delta_t, 1)?;
+    let delta_first_s = decoder.decode_required_integer(
+        JBig2ArithIntegerContext::TextFirstS,
+        AGGREGATE_SYMBOL_FIRST_S_DELTA,
+    )?;
+    let mut curs = state.consume_first_s_delta(delta_first_s)?;
+
+    loop {
+        let symbol_id = usize::try_from(decoder.decode_iaid(params.symbol_code_length)?)
+            .map_err(|_| Jbig2Error::Overflow(INTEGER_CONVERSION_OVERFLOW))?;
+        let symbol = decode_aggregate_symbol_instance(params, symbol_id, decoder)?;
+        let placed_curs =
+            geometry.adjust_curs_before_placement(curs, symbol.width(), symbol.height())?;
+        let placement =
+            geometry.placement_for(placed_curs, state.stript(), symbol.width(), symbol.height())?;
+        symbol.compose_clipped_to(image, placement.x, placement.y, ComposeOp::Or);
+        curs =
+            geometry.advance_curs_after_placement(placed_curs, symbol.width(), symbol.height())?;
+        state.record_instance()?;
+
+        let Some(delta_s) = decoder.decode_integer(JBig2ArithIntegerContext::TextDeltaS)? else {
+            break;
+        };
+        curs = advance_curs_by_delta_s(curs, delta_s, 0)?;
+        if state.is_complete(symbol_instances) {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn decode_aggregate_symbol_instance(
+    params: AggregateRefinementParams<'_>,
+    symbol_id: usize,
+    decoder: &mut JBig2ArithDecoder<'_, '_>,
+) -> Result<JBig2Image, Jbig2Error> {
+    let reference = params.symbols.get(symbol_id)?;
+    let apply_refinement = decoder.decode_required_integer(
+        JBig2ArithIntegerContext::RefinementInstance,
+        REFINEMENT_AGGREGATE_INSTANCES,
+    )? != 0;
+    if !apply_refinement {
+        return Ok(reference.clone());
+    }
+
+    let delta_width = decoder.decode_required_integer(
+        JBig2ArithIntegerContext::RefinementDeltaWidth,
+        REFINEMENT_SYMBOL_WIDTH,
+    )?;
+    let delta_height = decoder.decode_required_integer(
+        JBig2ArithIntegerContext::RefinementDeltaHeight,
+        REFINEMENT_SYMBOL_HEIGHT,
+    )?;
+    let delta_x = decoder.decode_required_integer(
+        JBig2ArithIntegerContext::RefinementDeltaX,
+        REFINEMENT_SYMBOL_X,
+    )?;
+    let delta_y = decoder.decode_required_integer(
+        JBig2ArithIntegerContext::RefinementDeltaY,
+        REFINEMENT_SYMBOL_Y,
+    )?;
+    let width = refined_dimension(reference.width(), delta_width, REFINEMENT_SYMBOL_WIDTH)?;
+    let height = refined_dimension(reference.height(), delta_height, REFINEMENT_SYMBOL_HEIGHT)?;
+    let reference_dx = refinement_reference_offset(delta_width, delta_x)?;
+    let reference_dy = refinement_reference_offset(delta_height, delta_y)?;
+    GenericRefinementRegionDecode::new(
+        width,
+        height,
+        params.template,
+        false,
+        params.at,
+        reference_dx,
+        reference_dy,
+    )
+    .decode(reference, decoder)
+}
+
+fn referenced_symbol<'a>(
+    input_symbols: &'a [JBig2Image],
+    new_symbols: &'a [JBig2Image],
+    symbol_id: usize,
+) -> Result<&'a JBig2Image, Jbig2Error> {
+    if let Some(symbol) = input_symbols.get(symbol_id) {
+        return Ok(symbol);
+    }
+    let new_index = symbol_id
+        .checked_sub(input_symbols.len())
+        .ok_or(Jbig2Error::InvalidState(REFINEMENT_SYMBOL_ID))?;
+    new_symbols
+        .get(new_index)
+        .ok_or(Jbig2Error::InvalidState(REFINEMENT_SYMBOL_ID))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CurrentSymbolSet<'a> {
+    input_symbols: &'a [JBig2Image],
+    new_symbols: &'a [JBig2Image],
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AggregateRefinementParams<'a> {
+    symbols: CurrentSymbolSet<'a>,
+    symbol_code_length: u8,
+    template: RefinementTemplate,
+    at: RefinementAdaptiveTemplate,
+}
+
+impl<'a> CurrentSymbolSet<'a> {
+    fn get(self, symbol_id: usize) -> Result<&'a JBig2Image, Jbig2Error> {
+        referenced_symbol(self.input_symbols, self.new_symbols, symbol_id)
+    }
 }
 
 /// Decode arithmetic-coded symbol export flags.

--- a/crates/pdf-jbig2/src/symbol_dictionary/header.rs
+++ b/crates/pdf-jbig2/src/symbol_dictionary/header.rs
@@ -1,6 +1,7 @@
 use super::flags::SymbolDictionaryFlagBits;
 use crate::{
     error::Jbig2Error,
+    generic_refinement_region::{RefinementAdaptiveTemplate, RefinementTemplate},
     generic_region::{GenericRegionAdaptiveTemplate, GenericRegionTemplate},
 };
 use pdf_utils::BitReader;
@@ -16,6 +17,8 @@ pub(crate) struct ParsedSymbolDictionaryHeader {
     pub(crate) flags: SymbolDictionaryFlagBits,
     /// Arithmetic generic-region adaptive template parsed when `SDHUFF` is not set.
     pub(super) generic_at: Option<GenericRegionAdaptiveTemplate>,
+    /// Arithmetic refinement adaptive template parsed when `SDREFAGG` is set.
+    pub(super) refinement_at: Option<RefinementAdaptiveTemplate>,
     /// Declared number of exported symbols produced by the segment.
     pub(crate) num_exported: usize,
     /// Declared number of newly decoded symbols carried by the segment.
@@ -43,10 +46,23 @@ impl TryFrom<&mut BitReader<'_>> for ParsedSymbolDictionaryHeader {
                 stream, false, template,
             )?)
         };
+        let refinement_at = if flags.contains(SymbolDictionaryFlagBits::SDREFAGG) {
+            let template = RefinementTemplate::from_flag(
+                flags.contains(SymbolDictionaryFlagBits::SDR_TEMPLATE),
+            );
+            if template == RefinementTemplate::Template0 {
+                Some(RefinementAdaptiveTemplate::parse(stream, template)?)
+            } else {
+                Some(RefinementAdaptiveTemplate::default_for(template))
+            }
+        } else {
+            None
+        };
 
         Self {
             flags,
             generic_at,
+            refinement_at,
             num_exported: stream.try_read_u32_be::<usize>()?,
             num_new_symbols: stream.try_read_u32_be::<usize>()?,
         }
@@ -59,16 +75,10 @@ impl ParsedSymbolDictionaryHeader {
     /// feature set.
     ///
     /// T.88 / ISO 14492 section 7.4.2.1 defines the symbol-dictionary header
-    /// flags. This decoder rejects refinement symbol dictionaries (`SDREFAGG`)
-    /// and the unsupported custom Huffman table variants described by the
-    /// header flags (`SDHUFFDH == 2`, `SDHUFFDW == 2`, or `SDHUFFBMSIZE` set
-    /// with `SDHUFF`).
+    /// flags. This decoder rejects the unsupported custom Huffman table
+    /// variants described by the header flags (`SDHUFFDH == 2`, `SDHUFFDW ==
+    /// 2`, or `SDHUFFBMSIZE` set with `SDHUFF`).
     fn validate_supported(self) -> Result<Self, Jbig2Error> {
-        if self.flags.contains(SymbolDictionaryFlagBits::SDREFAGG) {
-            return Err(Jbig2Error::UnsupportedFeature(
-                "refinement symbol dictionaries",
-            ));
-        }
         if self.flags.contains(SymbolDictionaryFlagBits::SDHUFF)
             && (self.flags.sdhuffdh() == 2 || self.flags.sdhuffdw() == 2)
         {
@@ -112,20 +122,38 @@ mod tests {
     }
 
     #[test]
-    fn header_rejects_refinement_symbol_dictionaries() {
+    fn header_accepts_refinement_symbol_dictionaries() {
         let flags = 1u16 << 1;
         let mut data = Vec::new();
         data.extend_from_slice(&flags.to_be_bytes());
         data.extend_from_slice(&[0u8; 8]);
+        data.extend_from_slice(&[0u8; 4]);
         data.extend_from_slice(&7u32.to_be_bytes());
         data.extend_from_slice(&9u32.to_be_bytes());
 
         let mut reader = BitReader::new(&data);
-        let err = ParsedSymbolDictionaryHeader::try_from(&mut reader).expect_err("header");
-        assert_eq!(
-            err,
-            Jbig2Error::UnsupportedFeature("refinement symbol dictionaries")
-        );
+        let header = ParsedSymbolDictionaryHeader::try_from(&mut reader).expect("header");
+        assert_eq!(header.num_exported, 7);
+        assert_eq!(header.num_new_symbols, 9);
+    }
+
+    #[test]
+    fn refinement_header_reads_refinement_at_bytes_before_symbol_counts() {
+        let flags = 1u16 << 1;
+        let mut data = Vec::new();
+        data.extend_from_slice(&flags.to_be_bytes());
+        data.extend_from_slice(&[3u8, 0xff, 0xfd, 0xff, 2, 0xfe, 0xfe, 0xfe]);
+        data.extend_from_slice(&[0xff, 0xff, 0xff, 0xff]);
+        data.extend_from_slice(&11u32.to_be_bytes());
+        data.extend_from_slice(&4u32.to_be_bytes());
+
+        let mut reader = BitReader::new(&data);
+        let header = ParsedSymbolDictionaryHeader::try_from(&mut reader).expect("header");
+
+        assert!(header.refinement_at.is_some());
+        assert_eq!(header.num_exported, 11);
+        assert_eq!(header.num_new_symbols, 4);
+        assert_eq!(reader.byte_pos(), 22);
     }
 
     #[test]

--- a/crates/pdf-jbig2/src/symbol_dictionary/mod.rs
+++ b/crates/pdf-jbig2/src/symbol_dictionary/mod.rs
@@ -126,7 +126,8 @@ impl<'context, 'segment, 'stream, 'data, 'decoded, 'prior>
     /// contexts for symbol height deltas, width deltas, and export run lengths.
     fn decode_arithmetic_dictionary(&mut self) -> Result<SymbolDictionary, Jbig2Error> {
         let mut decoder = self.context.arithmetic_decoder_until_end()?;
-        let new_symbols = decode_arithmetic_symbol_dictionary(&self.header, &mut decoder)?;
+        let new_symbols =
+            decode_arithmetic_symbol_dictionary(&self.header, &self.input_symbols, &mut decoder)?;
         let export_flags = arithmetic::decode_export_flags(
             &mut decoder,
             self.input_symbols.len(),

--- a/crates/pdf-jbig2/src/text_region.rs
+++ b/crates/pdf-jbig2/src/text_region.rs
@@ -8,11 +8,11 @@
 mod arithmetic;
 mod bitmap;
 mod flags;
-mod geometry;
+pub(crate) mod geometry;
 mod huffman;
 mod huffman_flags;
 mod parser;
-mod state;
+pub(crate) mod state;
 
 use crate::{
     error::Jbig2Error,

--- a/crates/pdf-jbig2/src/text_region/arithmetic.rs
+++ b/crates/pdf-jbig2/src/text_region/arithmetic.rs
@@ -4,6 +4,9 @@ use crate::{
     arith_decoder::{JBig2ArithDecoder, JBig2ArithIntegerContext},
     compose_op::ComposeOp,
     error::Jbig2Error,
+    generic_refinement_region::{
+        GenericRefinementRegionDecode, RefinementAdaptiveTemplate, RefinementTemplate,
+    },
     image::JBig2Image,
     segment_context::SegmentDecodeContext,
     text_region::{
@@ -13,13 +16,20 @@ use crate::{
         parser::ParsedTextRegion,
         state::{TextRegionDecodeState, advance_curs_by_delta_s},
     },
-    util::{INTEGER_CONVERSION_OVERFLOW, ceil_log2},
+    util::{
+        INTEGER_CONVERSION_OVERFLOW, ceil_log2, refined_dimension, refinement_reference_offset,
+    },
 };
 use pdf_utils::BitReader;
 
 const TEXT_REGION_DELTA_T: &str = "text region delta t";
 const TEXT_REGION_FIRST_S_DELTA: &str = "text region first-s delta";
 const TEXT_REGION_INSTANCE_T: &str = "text region instance t";
+const TEXT_REGION_REFINEMENT_FLAG: &str = "text region refinement flag";
+const TEXT_REGION_REFINEMENT_WIDTH: &str = "text region refinement width";
+const TEXT_REGION_REFINEMENT_HEIGHT: &str = "text region refinement height";
+const TEXT_REGION_REFINEMENT_X: &str = "text region refinement x";
+const TEXT_REGION_REFINEMENT_Y: &str = "text region refinement y";
 const TEXT_REGION_SYMBOL_ID: &str = "text region symbol id";
 
 /// Decode an arithmetic-coded JBIG2 text-region body.
@@ -51,17 +61,13 @@ impl<'a> ArithmeticTextRegionDecoder<'a> {
     /// Create an arithmetic text-region decoder from parsed segment state.
     ///
     /// ITU-T T.88 | ISO/IEC 14492 section 7.4.3.1.1 permits refinement text
-    /// regions, but this decoder currently supports only non-refinement input.
+    /// regions. When `SBREFINE` is set, individual instances carry a
+    /// refinement flag and may decode a temporary refinement bitmap before
+    /// composition.
     fn new(
         context: &SegmentDecodeContext<'_, '_, '_, '_, '_>,
         parsed: ParsedTextRegion<'a>,
     ) -> Result<Self, Jbig2Error> {
-        if parsed.flags.contains(TextRegionFlagBits::SBREFINE) {
-            return Err(Jbig2Error::UnsupportedFeature(
-                "arithmetic refinement text regions",
-            ));
-        }
-
         let symbols = context.referred_symbol_images()?;
         if symbols.is_empty() {
             return Err(Jbig2Error::MissingSegment);
@@ -161,7 +167,27 @@ impl<'a> ArithmeticTextRegionDecoder<'a> {
             .ok_or(Jbig2Error::Overflow(INTEGER_CONVERSION_OVERFLOW))?;
         let symbol_id = usize::try_from(decoder.decode_iaid(self.symbol_code_length)?)
             .map_err(|_| Jbig2Error::Overflow(INTEGER_CONVERSION_OVERFLOW))?;
-        self.draw_instance(symbol_id, curs, ti, state)
+        let refined = self.decode_refinement_flag(decoder)?;
+        if refined {
+            self.draw_refined_instance(symbol_id, curs, ti, decoder, state)
+        } else {
+            self.draw_instance(symbol_id, curs, ti, state)
+        }
+    }
+
+    /// Decode the per-instance refinement flag when `SBREFINE` is enabled.
+    fn decode_refinement_flag(
+        &self,
+        decoder: &mut JBig2ArithDecoder<'_, '_>,
+    ) -> Result<bool, Jbig2Error> {
+        if !self.parsed.flags.contains(TextRegionFlagBits::SBREFINE) {
+            return Ok(false);
+        }
+        let value = decoder.decode_required_integer(
+            JBig2ArithIntegerContext::RefinementInstance,
+            TEXT_REGION_REFINEMENT_FLAG,
+        )?;
+        Ok(value != 0)
     }
 
     /// Compose one decoded symbol and return the next `CURS` value.
@@ -191,6 +217,77 @@ impl<'a> ArithmeticTextRegionDecoder<'a> {
             placed_curs,
             symbol.width(),
             symbol.height(),
+        )?;
+        state.record_instance()?;
+        Ok(curs)
+    }
+
+    /// Decode, compose, and advance one refinement-coded symbol instance.
+    fn draw_refined_instance(
+        &mut self,
+        symbol_id: usize,
+        curs: i64,
+        ti: i64,
+        decoder: &mut JBig2ArithDecoder<'_, '_>,
+        state: &mut TextRegionDecodeState,
+    ) -> Result<i64, Jbig2Error> {
+        let reference = self
+            .symbols
+            .get(symbol_id)
+            .ok_or(Jbig2Error::InvalidState(TEXT_REGION_SYMBOL_ID))?;
+        let delta_width = decoder.decode_required_integer(
+            JBig2ArithIntegerContext::RefinementDeltaWidth,
+            TEXT_REGION_REFINEMENT_WIDTH,
+        )?;
+        let delta_height = decoder.decode_required_integer(
+            JBig2ArithIntegerContext::RefinementDeltaHeight,
+            TEXT_REGION_REFINEMENT_HEIGHT,
+        )?;
+        let delta_x = decoder.decode_required_integer(
+            JBig2ArithIntegerContext::RefinementDeltaX,
+            TEXT_REGION_REFINEMENT_X,
+        )?;
+        let delta_y = decoder.decode_required_integer(
+            JBig2ArithIntegerContext::RefinementDeltaY,
+            TEXT_REGION_REFINEMENT_Y,
+        )?;
+        let width =
+            refined_dimension(reference.width(), delta_width, TEXT_REGION_REFINEMENT_WIDTH)?;
+        let height = refined_dimension(
+            reference.height(),
+            delta_height,
+            TEXT_REGION_REFINEMENT_HEIGHT,
+        )?;
+        let template = RefinementTemplate::from_flag(
+            self.parsed.flags.contains(TextRegionFlagBits::SBRTEMPLATE),
+        );
+        let at = self
+            .parsed
+            .refinement_at
+            .unwrap_or_else(|| RefinementAdaptiveTemplate::default_for(template));
+        let reference_dx = refinement_reference_offset(delta_width, delta_x)?;
+        let reference_dy = refinement_reference_offset(delta_height, delta_y)?;
+        let image = GenericRefinementRegionDecode::new(
+            width,
+            height,
+            template,
+            false,
+            at,
+            reference_dx,
+            reference_dy,
+        )
+        .decode(reference, decoder)?;
+        let placed_curs =
+            self.geometry
+                .adjust_curs_before_placement(curs, image.width(), image.height())?;
+        let placement =
+            self.geometry
+                .placement_for(placed_curs, ti, image.width(), image.height())?;
+        image.compose_clipped_to(&mut self.region, placement.x, placement.y, self.compose_op);
+        let curs = self.geometry.advance_curs_after_placement(
+            placed_curs,
+            image.width(),
+            image.height(),
         )?;
         state.record_instance()?;
         Ok(curs)

--- a/crates/pdf-jbig2/src/text_region/parser.rs
+++ b/crates/pdf-jbig2/src/text_region/parser.rs
@@ -2,13 +2,13 @@
 
 use crate::{
     error::Jbig2Error,
+    generic_refinement_region::{RefinementAdaptiveTemplate, RefinementTemplate},
     region_info::RegionInfo,
     segment_context::SegmentDecodeContext,
     text_region::{flags::TextRegionFlagBits, huffman_flags::TextRegionHuffmanFlags},
 };
 use pdf_utils::BitReader;
 
-const REFINEMENT_AT_BYTES: usize = 4;
 const TEXT_REGION_BODY: &str = "text region body";
 
 /// Parsed JBIG2 text-region segment header and body slice.
@@ -24,6 +24,8 @@ pub(crate) struct ParsedTextRegion<'a> {
     pub(crate) flags: TextRegionFlagBits,
     /// Optional Huffman table selectors from section 7.4.3.1.2.
     pub(crate) huffman_flags: Option<TextRegionHuffmanFlags>,
+    /// Optional refinement adaptive-template data from section 7.4.3.1.1.
+    pub(crate) refinement_at: Option<RefinementAdaptiveTemplate>,
     /// `SBNUMINSTANCES`, the symbol-instance count used by section 6.4.5.
     pub(crate) symbol_instances: u32,
     /// Encoded text-region data after the segment header.
@@ -73,11 +75,7 @@ impl<'a> ParsedTextRegion<'a> {
             None
         };
 
-        if flags.contains(TextRegionFlagBits::SBREFINE)
-            && !flags.contains(TextRegionFlagBits::SBRTEMPLATE)
-        {
-            Self::skip_refinement_at_bytes(stream)?;
-        }
+        let refinement_at = Self::parse_refinement_at(stream, flags)?;
 
         let symbol_instances = stream.try_read_u32_be::<u32>()?;
         let body = stream
@@ -88,6 +86,7 @@ impl<'a> ParsedTextRegion<'a> {
             region,
             flags,
             huffman_flags,
+            refinement_at,
             symbol_instances,
             body,
         })
@@ -108,14 +107,22 @@ impl<'a> ParsedTextRegion<'a> {
         Ok(())
     }
 
-    /// Skip refinement adaptive-template bytes when `SBREFINE = 1` and `SBRTEMPLATE = 0`.
+    /// Parse refinement adaptive-template bytes when `SBREFINE = 1`.
     ///
-    /// ITU-T T.88 | ISO/IEC 14492 section 7.4.3.1.1 stores four bytes of
-    /// refinement AT coordinates for that flag combination.
-    fn skip_refinement_at_bytes(stream: &mut BitReader<'a>) -> Result<(), Jbig2Error> {
-        for _ in 0..REFINEMENT_AT_BYTES {
-            let _ = stream.try_read_u8::<u8>()?;
+    /// ITU-T T.88 | ISO/IEC 14492 section 7.4.3.1.1 stores refinement AT
+    /// coordinates when template 0 is selected.
+    fn parse_refinement_at(
+        stream: &mut BitReader<'a>,
+        flags: TextRegionFlagBits,
+    ) -> Result<Option<RefinementAdaptiveTemplate>, Jbig2Error> {
+        if !flags.contains(TextRegionFlagBits::SBREFINE) {
+            return Ok(None);
         }
-        Ok(())
+        let template =
+            RefinementTemplate::from_flag(flags.contains(TextRegionFlagBits::SBRTEMPLATE));
+        if template == RefinementTemplate::Template0 {
+            return RefinementAdaptiveTemplate::parse(stream, template).map(Some);
+        }
+        Ok(Some(RefinementAdaptiveTemplate::default_for(template)))
     }
 }

--- a/crates/pdf-jbig2/src/util.rs
+++ b/crates/pdf-jbig2/src/util.rs
@@ -39,5 +39,22 @@ pub(crate) fn required_huffman_value(value: HuffmanValue) -> Result<i32, Jbig2Er
     }
 }
 
+pub(crate) fn refinement_reference_offset(size_delta: i32, delta: i32) -> Result<i32, Jbig2Error> {
+    (size_delta >> 1)
+        .checked_add(delta)
+        .ok_or(Jbig2Error::Overflow(INTEGER_CONVERSION_OVERFLOW))
+}
+
+pub(crate) fn refined_dimension(
+    base: u16,
+    delta: i32,
+    label: &'static str,
+) -> Result<u16, Jbig2Error> {
+    let value = i32::from(base)
+        .checked_add(delta)
+        .ok_or(Jbig2Error::Overflow(INTEGER_CONVERSION_OVERFLOW))?;
+    u16::try_from(value).map_err(|_| Jbig2Error::InvalidState(label))
+}
+
 #[cfg(test)]
 mod tests {}


### PR DESCRIPTION
Support JBIG2 refinement symbol dictionaries and
arithmetic text regions, including reusable generic refinement decoding helpers and the needed
arithmetic context pools.