### PR TITLE
pdf-jbig2: fix MMR halftone decoding

### DIFF
--- a/crates/pdf-ccitt/src/ccitt.rs
+++ b/crates/pdf-ccitt/src/ccitt.rs
@@ -389,8 +389,8 @@ fn read_2d_mode(reader: &mut BitReader<'_>) -> Option<TwoDMode> {
 /// Encapsulates the bit reader, row buffers, and configuration needed to
 /// decode rows sequentially.  Created and consumed by [`decode`] and
 /// [`decode_rows`].
-struct CcittDecoder<'a> {
-    reader: BitReader<'a>,
+struct CcittDecoder<'reader, 'data> {
+    reader: &'reader mut BitReader<'data>,
     ref_row: Vec<u8>,
     row_buf: Vec<u8>,
     columns: usize,
@@ -403,20 +403,23 @@ struct CcittDecoder<'a> {
     damaged_rows_before_error: u32,
 }
 
-impl<'a> CcittDecoder<'a> {
+impl<'reader, 'data> CcittDecoder<'reader, 'data> {
     /// Construct a new decoder from raw stream data and CCITT parameters.
     ///
     /// # Errors
     ///
     /// Returns [`CcittDecodeError::ZeroColumns`] if `params.columns` is zero.
-    fn new(data: &'a [u8], params: &CCITTFaxParams) -> Result<Self, CcittDecodeError> {
+    fn new(
+        reader: &'reader mut BitReader<'data>,
+        params: &CCITTFaxParams,
+    ) -> Result<Self, CcittDecodeError> {
         if params.columns == 0 {
             return Err(CcittDecodeError::ZeroColumns);
         }
         let row_bytes = params.columns.div_ceil(8);
 
         Ok(Self {
-            reader: BitReader::new(data),
+            reader,
             ref_row: vec![0xff; row_bytes],
             row_buf: vec![0xff; row_bytes],
             columns: params.columns,
@@ -451,7 +454,9 @@ impl<'a> CcittDecoder<'a> {
                 break;
             }
 
-            skip_eol(&mut self.reader);
+            if self.end_of_line {
+                skip_eol(self.reader);
+            }
 
             if self.reader.exhausted() {
                 break;
@@ -484,8 +489,10 @@ impl<'a> CcittDecoder<'a> {
                 }
             }
 
+            self.consume_post_row_marker();
+
             if self.end_of_line {
-                skip_eol(&mut self.reader);
+                skip_eol(self.reader);
             }
 
             if self.byte_align {
@@ -501,6 +508,30 @@ impl<'a> CcittDecoder<'a> {
         }
 
         Ok(())
+    }
+
+    /// Consume optional zero fill bits and one following EOL marker after a row.
+    ///
+    /// This matches the permissive post-row cleanup used by PDF.js for raw
+    /// CCITT streams with `EndOfLine = false`, including the JBIG2 MMR
+    /// halftone-bitplane case.
+    fn consume_post_row_marker(&mut self) {
+        if self.end_of_line {
+            return;
+        }
+
+        loop {
+            match peek_bits(self.reader, 12) {
+                Some(0) => {
+                    let _ = self.reader.next_bit();
+                }
+                Some(1) => {
+                    self.reader.skip_bits(12);
+                    break;
+                }
+                Some(_) | None => break,
+            }
+        }
     }
 
     /// Emit the current row, applying `BlackIs1` polarity if requested.
@@ -556,7 +587,7 @@ impl<'a> CcittDecoder<'a> {
                 return Err(CcittDecodeError::UnexpectedEof);
             }
 
-            let run_len = decode_run_seq(&mut self.reader, color)?;
+            let run_len = decode_run_seq(self.reader, color)?;
 
             if !color {
                 fill_bits(
@@ -588,7 +619,7 @@ impl<'a> CcittDecoder<'a> {
             }
 
             let (b1, b2) = find_b1_b2(&self.ref_row, self.columns, a0, a0color);
-            let mode = read_2d_mode(&mut self.reader).ok_or(CcittDecodeError::UnexpectedEof)?;
+            let mode = read_2d_mode(self.reader).ok_or(CcittDecodeError::UnexpectedEof)?;
 
             match mode {
                 TwoDMode::VerticalRight(delta) | TwoDMode::VerticalLeft(delta) => {
@@ -612,16 +643,16 @@ impl<'a> CcittDecoder<'a> {
                     a0color = !a0color;
                 }
                 TwoDMode::Horizontal => {
-                    let run_len1 = decode_run_seq(&mut self.reader, a0color)?;
+                    let run_len1 = decode_run_seq(self.reader, a0color)?;
                     let (a0_fill, a1) = match a0 {
-                        None => (0, run_len1.saturating_add(1)),
+                        None => (0, run_len1),
                         Some(pos) => (pos, pos.saturating_add(run_len1)),
                     };
                     if !a0color {
                         fill_bits(&mut self.row_buf, self.columns, a0_fill, a1);
                     }
 
-                    let run_len2 = decode_run_seq(&mut self.reader, !a0color)?;
+                    let run_len2 = decode_run_seq(self.reader, !a0color)?;
                     let a2 = a1.saturating_add(run_len2);
                     if a0color {
                         fill_bits(&mut self.row_buf, self.columns, a1, a2);
@@ -693,8 +724,54 @@ pub fn decode_rows<F>(
 where
     F: FnMut(&[u8]),
 {
-    let mut decoder = CcittDecoder::new(data, params)?;
-    decoder.decode_rows_with(params.rows, row_sink)
+    let mut reader = BitReader::new(data);
+    decode_rows_from_reader(&mut reader, params, row_sink)
+}
+
+/// Decode a CCITTFaxDecode-compressed byte stream from an existing bit reader.
+///
+/// This preserves the caller's bit position, which allows formats such as
+/// JBIG2 to decode consecutive EOFB-delimited MMR bitmaps from one shared
+/// stream without reparsing the already-consumed bytes.
+pub fn decode_rows_from_reader<F>(
+    reader: &mut BitReader<'_>,
+    params: &CCITTFaxParams,
+    row_sink: F,
+) -> Result<(), CcittDecodeError>
+where
+    F: FnMut(&[u8]),
+{
+    let mut decoder = CcittDecoder::new(reader, params)?;
+    decoder.decode_rows_with(params.rows, row_sink)?;
+    if params.k < 0 && params.end_of_block {
+        consume_mmr_end_of_block(decoder.reader);
+    }
+    Ok(())
+}
+
+fn consume_mmr_end_of_block(reader: &mut BitReader<'_>) {
+    let _ = consume_optional_eol(reader);
+    reader.align_to_byte_boundary();
+}
+
+fn consume_optional_eol(reader: &mut BitReader<'_>) -> bool {
+    loop {
+        match peek_bits(reader, 12) {
+            Some(0) => {
+                let _ = reader.next_bit();
+            }
+            Some(1) => {
+                reader.skip_bits(12);
+                return true;
+            }
+            Some(_) | None => return false,
+        }
+    }
+}
+
+fn peek_bits(reader: &BitReader<'_>, bits: u8) -> Option<u16> {
+    let mut clone = reader.clone();
+    clone.read_bits(bits)
 }
 
 #[cfg(test)]
@@ -1074,6 +1151,21 @@ mod tests {
         let out = decode(data, &params_g4(8, 1)).expect("decode failed");
         // No bits → skip_eol reads nothing → exhausted → no rows appended.
         assert_eq!(out.len(), 0);
+    }
+
+    #[test]
+    fn decode_g4_single_black_pixel_from_horizontal_mode_at_row_start() {
+        let data = bits_to_bytes(&[
+            0, 0, 1, // horizontal mode
+            0, 0, 1, 1, 0, 1, 0, 1, // white run 0
+            0, 1, 0, // black run 1
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // EOFB EOL #1
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // EOFB EOL #2
+        ]);
+
+        let out = decode(&data, &params_g4(1, 1)).expect("decode failed");
+
+        assert_eq!(out, [0x7f]);
     }
 
     // ── encoded_byte_align ───────────────────────────────────────────────────

--- a/crates/pdf-ccitt/src/lib.rs
+++ b/crates/pdf-ccitt/src/lib.rs
@@ -4,5 +4,5 @@ mod ccitt;
 mod ccitt_fax_params;
 mod ccitt_tables;
 
-pub use ccitt::{CcittDecodeError, decode, decode_rows};
+pub use ccitt::{CcittDecodeError, decode, decode_rows, decode_rows_from_reader};
 pub use ccitt_fax_params::CCITTFaxParams;

--- a/crates/pdf-jbig2/src/generic_region/mmr.rs
+++ b/crates/pdf-jbig2/src/generic_region/mmr.rs
@@ -1,6 +1,7 @@
-use pdf_ccitt::{CCITTFaxParams, decode_rows as ccitt_decode_rows};
+use pdf_ccitt::{CCITTFaxParams, decode_rows_from_reader as ccitt_decode_rows_from_reader};
 
 use crate::{error::Jbig2Error, image::JBig2Image, util::packed_row_len};
+use pdf_utils::BitReader;
 
 /// Decode an MMR-coded JBIG2 generic region.
 ///
@@ -11,6 +12,15 @@ pub(crate) fn decode_mmr_region(
     width: u16,
     height: u16,
     data: &[u8],
+) -> Result<JBig2Image, Jbig2Error> {
+    let mut reader = BitReader::new(data);
+    decode_mmr_region_from_reader(width, height, &mut reader)
+}
+
+pub(crate) fn decode_mmr_region_from_reader(
+    width: u16,
+    height: u16,
+    reader: &mut BitReader<'_>,
 ) -> Result<JBig2Image, Jbig2Error> {
     let row_bytes = packed_row_len(width)?;
     let ccitt_params = CCITTFaxParams {
@@ -29,7 +39,7 @@ pub(crate) fn decode_mmr_region(
     let image_data_len = image.data().len();
     let mut row_index = 0usize;
 
-    ccitt_decode_rows(data, &ccitt_params, |src_row| {
+    ccitt_decode_rows_from_reader(reader, &ccitt_params, |src_row| {
         let Some(dst_start) = row_index.checked_mul(stride) else {
             return;
         };
@@ -53,8 +63,23 @@ pub(crate) fn decode_mmr_region(
 
 #[cfg(test)]
 mod tests {
-    use super::decode_mmr_region;
+    use super::{decode_mmr_region, decode_mmr_region_from_reader};
     use crate::error::Jbig2Error;
+    use pdf_utils::BitReader;
+
+    fn bits_to_bytes(bits: &[u8]) -> Vec<u8> {
+        let byte_len = bits.len().div_ceil(8);
+        let mut bytes = vec![0u8; byte_len];
+        for (index, bit) in bits.iter().copied().enumerate() {
+            if bit == 0 {
+                continue;
+            }
+            let byte = index / 8;
+            let offset = 7usize.saturating_sub(index % 8);
+            bytes[byte] |= 1u8 << offset;
+        }
+        bytes
+    }
 
     #[test]
     fn mmr_failure_is_wrapped() {
@@ -69,6 +94,38 @@ mod tests {
         assert_eq!(image.stride(), 4);
         assert_eq!(image.to_tight_bytes(), [0x00, 0x00]);
         assert_eq!(image.data(), [0x00, 0x00, 0x00, 0x00]);
+        Ok(())
+    }
+
+    #[test]
+    fn mmr_reader_decode_advances_past_bitmap_end_of_block() -> Result<(), Jbig2Error> {
+        let mut reader = BitReader::new(&[0x80, 0x00, 0x10, 0x00, 0x01]);
+
+        let image = decode_mmr_region_from_reader(1, 1, &mut reader)?;
+
+        assert_eq!(image.to_tight_bytes(), [0x00]);
+        assert_eq!(reader.pos(), 40);
+        Ok(())
+    }
+
+    #[test]
+    fn mmr_reader_decode_handles_consecutive_bitmaps() -> Result<(), Jbig2Error> {
+        let data = bits_to_bytes(&[
+            1, // first 1x1 white row via V(0)
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // EOFB EOL #1
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // EOFB EOL #2
+            1, // second 1x1 white row via V(0)
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // EOFB EOL #1
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // EOFB EOL #2
+        ]);
+        let mut reader = BitReader::new(&data);
+
+        let first = decode_mmr_region_from_reader(1, 1, &mut reader)?;
+        let second = decode_mmr_region_from_reader(1, 1, &mut reader)?;
+
+        assert_eq!(first.to_tight_bytes(), [0x00]);
+        assert_eq!(second.to_tight_bytes(), [0x00]);
+        assert_eq!(reader.pos(), 56);
         Ok(())
     }
 }

--- a/crates/pdf-jbig2/src/generic_region/mod.rs
+++ b/crates/pdf-jbig2/src/generic_region/mod.rs
@@ -10,5 +10,5 @@ pub(crate) mod tables;
 
 pub(crate) use adaptive_template::GenericRegionAdaptiveTemplate;
 pub(crate) use flags::{GenericRegionFlags, GenericRegionTemplate};
-pub(crate) use mmr::decode_mmr_region;
+pub(crate) use mmr::{decode_mmr_region, decode_mmr_region_from_reader};
 pub(crate) use parser::GenericRegion;

--- a/crates/pdf-jbig2/src/halftone_region.rs
+++ b/crates/pdf-jbig2/src/halftone_region.rs
@@ -5,14 +5,16 @@ use crate::{
     arith_decoder::JBig2ArithDecoder,
     decoded_region_segment::DecodedRegionSegment,
     error::Jbig2Error,
-    generic_region::{GenericRegion, GenericRegionAdaptiveTemplate, GenericRegionTemplate},
+    generic_region::{
+        GenericRegion, GenericRegionAdaptiveTemplate, GenericRegionTemplate,
+        decode_mmr_region_from_reader,
+    },
     image::JBig2Image,
     segment_context::SegmentDecodeContext,
 };
 use pdf_utils::BitReader;
 
 const HALFTONE_REGION_BODY: &str = "halftone region body";
-const MMR_HALFTONE_REGION: &str = "MMR halftone region";
 const HALFTONE_GRAY_INDEX: &str = "halftone gray index";
 const HALFTONE_PATTERN_INDEX: &str = "halftone pattern index";
 const HALFTONE_BITS_PER_VALUE: &str = "halftone bits per value";
@@ -26,15 +28,12 @@ const HALFTONE_TEMPLATE23_ADAPTIVE_PIXELS: [i8; 8] = [2, -1, -3, -1, 2, -2, -2, 
 ///
 /// ITU-T T.88 / ISO/IEC 14492 section 7.4.5 defines the segment header and
 /// referred pattern dictionary requirements. Section 6.6.5 defines the
-/// halftone-region decoding procedure used here for arithmetic-coded gray
-/// images; MMR halftone gray images remain unsupported.
+/// halftone-region decoding procedure used here for both arithmetic-coded and
+/// MMR-coded gray images.
 pub(crate) fn decode_halftone_region_segment(
     context: &mut SegmentDecodeContext<'_, '_, '_, '_, '_>,
 ) -> Result<DecodedRegionSegment, Jbig2Error> {
     let header = HalftoneRegionHeader::try_from(&mut *context.stream())?;
-    if header.mmr {
-        return Err(Jbig2Error::UnsupportedFeature(MMR_HALFTONE_REGION));
-    }
     let patterns = context.referred_pattern_dictionary()?;
 
     let mut region_image = JBig2Image::try_new(
@@ -57,6 +56,7 @@ pub(crate) fn decode_halftone_region_segment(
         &mut body_reader,
         header.grid_width,
         header.grid_height,
+        header.mmr,
         header.template,
         skip.as_ref(),
         patterns.patterns.len(),
@@ -91,6 +91,7 @@ fn decode_gray_indices<'stream, 'data>(
     stream: &'stream mut BitReader<'data>,
     grid_width: u16,
     grid_height: u16,
+    mmr: bool,
     template: u8,
     skip: Option<&JBig2Image>,
     pattern_count: usize,
@@ -99,6 +100,7 @@ fn decode_gray_indices<'stream, 'data>(
         stream,
         grid_width,
         grid_height,
+        mmr,
         template,
         skip,
         pattern_count,
@@ -130,24 +132,33 @@ impl HalftoneGrayPlanes {
         stream: &'stream mut BitReader<'data>,
         grid_width: u16,
         grid_height: u16,
+        mmr: bool,
         template: u8,
         skip: Option<&JBig2Image>,
         pattern_count: usize,
     ) -> Result<Self, Jbig2Error> {
         let bits_per_value = usize::from(pattern_bits_per_value(pattern_count)?);
-        let template = GenericRegionTemplate::try_from(template)?;
-        let gbat = halftone_template(template);
-        let region = GenericRegion::new_arithmetic(grid_width, grid_height, template, false, gbat)?;
-        let mut decoder = JBig2ArithDecoder::new(stream);
         let mut planes = Vec::new();
         planes
             .try_reserve_exact(bits_per_value)
             .map_err(|_| Jbig2Error::Allocation(HALFTONE_GRAY_PLANES_ALLOCATION))?;
-
-        for _ in (0..bits_per_value).rev() {
-            let mut decoded = region.decode_arithmetic_with_decoder(&mut decoder, skip)?;
-            apply_gray_code_plane_delta(&mut decoded, planes.last());
-            planes.push(decoded);
+        if mmr {
+            for _ in (0..bits_per_value).rev() {
+                let mut decoded = decode_mmr_region_from_reader(grid_width, grid_height, stream)?;
+                apply_gray_code_plane_delta(&mut decoded, planes.last());
+                planes.push(decoded);
+            }
+        } else {
+            let template = GenericRegionTemplate::try_from(template)?;
+            let gbat = halftone_template(template);
+            let region =
+                GenericRegion::new_arithmetic(grid_width, grid_height, template, false, gbat)?;
+            let mut decoder = JBig2ArithDecoder::new(stream);
+            for _ in (0..bits_per_value).rev() {
+                let mut decoded = region.decode_arithmetic_with_decoder(&mut decoder, skip)?;
+                apply_gray_code_plane_delta(&mut decoded, planes.last());
+                planes.push(decoded);
+            }
         }
         planes.reverse();
 
@@ -304,8 +315,22 @@ mod tests {
     fn decode_gray_indices_with_reader(
         mut reader: BitReader<'_>,
     ) -> Result<(Vec<Vec<usize>>, BitReader<'_>), Jbig2Error> {
-        let indices = decode_gray_indices(&mut reader, 8, 4, 0, None, 2)?;
+        let indices = decode_gray_indices(&mut reader, 8, 4, false, 0, None, 2)?;
         Ok((indices, reader))
+    }
+
+    fn bits_to_bytes(bits: &[u8]) -> Vec<u8> {
+        let byte_len = bits.len().div_ceil(8);
+        let mut bytes = vec![0u8; byte_len];
+        for (index, bit) in bits.iter().copied().enumerate() {
+            if bit == 0 {
+                continue;
+            }
+            let byte = index / 8;
+            let offset = 7usize.saturating_sub(index % 8);
+            bytes[byte] |= 1u8 << offset;
+        }
+        bytes
     }
 
     fn plane(width: u16, height: u16, pixels: &[(u16, u16)]) -> JBig2Image {
@@ -395,6 +420,24 @@ mod tests {
         assert_eq!(indices.len(), 4);
         assert!(indices.iter().all(|row| row.len() == 8));
         assert!(reader.byte_pos() > prefix.len());
+    }
+
+    #[test]
+    fn decode_gray_indices_handles_mmr_bitplanes_from_one_stream() {
+        let body = bits_to_bytes(&[
+            1, // plane 1: white 1x1 row via V(0)
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // EOFB EOL #1
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // EOFB EOL #2
+            1, // plane 0: white 1x1 row via V(0)
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // EOFB EOL #1
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, // EOFB EOL #2
+        ]);
+        let mut reader = BitReader::new(&body);
+
+        let indices = decode_gray_indices(&mut reader, 1, 1, true, 0, None, 4).expect("indices");
+
+        assert_eq!(indices, vec![vec![0]]);
+        assert_eq!(reader.pos(), 56);
     }
 
     #[test]


### PR DESCRIPTION
Fix the streamed Group 4 halftone path used by JBIG2 MMR gray planes.

Correct CCITT horizontal-mode decoding at row start, align the reader-based MMR handoff with the existing plane streaming behavior, and add a regression for the row-start horizontal case.