### PR TITLE
pdf-cmap: tolerate whitespace after name solidus in CMaps

### DIFF
--- a/crates/pdf-cmap/src/cmap/parser.rs
+++ b/crates/pdf-cmap/src/cmap/parser.rs
@@ -76,10 +76,7 @@ impl<'a> CMapParser<'a> {
                     .parse_literal_string()
                     .map_err(ParserError::from)?,
             ),
-            b'/' => {
-                let _ = self.parser.tokenizer.read();
-                CMapToken::Name(self.parser.read_operator_name()?.to_vec())
-            }
+            b'/' => self.parse_name_token()?,
             b'<' => self.parse_left_angle_token()?,
             b'>' => self.parse_right_angle_token(byte)?,
             b'+' | b'-' | b'0'..=b'9' => self.parse_number_token(byte)?,
@@ -90,6 +87,12 @@ impl<'a> CMapParser<'a> {
         };
 
         Ok(Some(token))
+    }
+
+    fn parse_name_token(&mut self) -> Result<CMapToken, CMapError> {
+        let _ = self.parser.tokenizer.read();
+        self.parser.skip_whitespace();
+        Ok(CMapToken::Name(self.parser.read_operator_name()?.to_vec()))
     }
 
     fn parse_left_angle_token(&mut self) -> Result<CMapToken, CMapError> {
@@ -232,6 +235,21 @@ mod tests {
         assert_eq!(
             parser.next_token().unwrap(),
             Some(CMapToken::RightSquareBracket)
+        );
+        assert_eq!(parser.next_token().unwrap(), None);
+    }
+
+    #[test]
+    fn tolerates_whitespace_after_name_solidus() {
+        let mut parser = CMapParser::from(b"/ CIDInit / ProcSet".as_slice());
+
+        assert_eq!(
+            parser.next_token().unwrap(),
+            Some(CMapToken::Name(b"CIDInit".to_vec()))
+        );
+        assert_eq!(
+            parser.next_token().unwrap(),
+            Some(CMapToken::Name(b"ProcSet".to_vec()))
         );
         assert_eq!(parser.next_token().unwrap(), None);
     }

--- a/crates/pdf-cmap/src/to_unicode.rs
+++ b/crates/pdf-cmap/src/to_unicode.rs
@@ -74,6 +74,38 @@ end
     }
 
     #[test]
+    fn parses_cmap_with_whitespace_after_name_solidus() {
+        let map = ToUnicodeCMap::try_from(
+            br"
+/ CIDInit / ProcSet findresource begin
+12 dict begin
+begincmap
+/ CIDSystemInfo
+<< / Registry (Adobe)
+/ Ordering (UCS) / Supplement 0 >> def
+/ CMapName / Adobe-Identity-UCS def
+/ CMapType 2 def
+1 begincodespacerange
+<00> <FF>
+endcodespacerange
+1 beginbfchar
+<01> <D83DDCA1>
+endbfchar
+endcmap CMapName currentdict /CMap defineresource pop end end
+"
+            .as_slice(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            map.map_char_code(1)
+                .and_then(|chars| chars.first())
+                .copied(),
+            char::from_u32(0x1F4A1)
+        );
+    }
+
+    #[test]
     fn parses_cmap_with_real_number_metadata() {
         let map = ToUnicodeCMap::try_from(
             br"


### PR DESCRIPTION
Allow optional whitespace after '/' when parsing CMap name tokens.

This fixes malformed embedded CMaps that emit boilerplate like '/ CIDInit / ProcSet' without relaxing the general PDF parser.