### PR TITLE
pdf-document: accept PDF 2.x headers

### DIFF
--- a/crates/pdf-document/src/reader.rs
+++ b/crates/pdf-document/src/reader.rs
@@ -54,7 +54,7 @@ impl PdfReader {
 
         // Parse and validate the PDF header when it is present near the start of the file.
         if let Some(version) = parser.parse_header_in_opening_bytes()?
-            && version.major() != 1
+            && version.major() > 2
         {
             return Err(PdfReaderError::UnsupportedVersion(
                 version.major(),


### PR DESCRIPTION
Reject only PDF major versions above 2 instead of rejecting every non-1 major version. This allows standard PDF 2.x files to load while keeping the unsupported-version error for newer majors.