### PR TITLE
pdf-jbig2: support custom Huffman tables

### DIFF
--- a/crates/pdf-jbig2/src/huffman/custom.rs
+++ b/crates/pdf-jbig2/src/huffman/custom.rs
@@ -1,0 +1,268 @@
+use pdf_utils::BitReader;
+
+use crate::error::Jbig2Error;
+
+use super::{
+    code::{HuffmanCode, assign_canonical_codes},
+    decoder::{HuffmanValue, read_extra_bits},
+    tree::DecodeTree,
+};
+
+const CODE_TABLE_HEADER: &str = "Huffman code table header";
+const CODE_TABLE_BITS: &str = "Huffman code table bits";
+const CODE_TABLE_RANGE: &str = "Huffman code table range";
+const CODE_TABLE_PREFIX_LENGTH: &str = "Huffman code table prefix length";
+const CODE_TABLE_RANGE_LENGTH: &str = "Huffman code table range length";
+const DECODED_VALUE_OVERFLOW: &str = "Huffman decoded value overflow";
+const INTEGER_CONVERSION_OVERFLOW: &str = "integer conversion overflow";
+const MAX_CODE_LEN: u8 = 32;
+const MAX_RANGE_LEN: u8 = 32;
+
+/// Decoder for a JBIG2 Tables segment carrying a custom Huffman table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CustomHuffmanDecoder {
+    entries: Vec<CustomHuffmanEntry>,
+    codes: Vec<HuffmanCode>,
+    tree: DecodeTree,
+}
+
+impl CustomHuffmanDecoder {
+    /// Parse a custom Huffman code table segment body.
+    pub(crate) fn parse(data: &[u8]) -> Result<Self, Jbig2Error> {
+        let mut reader = BitReader::new(data);
+        let flags = reader.try_read_u8::<u8>()?;
+        let lowest_value = reader.try_read_i32_be()?;
+        let highest_value = reader.try_read_i32_be()?;
+        if lowest_value > highest_value {
+            return Err(Jbig2Error::InvalidTable(CODE_TABLE_RANGE));
+        }
+
+        let prefix_size_bits = ((flags >> 1) & 0x07).saturating_add(1);
+        let range_size_bits = ((flags >> 4) & 0x07).saturating_add(1);
+        let has_oob = flags & 1 != 0;
+        if reader.byte_pos() != 9 {
+            return Err(Jbig2Error::InvalidTable(CODE_TABLE_HEADER));
+        }
+
+        let mut entries = Vec::new();
+        let mut lengths = Vec::new();
+        let mut current_range_low = lowest_value;
+        while current_range_low < highest_value {
+            let prefix_len = read_table_bits(&mut reader, prefix_size_bits)?;
+            let range_len = read_table_bits(&mut reader, range_size_bits)?;
+            validate_prefix_len(prefix_len)?;
+            validate_range_len(range_len)?;
+            lengths.push(prefix_len);
+            entries.push(CustomHuffmanEntry {
+                range_low: current_range_low,
+                range_len,
+                kind: CustomHuffmanEntryKind::Normal,
+            });
+            let range_size = range_size(range_len)?;
+            current_range_low = current_range_low
+                .checked_add(range_size)
+                .ok_or(Jbig2Error::Overflow(CODE_TABLE_RANGE))?;
+        }
+
+        let lower_prefix_len = read_table_bits(&mut reader, prefix_size_bits)?;
+        validate_prefix_len(lower_prefix_len)?;
+        lengths.push(lower_prefix_len);
+        entries.push(CustomHuffmanEntry {
+            range_low: lowest_value
+                .checked_sub(1)
+                .ok_or(Jbig2Error::Overflow(CODE_TABLE_RANGE))?,
+            range_len: MAX_RANGE_LEN,
+            kind: CustomHuffmanEntryKind::Lower,
+        });
+
+        let upper_prefix_len = read_table_bits(&mut reader, prefix_size_bits)?;
+        validate_prefix_len(upper_prefix_len)?;
+        lengths.push(upper_prefix_len);
+        entries.push(CustomHuffmanEntry {
+            range_low: highest_value,
+            range_len: MAX_RANGE_LEN,
+            kind: CustomHuffmanEntryKind::Normal,
+        });
+
+        if has_oob {
+            let oob_prefix_len = read_table_bits(&mut reader, prefix_size_bits)?;
+            validate_prefix_len(oob_prefix_len)?;
+            lengths.push(oob_prefix_len);
+            entries.push(CustomHuffmanEntry {
+                range_low: 0,
+                range_len: 0,
+                kind: CustomHuffmanEntryKind::OutOfBand,
+            });
+        }
+
+        let codes = assign_canonical_codes(&lengths)?;
+        let tree = DecodeTree::new(&codes)?;
+        Ok(Self {
+            entries,
+            codes,
+            tree,
+        })
+    }
+
+    /// Decode one custom Huffman table value.
+    pub(crate) fn decode(&self, reader: &mut BitReader<'_>) -> Result<HuffmanValue, Jbig2Error> {
+        let index = self.tree.decode(reader, CODE_TABLE_BITS)?;
+        let entry = self
+            .entries
+            .get(index)
+            .ok_or(Jbig2Error::InvalidTable(CODE_TABLE_HEADER))?;
+        if entry.kind == CustomHuffmanEntryKind::OutOfBand {
+            return Ok(HuffmanValue::OutOfBand);
+        }
+
+        let extra = read_extra_bits(reader, entry.range_len)?;
+        let decoded = if entry.kind == CustomHuffmanEntryKind::Lower {
+            entry.range_low.checked_sub(extra)
+        } else {
+            entry.range_low.checked_add(extra)
+        }
+        .ok_or(Jbig2Error::Overflow(DECODED_VALUE_OVERFLOW))?;
+        Ok(HuffmanValue::Value(decoded))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CustomHuffmanEntry {
+    range_low: i32,
+    range_len: u8,
+    kind: CustomHuffmanEntryKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CustomHuffmanEntryKind {
+    Normal,
+    Lower,
+    OutOfBand,
+}
+
+fn read_table_bits(reader: &mut BitReader<'_>, bits: u8) -> Result<u8, Jbig2Error> {
+    let value = reader
+        .read_bits(bits)
+        .ok_or(Jbig2Error::Truncated(CODE_TABLE_BITS))?;
+    u8::try_from(value).map_err(|_| Jbig2Error::Overflow(INTEGER_CONVERSION_OVERFLOW))
+}
+
+fn validate_prefix_len(prefix_len: u8) -> Result<(), Jbig2Error> {
+    if prefix_len > MAX_CODE_LEN {
+        return Err(Jbig2Error::InvalidTable(CODE_TABLE_PREFIX_LENGTH));
+    }
+    Ok(())
+}
+
+fn validate_range_len(range_len: u8) -> Result<(), Jbig2Error> {
+    if range_len > MAX_RANGE_LEN {
+        return Err(Jbig2Error::InvalidTable(CODE_TABLE_RANGE_LENGTH));
+    }
+    Ok(())
+}
+
+fn range_size(range_len: u8) -> Result<i32, Jbig2Error> {
+    if range_len >= 31 {
+        return Err(Jbig2Error::InvalidTable(CODE_TABLE_RANGE_LENGTH));
+    }
+    1i32.checked_shl(u32::from(range_len))
+        .ok_or(Jbig2Error::Overflow(CODE_TABLE_RANGE))
+}
+
+#[cfg(test)]
+mod tests {
+    use pdf_utils::BitReader;
+
+    use super::CustomHuffmanDecoder;
+    use crate::{error::Jbig2Error, huffman::HuffmanValue};
+
+    fn push_header(bytes: &mut Vec<u8>, flags: u8, lowest_value: i32, highest_value: i32) {
+        bytes.push(flags);
+        bytes.extend_from_slice(&lowest_value.to_be_bytes());
+        bytes.extend_from_slice(&highest_value.to_be_bytes());
+    }
+
+    fn push_bits(bits: &mut Vec<bool>, value: u32, width: u8) {
+        for shift in (0..u32::from(width)).rev() {
+            bits.push(((value >> shift) & 1) != 0);
+        }
+    }
+
+    fn push_bits_as_bytes(bytes: &mut Vec<u8>, bits: &[bool]) {
+        let mut current = 0u8;
+        for (index, bit) in bits.iter().copied().enumerate() {
+            if bit {
+                current |= 1u8 << (7usize.saturating_sub(index % 8));
+            }
+            if index % 8 == 7 {
+                bytes.push(current);
+                current = 0;
+            }
+        }
+        if bits.len() % 8 != 0 {
+            bytes.push(current);
+        }
+    }
+
+    fn simple_table() -> CustomHuffmanDecoder {
+        let mut data = Vec::new();
+        push_header(&mut data, 0b0000_0010, 0, 2);
+        let mut bits = Vec::new();
+        push_bits(&mut bits, 1, 2);
+        push_bits(&mut bits, 0, 1);
+        push_bits(&mut bits, 2, 2);
+        push_bits(&mut bits, 0, 1);
+        push_bits(&mut bits, 0, 2);
+        push_bits(&mut bits, 2, 2);
+        push_bits_as_bytes(&mut data, &bits);
+        CustomHuffmanDecoder::parse(&data).expect("custom table")
+    }
+
+    #[test]
+    fn decodes_custom_table_normal_ranges() {
+        let table = simple_table();
+        let data = [0b0100_0000u8];
+        let mut reader = BitReader::new(&data);
+
+        assert_eq!(table.decode(&mut reader), Ok(HuffmanValue::Value(0)));
+        assert_eq!(table.decode(&mut reader), Ok(HuffmanValue::Value(1)));
+    }
+
+    #[test]
+    fn decodes_custom_table_upper_open_range() {
+        let table = simple_table();
+        let mut bits = Vec::new();
+        push_bits(&mut bits, 0b11, 2);
+        push_bits(&mut bits, 5, 32);
+        let mut data = Vec::new();
+        push_bits_as_bytes(&mut data, &bits);
+        let mut reader = BitReader::new(&data);
+
+        assert_eq!(table.decode(&mut reader), Ok(HuffmanValue::Value(7)));
+    }
+
+    #[test]
+    fn decodes_custom_table_oob_row() {
+        let mut data = Vec::new();
+        push_header(&mut data, 0b0000_0011, 0, 1);
+        let mut bits = Vec::new();
+        push_bits(&mut bits, 1, 2);
+        push_bits(&mut bits, 0, 1);
+        push_bits(&mut bits, 0, 2);
+        push_bits(&mut bits, 2, 2);
+        push_bits(&mut bits, 2, 2);
+        push_bits_as_bytes(&mut data, &bits);
+        let table = CustomHuffmanDecoder::parse(&data).expect("custom table");
+        let encoded = [0b1100_0000u8];
+        let mut reader = BitReader::new(&encoded);
+
+        assert_eq!(table.decode(&mut reader), Ok(HuffmanValue::OutOfBand));
+    }
+
+    #[test]
+    fn rejects_truncated_custom_table() {
+        let err = CustomHuffmanDecoder::parse(&[0]).expect_err("truncated");
+
+        assert_eq!(err, Jbig2Error::Truncated("byte-aligned read"));
+    }
+}

--- a/crates/pdf-jbig2/src/huffman/decoder.rs
+++ b/crates/pdf-jbig2/src/huffman/decoder.rs
@@ -146,7 +146,7 @@ impl StandardHuffmanDecoder {
 /// ITU-T T.88 / ISO/IEC 14492 Annex B names this count `RANGELEN`; bits are
 /// read most-significant first and interpreted as an unsigned integer before
 /// being added to or subtracted from `RANGELOW`.
-fn read_extra_bits(reader: &mut BitReader<'_>, bit_len: u8) -> Result<i32, Jbig2Error> {
+pub(crate) fn read_extra_bits(reader: &mut BitReader<'_>, bit_len: u8) -> Result<i32, Jbig2Error> {
     let mut value = 0i32;
     for _ in 0..bit_len {
         let bit = reader

--- a/crates/pdf-jbig2/src/huffman/mod.rs
+++ b/crates/pdf-jbig2/src/huffman/mod.rs
@@ -5,7 +5,10 @@
 //! text-region procedure. The ITU recommendation is available at
 //! <https://www.itu.int/rec/T-REC-T.88>.
 
+use crate::error::Jbig2Error;
+
 mod code;
+mod custom;
 mod decoder;
 mod selector;
 mod standard;
@@ -15,6 +18,7 @@ pub(crate) mod test_support;
 mod tree;
 
 pub(crate) use code::HuffmanCode;
+pub(crate) use custom::CustomHuffmanDecoder;
 pub(crate) use decoder::{HuffmanValue, StandardHuffmanDecoder};
 pub(crate) use selector::{
     HuffmanTableSelection, text_region_refinement_standard_decoder,
@@ -26,3 +30,25 @@ pub(crate) use standard::{STANDARD_TABLE_B2, STANDARD_TABLE_B4};
 pub(crate) use symbol_id::{
     SymbolIdHuffmanTable, decode_symbol_id, decode_symbol_id_huffman_table,
 };
+
+/// A JBIG2 Huffman decoder selected from either Annex B standard tables or a custom table segment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HuffmanDecoder {
+    /// Standard Annex B Huffman table.
+    Standard(StandardHuffmanDecoder),
+    /// Custom Huffman table decoded from a Tables segment.
+    Custom(CustomHuffmanDecoder),
+}
+
+impl HuffmanDecoder {
+    /// Decode one Huffman value from `reader`.
+    pub(crate) fn decode(
+        &self,
+        reader: &mut pdf_utils::BitReader<'_>,
+    ) -> Result<HuffmanValue, Jbig2Error> {
+        match self {
+            Self::Standard(decoder) => decoder.decode(reader),
+            Self::Custom(decoder) => decoder.decode(reader),
+        }
+    }
+}

--- a/crates/pdf-jbig2/src/segment.rs
+++ b/crates/pdf-jbig2/src/segment.rs
@@ -3,6 +3,7 @@
 use crate::pattern_dictionary::PatternDictionary;
 use crate::symbol_dictionary::SymbolDictionary;
 
+use super::huffman::CustomHuffmanDecoder;
 use super::image::JBig2Image;
 use super::segment_header::SegmentHeaderFlagBits;
 
@@ -91,6 +92,7 @@ impl SegmentType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum JBig2SegmentResult {
     None,
+    HuffmanTable(CustomHuffmanDecoder),
     Image(JBig2Image),
     PatternDictionary(PatternDictionary),
     SymbolDictionary(SymbolDictionary),

--- a/crates/pdf-jbig2/src/segment_context.rs
+++ b/crates/pdf-jbig2/src/segment_context.rs
@@ -3,6 +3,7 @@
 use crate::{
     arith_decoder::JBig2ArithDecoder,
     error::Jbig2Error,
+    huffman::CustomHuffmanDecoder,
     image::JBig2Image,
     pattern_dictionary::PatternDictionary,
     segment::{JBig2SegmentResult, ParsedSegment},
@@ -115,6 +116,31 @@ impl<'segment, 'stream, 'data, 'decoded, 'prior>
             }
         }
         Ok(images)
+    }
+
+    /// Resolves a custom Huffman table by index among referenced Tables segments.
+    ///
+    /// JBIG2 Huffman table selectors consume only referenced Code Table
+    /// segments; other referenced segment types are ignored for this lookup.
+    pub(crate) fn referred_huffman_table(
+        &self,
+        table_index: usize,
+    ) -> Result<&CustomHuffmanDecoder, Jbig2Error> {
+        let mut current_index = 0usize;
+        for referred_number in &self.segment.referred_to_segment_numbers {
+            let referred = self
+                .referred_segment(*referred_number)
+                .ok_or(Jbig2Error::MissingSegment)?;
+            if let JBig2SegmentResult::HuffmanTable(table) = &referred.result {
+                if current_index == table_index {
+                    return Ok(table);
+                }
+                current_index = current_index
+                    .checked_add(1)
+                    .ok_or(Jbig2Error::Overflow("Huffman table index overflow"))?;
+            }
+        }
+        Err(Jbig2Error::MissingSegment)
     }
 
     /// Resolves the first pattern dictionary referenced by the current segment.

--- a/crates/pdf-jbig2/src/stream.rs
+++ b/crates/pdf-jbig2/src/stream.rs
@@ -6,6 +6,7 @@ use crate::{
     generic_refinement_region::decode_generic_refinement_region_segment,
     generic_region::GenericRegion,
     halftone_region::decode_halftone_region_segment,
+    huffman::CustomHuffmanDecoder,
     image::JBig2Image,
     page::PageInfo,
     pattern_dictionary::PatternDictionary,
@@ -209,10 +210,8 @@ impl<'data, 'prior> Jbig2SegmentStreamDecoder<'data, 'prior> {
             }
             SegmentType::PageInformation => self.initialize_page_from_info()?,
             SegmentType::EndOfPage | SegmentType::EndOfFile => return Ok(false),
-            SegmentType::EndOfStripe
-            | SegmentType::Profile
-            | SegmentType::CodeTable
-            | SegmentType::Extension => {}
+            SegmentType::CodeTable => self.decode_code_table(segment, segment_end)?,
+            SegmentType::EndOfStripe | SegmentType::Profile | SegmentType::Extension => {}
         }
 
         Ok(true)
@@ -269,6 +268,20 @@ impl<'data, 'prior> Jbig2SegmentStreamDecoder<'data, 'prior> {
         );
         let dict = PatternDictionary::decode(&mut context)?;
         segment.result = JBig2SegmentResult::PatternDictionary(dict);
+        Ok(())
+    }
+
+    /// Decode a JBIG2 Tables segment and retain its custom Huffman table.
+    fn decode_code_table(
+        &mut self,
+        segment: &mut ParsedSegment,
+        segment_end: usize,
+    ) -> Result<(), Jbig2Error> {
+        let data = self
+            .stream
+            .remaining_from_byte_until(segment_end)
+            .ok_or(Jbig2Error::Truncated("Huffman code table segment"))?;
+        segment.result = JBig2SegmentResult::HuffmanTable(CustomHuffmanDecoder::parse(data)?);
         Ok(())
     }
 

--- a/crates/pdf-jbig2/src/symbol_dictionary/header.rs
+++ b/crates/pdf-jbig2/src/symbol_dictionary/header.rs
@@ -75,20 +75,14 @@ impl ParsedSymbolDictionaryHeader {
     /// feature set.
     ///
     /// T.88 / ISO 14492 section 7.4.2.1 defines the symbol-dictionary header
-    /// flags. This decoder rejects the unsupported custom Huffman table
-    /// variants described by the header flags (`SDHUFFDH == 2`, `SDHUFFDW ==
-    /// 2`, or `SDHUFFBMSIZE` set with `SDHUFF`).
+    /// flags. This decoder rejects the invalid Huffman table selector value
+    /// `2` for `SDHUFFDH` and `SDHUFFDW`.
     fn validate_supported(self) -> Result<Self, Jbig2Error> {
         if self.flags.contains(SymbolDictionaryFlagBits::SDHUFF)
             && (self.flags.sdhuffdh() == 2 || self.flags.sdhuffdw() == 2)
         {
-            return Err(Jbig2Error::UnsupportedFeature(
-                "custom Huffman symbol dictionary tables",
-            ));
-        }
-        if self.flags.contains(SymbolDictionaryFlagBits::SDHUFF) && self.flags.sdhuffbmsize() {
-            return Err(Jbig2Error::UnsupportedFeature(
-                "custom Huffman symbol bitmap-size tables",
+            return Err(Jbig2Error::InvalidTable(
+                "Huffman symbol dictionary selector",
             ));
         }
 
@@ -157,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    fn header_rejects_custom_huffman_symbol_dictionary_tables() {
+    fn header_rejects_invalid_huffman_symbol_dictionary_selectors() {
         let flags = (1u16 << 0) | (2u16 << 2);
         let mut data = Vec::new();
         data.extend_from_slice(&flags.to_be_bytes());
@@ -168,12 +162,12 @@ mod tests {
         let err = ParsedSymbolDictionaryHeader::try_from(&mut reader).expect_err("header");
         assert_eq!(
             err,
-            Jbig2Error::UnsupportedFeature("custom Huffman symbol dictionary tables")
+            Jbig2Error::InvalidTable("Huffman symbol dictionary selector")
         );
     }
 
     #[test]
-    fn header_rejects_custom_huffman_bitmap_size_tables() {
+    fn header_accepts_custom_huffman_bitmap_size_tables() {
         let flags = (1u16 << 0) | (1u16 << 6);
         let mut data = Vec::new();
         data.extend_from_slice(&flags.to_be_bytes());
@@ -181,10 +175,7 @@ mod tests {
         data.extend_from_slice(&9u32.to_be_bytes());
 
         let mut reader = BitReader::new(&data);
-        let err = ParsedSymbolDictionaryHeader::try_from(&mut reader).expect_err("header");
-        assert_eq!(
-            err,
-            Jbig2Error::UnsupportedFeature("custom Huffman symbol bitmap-size tables")
-        );
+        let header = ParsedSymbolDictionaryHeader::try_from(&mut reader).expect("header");
+        assert!(header.flags.sdhuffbmsize());
     }
 }

--- a/crates/pdf-jbig2/src/symbol_dictionary/huffman.rs
+++ b/crates/pdf-jbig2/src/symbol_dictionary/huffman.rs
@@ -3,7 +3,10 @@ use pdf_utils::BitReader;
 use crate::{
     error::Jbig2Error,
     generic_region::decode_mmr_region,
-    huffman::{HuffmanTableSelection, HuffmanValue, STANDARD_TABLE_B1, StandardHuffmanDecoder},
+    huffman::{
+        CustomHuffmanDecoder, HuffmanDecoder, HuffmanTableSelection, HuffmanValue,
+        STANDARD_TABLE_B1, StandardHuffmanDecoder,
+    },
     image::JBig2Image,
     symbol_dictionary::{
         collective_bitmap::append_collective_bitmap_symbols,
@@ -29,9 +32,10 @@ const SYMBOL_DICTIONARY_WIDTH_RUN: &str = "symbol dictionary width run";
 /// from Annex B for Huffman-coded symbol dictionaries.
 pub(super) struct HuffmanSymbolDictionaryDecoder<'stream, 'data> {
     stream: &'stream mut BitReader<'data>,
-    dh_table: StandardHuffmanDecoder,
-    dw_table: StandardHuffmanDecoder,
-    bmsize_table: StandardHuffmanDecoder,
+    dh_table: HuffmanDecoder,
+    dw_table: HuffmanDecoder,
+    bmsize_table: HuffmanDecoder,
+    export_table: StandardHuffmanDecoder,
 }
 
 impl<'stream, 'data> HuffmanSymbolDictionaryDecoder<'stream, 'data> {
@@ -42,18 +46,32 @@ impl<'stream, 'data> HuffmanSymbolDictionaryDecoder<'stream, 'data> {
     pub(super) fn new(
         stream: &'stream mut BitReader<'data>,
         flags: SymbolDictionaryFlagBits,
+        custom_tables: &[CustomHuffmanDecoder],
     ) -> Result<Self, Jbig2Error> {
-        let dh_table =
-            HuffmanTableSelection::SymbolDictionaryDh(flags.sdhuffdh()).standard_decoder()?;
-        let dw_table =
-            HuffmanTableSelection::SymbolDictionaryDw(flags.sdhuffdw()).standard_decoder()?;
-        let bmsize_table = StandardHuffmanDecoder::new(STANDARD_TABLE_B1)?;
+        let mut custom_index = 0usize;
+        let dh_table = symbol_dictionary_table(
+            HuffmanTableSelection::SymbolDictionaryDh(flags.sdhuffdh()),
+            custom_tables,
+            &mut custom_index,
+        )?;
+        let dw_table = symbol_dictionary_table(
+            HuffmanTableSelection::SymbolDictionaryDw(flags.sdhuffdw()),
+            custom_tables,
+            &mut custom_index,
+        )?;
+        let bmsize_table = if flags.sdhuffbmsize() {
+            next_custom_table(custom_tables, &mut custom_index)?
+        } else {
+            HuffmanDecoder::Standard(StandardHuffmanDecoder::new(STANDARD_TABLE_B1)?)
+        };
+        let export_table = StandardHuffmanDecoder::new(STANDARD_TABLE_B1)?;
 
         Ok(Self {
             stream,
             dh_table,
             dw_table,
             bmsize_table,
+            export_table,
         })
     }
 
@@ -180,7 +198,7 @@ impl<'stream, 'data> HuffmanSymbolDictionaryDecoder<'stream, 'data> {
         let mut export_index = 0usize;
 
         while export_index < total_symbols {
-            let run_length = required_huffman_value(self.bmsize_table.decode(self.stream)?)?;
+            let run_length = required_huffman_value(self.export_table.decode(self.stream)?)?;
             let run_length = i32_to_usize(run_length)?;
             export_index =
                 fill_export_flag_run(&mut export_flags, export_index, run_length, current_flag)?;
@@ -196,4 +214,32 @@ impl<'stream, 'data> HuffmanSymbolDictionaryDecoder<'stream, 'data> {
 struct HuffmanWidthRun {
     widths: Vec<u16>,
     total_width: usize,
+}
+
+fn symbol_dictionary_table(
+    selection: HuffmanTableSelection,
+    custom_tables: &[CustomHuffmanDecoder],
+    custom_index: &mut usize,
+) -> Result<HuffmanDecoder, Jbig2Error> {
+    match selection {
+        HuffmanTableSelection::SymbolDictionaryDh(3)
+        | HuffmanTableSelection::SymbolDictionaryDw(3) => {
+            next_custom_table(custom_tables, custom_index)
+        }
+        _ => selection.standard_decoder().map(HuffmanDecoder::Standard),
+    }
+}
+
+fn next_custom_table(
+    custom_tables: &[CustomHuffmanDecoder],
+    custom_index: &mut usize,
+) -> Result<HuffmanDecoder, Jbig2Error> {
+    let table = custom_tables
+        .get(*custom_index)
+        .cloned()
+        .ok_or(Jbig2Error::MissingSegment)?;
+    *custom_index = custom_index
+        .checked_add(1)
+        .ok_or(Jbig2Error::Overflow("Huffman table index overflow"))?;
+    Ok(HuffmanDecoder::Custom(table))
 }

--- a/crates/pdf-jbig2/src/symbol_dictionary/mod.rs
+++ b/crates/pdf-jbig2/src/symbol_dictionary/mod.rs
@@ -107,8 +107,12 @@ impl<'context, 'segment, 'stream, 'data, 'decoded, 'prior>
     /// selected by the symbol dictionary flags to decode heights, widths,
     /// collective bitmap sizes, and export runs.
     fn decode_huffman_dictionary(&mut self) -> Result<SymbolDictionary, Jbig2Error> {
-        let mut decoder =
-            HuffmanSymbolDictionaryDecoder::new(self.context.stream(), self.header.flags)?;
+        let custom_tables = self.referred_huffman_tables()?;
+        let mut decoder = HuffmanSymbolDictionaryDecoder::new(
+            self.context.stream(),
+            self.header.flags,
+            &custom_tables,
+        )?;
         let new_symbols = decoder.decode_new_symbols(self.header.num_new_symbols)?;
         let export_flags =
             decoder.decode_export_flags(self.input_symbols.len(), new_symbols.len())?;
@@ -118,6 +122,20 @@ impl<'context, 'segment, 'stream, 'data, 'decoded, 'prior>
             &export_flags,
             self.header.num_exported,
         )
+    }
+
+    fn referred_huffman_tables(
+        &self,
+    ) -> Result<Vec<crate::huffman::CustomHuffmanDecoder>, Jbig2Error> {
+        let mut tables = Vec::new();
+        for index in 0usize.. {
+            match self.context.referred_huffman_table(index) {
+                Ok(table) => tables.push(table.clone()),
+                Err(Jbig2Error::MissingSegment) => break,
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(tables)
     }
 
     /// Decode an arithmetic-coded symbol dictionary body.

--- a/crates/pdf-jbig2/src/text_region/huffman.rs
+++ b/crates/pdf-jbig2/src/text_region/huffman.rs
@@ -8,8 +8,9 @@ use crate::{
         GenericRefinementRegionDecode, RefinementAdaptiveTemplate, RefinementTemplate,
     },
     huffman::{
-        HuffmanTableSelection, HuffmanValue, StandardHuffmanDecoder, SymbolIdHuffmanTable,
-        decode_symbol_id, decode_symbol_id_huffman_table, text_region_refinement_standard_decoder,
+        CustomHuffmanDecoder, HuffmanDecoder, HuffmanTableSelection, HuffmanValue,
+        StandardHuffmanDecoder, SymbolIdHuffmanTable, decode_symbol_id,
+        decode_symbol_id_huffman_table, text_region_refinement_standard_decoder,
         text_region_rsize_standard_decoder,
     },
     image::JBig2Image,
@@ -39,9 +40,9 @@ const TEXT_REGION_REFINEMENT_HEIGHT: &str = "text region refinement height";
 struct TextRegionDecodeContext<'a> {
     parsed: ParsedTextRegion<'a>,
     symbols: Vec<JBig2Image>,
-    fs_table: StandardHuffmanDecoder,
-    ds_table: StandardHuffmanDecoder,
-    dt_table: StandardHuffmanDecoder,
+    fs_table: HuffmanDecoder,
+    ds_table: HuffmanDecoder,
+    dt_table: HuffmanDecoder,
     symbol_id_table: SymbolIdHuffmanTable,
     refinement_tables: Option<TextRegionRefinementTables>,
     compose_op: ComposeOp,
@@ -99,12 +100,23 @@ impl<'a> TextRegionDecodeContext<'a> {
         let huffman_flags = parsed
             .huffman_flags
             .ok_or(Jbig2Error::InvalidState("text region Huffman flags"))?;
-        let fs_table =
-            HuffmanTableSelection::TextRegionFs(huffman_flags.fs_selector).standard_decoder()?;
-        let ds_table =
-            HuffmanTableSelection::TextRegionDs(huffman_flags.ds_selector).standard_decoder()?;
-        let dt_table =
-            HuffmanTableSelection::TextRegionDt(huffman_flags.dt_selector).standard_decoder()?;
+        let custom_tables = referred_huffman_tables(context)?;
+        let mut custom_index = 0usize;
+        let fs_table = text_region_table(
+            HuffmanTableSelection::TextRegionFs(huffman_flags.fs_selector),
+            &custom_tables,
+            &mut custom_index,
+        )?;
+        let ds_table = text_region_table(
+            HuffmanTableSelection::TextRegionDs(huffman_flags.ds_selector),
+            &custom_tables,
+            &mut custom_index,
+        )?;
+        let dt_table = text_region_table(
+            HuffmanTableSelection::TextRegionDt(huffman_flags.dt_selector),
+            &custom_tables,
+            &mut custom_index,
+        )?;
         let mut body_reader = BitReader::new(parsed.body);
         let symbol_id_table = decode_symbol_id_huffman_table(&mut body_reader, symbols.len())?;
         body_reader.align_to_byte_boundary();
@@ -131,6 +143,42 @@ impl<'a> TextRegionDecodeContext<'a> {
             body,
         })
     }
+}
+
+fn text_region_table(
+    selection: HuffmanTableSelection,
+    custom_tables: &[CustomHuffmanDecoder],
+    custom_index: &mut usize,
+) -> Result<HuffmanDecoder, Jbig2Error> {
+    match selection {
+        HuffmanTableSelection::TextRegionFs(3)
+        | HuffmanTableSelection::TextRegionDs(3)
+        | HuffmanTableSelection::TextRegionDt(3) => {
+            let table = custom_tables
+                .get(*custom_index)
+                .cloned()
+                .ok_or(Jbig2Error::MissingSegment)?;
+            *custom_index = custom_index
+                .checked_add(1)
+                .ok_or(Jbig2Error::Overflow("Huffman table index overflow"))?;
+            Ok(HuffmanDecoder::Custom(table))
+        }
+        _ => selection.standard_decoder().map(HuffmanDecoder::Standard),
+    }
+}
+
+fn referred_huffman_tables(
+    context: &SegmentDecodeContext<'_, '_, '_, '_, '_>,
+) -> Result<Vec<CustomHuffmanDecoder>, Jbig2Error> {
+    let mut tables = Vec::new();
+    for index in 0usize.. {
+        match context.referred_huffman_table(index) {
+            Ok(table) => tables.push(table.clone()),
+            Err(Jbig2Error::MissingSegment) => break,
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(tables)
 }
 
 impl TextRegionRefinementTables {
@@ -488,16 +536,16 @@ mod tests {
         writer: &mut BitWriter,
         table: &StandardHuffmanDecoder,
         candidates: &[i32],
-    ) -> i32 {
+    ) -> Result<i32, Jbig2Error> {
         for candidate in candidates {
             let value = HuffmanValue::Value(*candidate);
             if let Some((code, codelen, extra, extra_len)) = bits_for_value(table, value) {
                 writer.push_bits(code, codelen);
                 writer.push_bits(extra, extra_len);
-                return *candidate;
+                return Ok(*candidate);
             }
         }
-        panic!("no encodable candidate value");
+        Err(Jbig2Error::InvalidState("encodable Huffman test value"))
     }
 
     fn push_single_symbol_id_table(writer: &mut BitWriter) {
@@ -833,13 +881,19 @@ mod tests {
         let rsize_table = text_region_rsize_standard_decoder(false).expect("rsize");
         let mut writer = BitWriter::new();
         push_single_symbol_id_table(&mut writer);
-        let _ = push_first_encodable_value(&mut writer, &dt_table, &[1, 0, 2, 3]);
-        let _ = push_first_encodable_value(&mut writer, &fs_table, &[1, 0, 2, 3]);
+        let _ =
+            push_first_encodable_value(&mut writer, &dt_table, &[1, 0, 2, 3]).expect("dt value");
+        let _ =
+            push_first_encodable_value(&mut writer, &fs_table, &[1, 0, 2, 3]).expect("fs value");
         writer.push_bits(0, 1);
-        let _ = push_first_encodable_value(&mut writer, &rdw_table, &[0, 1, 2, 3]);
-        let _ = push_first_encodable_value(&mut writer, &rdh_table, &[0, 1, 2, 3]);
-        let _ = push_first_encodable_value(&mut writer, &rdx_table, &[0, 1, 2, 3]);
-        let _ = push_first_encodable_value(&mut writer, &rdy_table, &[0, 1, 2, 3]);
+        let _ =
+            push_first_encodable_value(&mut writer, &rdw_table, &[0, 1, 2, 3]).expect("rdw value");
+        let _ =
+            push_first_encodable_value(&mut writer, &rdh_table, &[0, 1, 2, 3]).expect("rdh value");
+        let _ =
+            push_first_encodable_value(&mut writer, &rdx_table, &[0, 1, 2, 3]).expect("rdx value");
+        let _ =
+            push_first_encodable_value(&mut writer, &rdy_table, &[0, 1, 2, 3]).expect("rdy value");
         push_huffman_result(&mut writer, &rsize_table, HuffmanValue::Value(4));
         writer.push_bytes(&[0x00, 0x00, 0x00, 0x00]);
 


### PR DESCRIPTION
Implement custom JBIG2 Tables segment decoding and route the resulting Huffman tables through symbol dictionaries and text regions. This fixes the custom bitmap-size selector path and the custom text-region Huffman selectors used by the failing fixture.

Add targeted regressions for custom table decoding and selector resolution.