### PR TITLE
pdf-page: keep unreadable font resources recoverable

### DIFF
--- a/crates/pdf-font/src/fallback.rs
+++ b/crates/pdf-font/src/fallback.rs
@@ -37,22 +37,10 @@ pub(crate) fn fallback_program_from_dictionary(
     objects: &dyn ObjectResolver,
 ) -> Result<FallbackFontProgram, FontError> {
     let flags = descriptor_flags(dictionary, objects)?;
-    let standard14 = dictionary
-        .get("BaseFont")
-        .and_then(|value| value.try_str(objects).ok())
-        .and_then(|name| Standard14Font::from_base_font_name(name.as_ref()))
-        .unwrap_or_else(|| Standard14Font::from(flags));
-    let font_file: Cow<'static, [u8]> = if is_cjk_cid_font(dictionary, objects)? {
-        Cow::Borrowed(include_bytes!("../assets/NotoSansCJKjp-Regular.otf").as_slice())
-    } else {
-        standard14.fallback_font_bytes()
-    };
+    let standard14 = standard14_from_dictionary(dictionary, objects, flags);
+    let is_cjk = is_cjk_cid_font(dictionary, objects)?;
 
-    Ok(FallbackFontProgram {
-        font_file,
-        standard14,
-        flags,
-    })
+    Ok(fallback_program(flags, standard14, is_cjk))
 }
 
 /// Build a synthetic TrueType font from fallback font data.
@@ -83,6 +71,65 @@ pub(crate) fn fallback_true_type_from_dictionary(
         standard14: Some(fallback.standard14),
         flags: fallback.flags,
     })
+}
+
+/// Build a synthetic TrueType font from fallback font data without failing on
+/// malformed optional metadata.
+///
+/// This is used by higher-level resource loading when a font resource is
+/// otherwise unreadable and the parser should preserve best-effort rendering.
+pub(crate) fn fallback_true_type_from_dictionary_best_effort(
+    dictionary: &Dictionary,
+    objects: &dyn ObjectResolver,
+) -> TrueTypeFont {
+    let flags = descriptor_flags(dictionary, objects).unwrap_or_default();
+    let is_cjk = is_cjk_cid_font(dictionary, objects).unwrap_or(false);
+    let standard14 = standard14_from_dictionary(dictionary, objects, flags);
+    let fallback = fallback_program(flags, standard14, is_cjk);
+    let mut font = TrueTypeFont::from_bytes(fallback.font_file, Some(fallback.standard14));
+    font.flags = fallback.flags;
+
+    font
+}
+
+/// Resolve the Standard 14 identity to use for fallback substitution.
+///
+/// This prefers a readable `/BaseFont` name when it maps to a known Standard 14
+/// font. If `/BaseFont` is missing, malformed, or unrecognized, it falls back
+/// to the flag-driven Standard 14 selection.
+fn standard14_from_dictionary(
+    dictionary: &Dictionary,
+    objects: &dyn ObjectResolver,
+    flags: FontFlags,
+) -> Standard14Font {
+    dictionary
+        .get("BaseFont")
+        .and_then(|value| value.try_str(objects).ok())
+        .and_then(|name| Standard14Font::from_base_font_name(name.as_ref()))
+        .unwrap_or_else(|| Standard14Font::from(flags))
+}
+
+/// Build the fallback font program descriptor from already-decided inputs.
+///
+/// `standard14` selects the Standard 14 identity for simple-font fallback,
+/// while `is_cjk` switches the program bytes to the bundled CJK fallback for
+/// CID fonts that declare a supported CJK ordering.
+fn fallback_program(
+    flags: FontFlags,
+    standard14: Standard14Font,
+    is_cjk: bool,
+) -> FallbackFontProgram {
+    let font_file: Cow<'static, [u8]> = if is_cjk {
+        Cow::Borrowed(include_bytes!("../assets/NotoSansCJKjp-Regular.otf").as_slice())
+    } else {
+        standard14.fallback_font_bytes()
+    };
+
+    FallbackFontProgram {
+        font_file,
+        standard14,
+        flags,
+    }
 }
 
 /// Read font descriptor flags from a font dictionary.

--- a/crates/pdf-font/src/font.rs
+++ b/crates/pdf-font/src/font.rs
@@ -5,9 +5,16 @@ use pdf_content_stream::ContentStreamIdAllocator;
 use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 
 use crate::{
-    char_vec::CharVec, error::FontError, fallback::fallback_true_type_from_dictionary,
-    glyph_name_to_unicode::glyph_name_to_unicode, standard14::Standard14Font,
-    true_type_font::TrueTypeFont, type0_font::Type0Font, type1_font::Type1Font,
+    char_vec::CharVec,
+    error::FontError,
+    fallback::{
+        fallback_true_type_from_dictionary, fallback_true_type_from_dictionary_best_effort,
+    },
+    glyph_name_to_unicode::glyph_name_to_unicode,
+    standard14::Standard14Font,
+    true_type_font::TrueTypeFont,
+    type0_font::Type0Font,
+    type1_font::Type1Font,
     type3_font::Type3Font,
 };
 
@@ -58,6 +65,27 @@ impl Font {
                 subtype: other.to_string(),
             }),
         }
+    }
+
+    /// Build a minimal Standard 14-backed fallback font for best-effort
+    /// resource recovery.
+    ///
+    /// This is intentionally narrower than the normal font parsing path:
+    /// once the original font dictionary has already failed to parse, this
+    /// fallback does not attempt to preserve `/Widths`, `/Encoding`, or
+    /// `/ToUnicode` data from that failed font. The synthetic font keeps only
+    /// the bundled fallback program and the selected Standard 14 identity.
+    ///
+    /// Callers should use this only at higher-level recovery boundaries, such
+    /// as page resource loading, where replacing an unreadable font is better
+    /// than aborting the entire resource dictionary.
+    pub fn fallback_from_dictionary_best_effort(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+    ) -> Self {
+        Self::TrueType(fallback_true_type_from_dictionary_best_effort(
+            dictionary, objects,
+        ))
     }
 }
 

--- a/crates/pdf-page/src/resources.rs
+++ b/crates/pdf-page/src/resources.rs
@@ -80,11 +80,28 @@ pub(crate) fn read_font_resource(
     cycle_tracker: &mut ReadCycleTracker,
     id_allocator: &mut ContentStreamIdAllocator,
 ) -> Result<Resource, PdfPagesError> {
-    let font = Rc::new(Font::from_dictionary(dictionary, objects, id_allocator)?);
-    let resources =
-        Resources::read(dictionary, objects, cache, cycle_tracker, id_allocator)?.map(Rc::new);
+    // Font resources are loaded best-effort: if parsing the original font
+    // fails, keep the resource name resolvable by substituting a minimal
+    // Standard 14-backed fallback instead of aborting the whole /Resources
+    // dictionary. Nested font resources are only preserved for successfully
+    // parsed fonts.
+    let (font, resources) = match Font::from_dictionary(dictionary, objects, id_allocator) {
+        Ok(font) => {
+            let resources =
+                Resources::read(dictionary, objects, cache, cycle_tracker, id_allocator)?
+                    .map(Rc::new);
+            (font, resources)
+        }
+        Err(_) => (
+            Font::fallback_from_dictionary_best_effort(dictionary, objects),
+            None,
+        ),
+    };
 
-    Ok(Resource::Font { font, resources })
+    Ok(Resource::Font {
+        font: Rc::new(font),
+        resources,
+    })
 }
 
 /// Parses all font resources from the `/Font` sub-dictionary.


### PR DESCRIPTION
Fallback unreadable font dictionaries to a minimal Standard 14- backed TrueType font so /Resources parsing can continue. Preserve nested font resources only when the original font parses successfully.