### PR TITLE
pdf-canvas: split font renderers into shared helpers

### DIFF
--- a/crates/pdf-canvas/src/font_renderer_support.rs
+++ b/crates/pdf-canvas/src/font_renderer_support.rs
@@ -1,0 +1,100 @@
+use crate::{
+    canvas_backend::CanvasBackend, error::PdfCanvasError, pdf_canvas::PdfCanvas,
+    text_state::TextState,
+};
+use pdf_font::{font::Font, glyph_name_to_unicode::glyph_name_to_unicode};
+use pdf_graphics::transform::Transform;
+use read_fonts::TableProvider;
+use skrifa::{FontRef, GlyphId, charmap::Charmap};
+
+/// Normalizes a parsed `units_per_em` value into the range accepted by text rendering.
+///
+/// # Parameters
+///
+/// - `units_per_em`: The parsed `units_per_em` value, if present.
+///
+/// # Returns
+///
+/// The normalized `units_per_em`, or `TextState::DEFAULT_UNITS_PER_EM` when the input is
+/// missing or out of range.
+pub(crate) fn normalized_units_per_em(units_per_em: Option<u16>) -> u16 {
+    units_per_em
+        .filter(|&upe| (TextState::MIN_UNITS_PER_EM..=TextState::MAX_UNITS_PER_EM).contains(&upe))
+        .unwrap_or(TextState::DEFAULT_UNITS_PER_EM)
+}
+
+/// Builds the glyph base transform for the current text state.
+///
+/// # Parameters
+///
+/// - `canvas`: The canvas whose current text state provides glyph placement settings.
+/// - `units_per_em`: The font design units per em.
+///
+/// # Returns
+///
+/// The glyph base transform derived from the current text state and font scaling.
+pub(crate) fn glyph_base_transform<B: CanvasBackend>(
+    canvas: &PdfCanvas<'_, B>,
+    units_per_em: u16,
+) -> Result<Transform, PdfCanvasError> {
+    let units_per_em_inverse = 1.0 / f32::from(units_per_em);
+    Ok(canvas
+        .current_state()?
+        .text_state
+        .glyph_base_transform(units_per_em_inverse))
+}
+
+/// Resolves a glyph identifier for a simple font using the configured fallback order.
+///
+/// # Parameters
+///
+/// - `font`: The current PDF font, if one is attached to the text state.
+/// - `code`: The source character code.
+/// - `glyph_name`: The glyph name associated with `code`, if available.
+/// - `charmap`: The font charmap used for Unicode-to-glyph lookup.
+/// - `font_ref`: The parsed font reference used for cmap fallback lookup.
+/// - `is_symbolic`: Whether symbolic codepoint fallback is allowed.
+///
+/// # Returns
+///
+/// The resolved glyph identifier, or `GlyphId::NOTDEF` when no mapping succeeds.
+pub(crate) fn resolve_simple_font_gid(
+    font: Option<&Font>,
+    code: u16,
+    glyph_name: Option<&str>,
+    charmap: &Charmap<'_>,
+    font_ref: &FontRef<'_>,
+    is_symbolic: bool,
+) -> GlyphId {
+    pdf_unicode_gid(font, code, charmap)
+        .or_else(|| glyph_name_gid(glyph_name, charmap))
+        .or_else(|| direct_cmap_gid(font_ref, code))
+        .or_else(|| symbolic_gid(code, charmap, is_symbolic))
+        .unwrap_or(GlyphId::NOTDEF)
+}
+
+fn pdf_unicode_gid(font: Option<&Font>, code: u16, charmap: &Charmap<'_>) -> Option<GlyphId> {
+    font.and_then(|current_font| current_font.char_to_unicode(code))
+        .and_then(|unicode_char| charmap.map(unicode_char))
+}
+
+fn glyph_name_gid(glyph_name: Option<&str>, charmap: &Charmap<'_>) -> Option<GlyphId> {
+    glyph_name
+        .and_then(glyph_name_to_unicode)
+        .and_then(|unicode_char| charmap.map(unicode_char))
+}
+
+fn direct_cmap_gid(font_ref: &FontRef<'_>, code: u16) -> Option<GlyphId> {
+    font_ref
+        .cmap()
+        .ok()
+        .and_then(|cmap| cmap.best_subtable())
+        .and_then(|(_, _, subtable)| subtable.map_codepoint(code))
+}
+
+fn symbolic_gid(code: u16, charmap: &Charmap<'_>, is_symbolic: bool) -> Option<GlyphId> {
+    is_symbolic
+        .then(|| char::from_u32(u32::from(code)))
+        .flatten()
+        .and_then(|unicode_char| charmap.map(unicode_char))
+}

--- a/crates/pdf-canvas/src/lib.rs
+++ b/crates/pdf-canvas/src/lib.rs
@@ -12,6 +12,7 @@ mod canvas_path_ops;
 mod canvas_state;
 mod canvas_text_ops;
 pub mod error;
+mod font_renderer_support;
 mod pdf_path_pen;
 
 pub mod pdf_canvas;

--- a/crates/pdf-canvas/src/recording_canvas.rs
+++ b/crates/pdf-canvas/src/recording_canvas.rs
@@ -95,127 +95,6 @@ impl<'a> Shader<'a> {
     }
 }
 
-#[cfg(test)]
-#[allow(clippy::expect_used)]
-mod tests {
-    use super::*;
-    use crate::stroke_style::StrokeStyle;
-    use pdf_graphics::DashPattern;
-
-    #[derive(Default)]
-    struct StrokeStyleCanvas {
-        last_stroke_style: Option<StrokeStyle>,
-    }
-
-    impl CanvasBackend for StrokeStyleCanvas {
-        fn fill_path(
-            &mut self,
-            _path: &PdfPath,
-            _fill_type: PathFillType,
-            _color: Color,
-            _shader: &Option<Shader>,
-            _blend_mode: Option<BlendMode>,
-        ) -> Result<(), PdfCanvasError> {
-            Ok(())
-        }
-
-        fn stroke_path(
-            &mut self,
-            _path: &PdfPath,
-            _color: Color,
-            _line_width: f32,
-            stroke_style: &StrokeStyle,
-            _shader: &Option<Shader>,
-            _blend_mode: Option<BlendMode>,
-        ) -> Result<(), PdfCanvasError> {
-            self.last_stroke_style = Some(stroke_style.clone());
-            Ok(())
-        }
-
-        fn set_clip_region(
-            &mut self,
-            _path: &PdfPath,
-            _mode: PathFillType,
-        ) -> Result<(), PdfCanvasError> {
-            Ok(())
-        }
-
-        fn width(&self) -> f32 {
-            100.0
-        }
-
-        fn height(&self) -> f32 {
-            100.0
-        }
-
-        fn save(&mut self) -> Result<(), PdfCanvasError> {
-            Ok(())
-        }
-
-        fn restore(&mut self) -> Result<(), PdfCanvasError> {
-            Ok(())
-        }
-
-        fn draw_image_rect(
-            &mut self,
-            _image: &BackendImage<'_>,
-            _blend_mode: Option<BlendMode>,
-            _dest_rect: Rect,
-            _image_rotation: Option<f32>,
-        ) -> Result<(), PdfCanvasError> {
-            Ok(())
-        }
-
-        fn begin_mask_layer(
-            &mut self,
-            _mask: &Arc<RecordingCanvas>,
-            _transform: &Transform,
-            _mask_mode: MaskMode,
-        ) -> Result<(), PdfCanvasError> {
-            Ok(())
-        }
-
-        fn end_mask_layer(
-            &mut self,
-            _mask: &Arc<RecordingCanvas>,
-            _transform: &Transform,
-            _mask_mode: MaskMode,
-        ) -> Result<(), PdfCanvasError> {
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn replay_preserves_stroke_style() {
-        let mut recording = RecordingCanvas::new(100.0, 100.0);
-        let mut path = PdfPath::default();
-        path.move_to(0.0, 0.0);
-        path.line_to(10.0, 0.0);
-        let stroke_style = StrokeStyle {
-            dash_pattern: Some(DashPattern {
-                intervals: vec![4.0, 2.0],
-                phase: 1.0,
-            }),
-        };
-
-        recording
-            .stroke_path(
-                &path,
-                Color::from_rgb(0.0, 0.0, 0.0),
-                1.0,
-                &stroke_style,
-                &None,
-                None,
-            )
-            .expect("stroke should record");
-
-        let mut backend = StrokeStyleCanvas::default();
-        recording.replay(&mut backend).expect("replay should work");
-
-        assert_eq!(backend.last_stroke_style, Some(stroke_style));
-    }
-}
-
 impl RecordingCanvas {
     /// Creates a new recording canvas with the given logical dimensions.
     pub fn new(width: f32, height: f32) -> Self {
@@ -448,5 +327,125 @@ impl CanvasBackend for RecordingCanvas {
             mask: Arc::clone(mask),
         });
         Ok(())
+    }
+}
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::stroke_style::StrokeStyle;
+    use pdf_graphics::DashPattern;
+
+    #[derive(Default)]
+    struct StrokeStyleCanvas {
+        last_stroke_style: Option<StrokeStyle>,
+    }
+
+    impl CanvasBackend for StrokeStyleCanvas {
+        fn fill_path(
+            &mut self,
+            _path: &PdfPath,
+            _fill_type: PathFillType,
+            _color: Color,
+            _shader: &Option<Shader>,
+            _blend_mode: Option<BlendMode>,
+        ) -> Result<(), PdfCanvasError> {
+            Ok(())
+        }
+
+        fn stroke_path(
+            &mut self,
+            _path: &PdfPath,
+            _color: Color,
+            _line_width: f32,
+            stroke_style: &StrokeStyle,
+            _shader: &Option<Shader>,
+            _blend_mode: Option<BlendMode>,
+        ) -> Result<(), PdfCanvasError> {
+            self.last_stroke_style = Some(stroke_style.clone());
+            Ok(())
+        }
+
+        fn set_clip_region(
+            &mut self,
+            _path: &PdfPath,
+            _mode: PathFillType,
+        ) -> Result<(), PdfCanvasError> {
+            Ok(())
+        }
+
+        fn width(&self) -> f32 {
+            100.0
+        }
+
+        fn height(&self) -> f32 {
+            100.0
+        }
+
+        fn save(&mut self) -> Result<(), PdfCanvasError> {
+            Ok(())
+        }
+
+        fn restore(&mut self) -> Result<(), PdfCanvasError> {
+            Ok(())
+        }
+
+        fn draw_image_rect(
+            &mut self,
+            _image: &BackendImage<'_>,
+            _blend_mode: Option<BlendMode>,
+            _dest_rect: Rect,
+            _image_rotation: Option<f32>,
+        ) -> Result<(), PdfCanvasError> {
+            Ok(())
+        }
+
+        fn begin_mask_layer(
+            &mut self,
+            _mask: &Arc<RecordingCanvas>,
+            _transform: &Transform,
+            _mask_mode: MaskMode,
+        ) -> Result<(), PdfCanvasError> {
+            Ok(())
+        }
+
+        fn end_mask_layer(
+            &mut self,
+            _mask: &Arc<RecordingCanvas>,
+            _transform: &Transform,
+            _mask_mode: MaskMode,
+        ) -> Result<(), PdfCanvasError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn replay_preserves_stroke_style() {
+        let mut recording = RecordingCanvas::new(100.0, 100.0);
+        let mut path = PdfPath::default();
+        path.move_to(0.0, 0.0);
+        path.line_to(10.0, 0.0);
+        let stroke_style = StrokeStyle {
+            dash_pattern: Some(DashPattern {
+                intervals: vec![4.0, 2.0],
+                phase: 1.0,
+            }),
+        };
+
+        recording
+            .stroke_path(
+                &path,
+                Color::from_rgb(0.0, 0.0, 0.0),
+                1.0,
+                &stroke_style,
+                &None,
+                None,
+            )
+            .expect("stroke should record");
+
+        let mut backend = StrokeStyleCanvas::default();
+        recording.replay(&mut backend).expect("replay should work");
+
+        assert_eq!(backend.last_stroke_style, Some(stroke_style));
     }
 }

--- a/crates/pdf-canvas/src/truetype_font_renderer.rs
+++ b/crates/pdf-canvas/src/truetype_font_renderer.rs
@@ -1,9 +1,13 @@
 use crate::{
-    canvas_backend::CanvasBackend, error::PdfCanvasError, pdf_canvas::PdfCanvas,
-    text_renderer::TextRenderer, text_state::TextState,
+    canvas_backend::CanvasBackend,
+    error::PdfCanvasError,
+    font_renderer_support::{
+        glyph_base_transform, normalized_units_per_em, resolve_simple_font_gid,
+    },
+    pdf_canvas::PdfCanvas,
+    text_renderer::TextRenderer,
 };
 use pdf_font::font::Font;
-use pdf_font::glyph_name_to_unicode::glyph_name_to_unicode;
 use pdf_graphics::transform::Transform;
 use read_fonts::TableProvider;
 use skrifa::{
@@ -43,36 +47,20 @@ impl<'a, 'b, B: CanvasBackend> TrueTypeFontRenderer<'a, 'b, B> {
         code: u16,
         glyph_name: Option<&str>,
     ) -> GlyphId {
-        if let Some(unicode_char) = font.and_then(|current_font| current_font.char_to_unicode(code))
-            && let Some(gid) = self.charmap.map(unicode_char)
-        {
-            return gid;
-        }
+        let glyph_id = resolve_simple_font_gid(
+            font,
+            code,
+            glyph_name,
+            &self.charmap,
+            &self.font_ref,
+            self.is_symbolic,
+        );
 
-        if let Some(name) = glyph_name
-            && let Some(unicode_char) = glyph_name_to_unicode(name)
-            && let Some(gid) = self.charmap.map(unicode_char)
-        {
-            return gid;
-        }
-
-        if let Ok(cmap) = self.font_ref.cmap()
-            && let Some((_, _, subtable)) = cmap.best_subtable()
-            && let Some(id) = subtable.map_codepoint(code)
-        {
-            return id;
-        }
-
-        if self.is_symbolic {
-            if let Some(unicode_char) = char::from_u32(u32::from(code))
-                && let Some(gid) = self.charmap.map(unicode_char)
-            {
-                return gid;
-            }
-        } else {
+        if glyph_id == GlyphId::NOTDEF && !self.is_symbolic {
             println!("Warning: No glyph found for char code {}", code);
         }
-        GlyphId::NOTDEF
+
+        glyph_id
     }
 
     pub fn new(
@@ -86,22 +74,9 @@ impl<'a, 'b, B: CanvasBackend> TrueTypeFontRenderer<'a, 'b, B> {
             .map_err(|e| PdfCanvasError::TrueTypeFontParse(e.to_string()))?;
         let outlines = font_ref.outline_glyphs();
         let charmap = font_ref.charmap();
-
-        let units_per_em = font_ref
-            .head()
-            .ok()
-            .map(|h| h.units_per_em())
-            .filter(|&upe| {
-                (TextState::MIN_UNITS_PER_EM..=TextState::MAX_UNITS_PER_EM).contains(&upe)
-            })
-            .unwrap_or(TextState::DEFAULT_UNITS_PER_EM);
-
-        let upe_inv = 1.0 / f32::from(units_per_em);
-
-        let glyph_base_transform = canvas
-            .current_state()?
-            .text_state
-            .glyph_base_transform(upe_inv);
+        let units_per_em =
+            normalized_units_per_em(font_ref.head().ok().map(|head| head.units_per_em()));
+        let glyph_base_transform = glyph_base_transform(&*canvas, units_per_em)?;
 
         Ok(Self {
             font_ref,
@@ -201,33 +176,7 @@ mod tests {
             FontRef::new(fallback_bytes.as_ref()).expect("bundled fallback font must parse");
         let charmap = font_ref.charmap();
 
-        if let Some(unicode_char) = font.and_then(|current_font| current_font.char_to_unicode(code))
-            && let Some(gid) = charmap.map(unicode_char)
-        {
-            return gid;
-        }
-
-        if let Some(name) = glyph_name
-            && let Some(unicode_char) = glyph_name_to_unicode(name)
-            && let Some(gid) = charmap.map(unicode_char)
-        {
-            return gid;
-        }
-
-        if let Ok(cmap) = font_ref.cmap()
-            && let Some((_, _, subtable)) = cmap.best_subtable()
-            && let Some(id) = subtable.map_codepoint(code)
-        {
-            return id;
-        }
-
-        if is_symbolic
-            && let Some(unicode_char) = char::from_u32(u32::from(code))
-            && let Some(gid) = charmap.map(unicode_char)
-        {
-            return gid;
-        }
-        GlyphId::NOTDEF
+        resolve_simple_font_gid(font, code, glyph_name, &charmap, &font_ref, is_symbolic)
     }
 
     #[test]

--- a/crates/pdf-canvas/src/type1_font_renderer.rs
+++ b/crates/pdf-canvas/src/type1_font_renderer.rs
@@ -1,7 +1,7 @@
 use crate::canvas_backend::CanvasBackend;
+use crate::font_renderer_support::{glyph_base_transform, normalized_units_per_em};
 use crate::pdf_canvas::PdfCanvas;
 use crate::pdf_path_pen::PdfPathPen;
-use crate::text_state::TextState;
 use crate::{error::PdfCanvasError, text_renderer::TextRenderer};
 use pdf_font::type1_font::Type1FontProgramFormat;
 use pdf_graphics::transform::Transform;
@@ -28,6 +28,11 @@ enum Type1RendererFont<'a> {
     ClassicType1(ClassicType1Font),
 }
 
+struct ParsedType1Font<'a> {
+    font: Type1RendererFont<'a>,
+    units_per_em: u16,
+}
+
 /// The rendering state shared by both Type 1 font formats.
 pub(crate) struct Type1FontRenderer<'a, 'b, B: CanvasBackend> {
     /// The canvas where glyphs are rendered.
@@ -46,71 +51,25 @@ pub(crate) struct Type1FontRenderer<'a, 'b, B: CanvasBackend> {
 #[allow(clippy::large_enum_variant)]
 enum PreparedGlyph<'a> {
     /// CFF/OpenType outline glyph data.
-    Cff {
-        /// Resolved glyph identifier.
-        gid: GlyphId,
-        /// The resolved outline, if the font contains one.
-        outline: Option<OutlineGlyph<'a>>,
-    },
+    Cff(CffPreparedGlyph<'a>),
     /// Classic Type 1 glyph data.
-    Classic {
-        /// The path pen populated by the Type 1 renderer.
-        pen: PdfPathPen,
-        /// Preferred PDF width override, if present.
-        pdf_width: Option<f32>,
-        /// Width reported by the Type 1 draw operation, if available.
-        glyph_width: Option<f32>,
-    },
+    Classic(ClassicPreparedGlyph),
 }
 
-/// Returns the canonical invalid-font error used by this renderer.
-fn invalid_type1_font_error() -> PdfCanvasError {
-    PdfCanvasError::InvalidFont("unrecognized Type 1 font data".into())
+struct CffPreparedGlyph<'a> {
+    /// Resolved glyph identifier.
+    gid: GlyphId,
+    /// The resolved outline, if the font contains one.
+    outline: Option<OutlineGlyph<'a>>,
 }
 
-/// Normalizes a parsed `units_per_em` value into the range accepted by the text state.
-fn normalized_units_per_em(units_per_em: Option<u16>) -> u16 {
-    units_per_em
-        .filter(|&upe| (TextState::MIN_UNITS_PER_EM..=TextState::MAX_UNITS_PER_EM).contains(&upe))
-        .unwrap_or(TextState::DEFAULT_UNITS_PER_EM)
-}
-
-/// Resolves the glyph identifier for a CFF/OpenType Type 1 font.
-fn resolve_cff_gid<'a, B: CanvasBackend>(
-    canvas: &PdfCanvas<'a, B>,
-    is_cid: bool,
-    char_code: u16,
-    font_ref: &FontRef<'_>,
-    cid_charset: Option<&CffCharset<'_>>,
-) -> Result<GlyphId, PdfCanvasError> {
-    if is_cid {
-        return Ok(cid_charset
-            .map(|charset| resolve_cid_cff_gid(char_code, charset))
-            .unwrap_or(GlyphId::NOTDEF));
-    }
-
-    let cff = font_ref.cff().map_err(|_| {
-        PdfCanvasError::InvalidFont("failed to read the CFF table from the Type 1 font".into())
-    })?;
-
-    let charset = cff.charset(0).map_err(|_| {
-        PdfCanvasError::InvalidFont("failed to read the Type 1 font CFF charset".into())
-    })?;
-
-    let state = canvas.current_state()?;
-    let name = state.text_state.glyph_name(char_code).unwrap_or(".notdef");
-
-    Ok(charset
-        .and_then(|charset| {
-            charset.iter().find_map(|(gid, glyph_name)| {
-                let is_match = glyph_name
-                    .resolve_standard()
-                    .map(|standard_name| standard_name == name.as_bytes())
-                    .unwrap_or(false);
-                if is_match { Some(gid) } else { None }
-            })
-        })
-        .unwrap_or(GlyphId::NOTDEF))
+struct ClassicPreparedGlyph {
+    /// The path pen populated by the Type 1 renderer.
+    pen: PdfPathPen,
+    /// Preferred PDF width override, if present.
+    pdf_width: Option<f32>,
+    /// Width reported by the Type 1 draw operation, if available.
+    glyph_width: Option<f32>,
 }
 
 /// Resolves a CID through the charset of a CID-keyed CFF font.
@@ -121,155 +80,250 @@ fn resolve_cid_cff_gid(cid: u16, charset: &CffCharset<'_>) -> GlyphId {
     charset.glyph_id(Sid::new(cid)).unwrap_or(GlyphId::NOTDEF)
 }
 
-/// Resolves the glyph identifier for a classic Type 1 font.
-fn resolve_classic_gid<'a, B: CanvasBackend>(
-    canvas: &PdfCanvas<'a, B>,
-    is_cid: bool,
-    char_code: u16,
-    font: &ClassicType1Font,
-) -> GlyphId {
-    if is_cid {
-        return GlyphId::new(u32::from(char_code));
-    }
-
-    let Ok(state) = canvas.current_state() else {
-        return GlyphId::NOTDEF;
-    };
-    let name = state.text_state.glyph_name(char_code).unwrap_or(".notdef");
-
-    if let Some(gid) = font
-        .glyph_names()
-        .find_map(|(gid, glyph_name)| (glyph_name == name).then_some(gid))
-    {
-        return gid;
-    }
-
-    GlyphId::NOTDEF
-}
-
-/// Prepares the glyph data needed to render one character code.
-fn prepare_type1_glyph<'font, C: CanvasBackend>(
-    font: &Type1RendererFont<'font>,
-    canvas: &PdfCanvas<'_, C>,
-    is_cid: bool,
-    char_code: u16,
-) -> Result<PreparedGlyph<'font>, PdfCanvasError> {
-    match font {
-        Type1RendererFont::OpenTypeCff {
-            font_ref,
-            outlines,
-            cid_charset,
-        } => {
-            let gid = resolve_cff_gid(canvas, is_cid, char_code, font_ref, cid_charset.as_ref())?;
-            Ok(PreparedGlyph::Cff {
-                gid,
-                outline: outlines.get(gid),
-            })
-        }
-        Type1RendererFont::ClassicType1(classic_font) => {
-            let gid = resolve_classic_gid(canvas, is_cid, char_code, classic_font);
-            let state = canvas.current_state()?;
-            let pdf_width = state
-                .text_state
-                .font
-                .and_then(|font| font.glyph_width(char_code));
-
-            let mut pen = PdfPathPen::default();
-            let glyph_width = classic_font.draw(gid, None, &mut pen).ok().flatten();
-
-            Ok(PreparedGlyph::Classic {
-                pen,
-                pdf_width,
-                glyph_width,
-            })
-        }
-    }
-}
-
-/// Draws a prepared glyph using the supplied glyph matrix.
-fn draw_prepared_type1_glyph<'font, C: CanvasBackend>(
-    font: &Type1RendererFont<'font>,
-    canvas: &mut PdfCanvas<'_, C>,
-    glyph_matrix: &Transform,
-    glyph: &mut PreparedGlyph<'font>,
-) -> Result<(), PdfCanvasError> {
-    match (font, glyph) {
-        (Type1RendererFont::OpenTypeCff { .. }, PreparedGlyph::Cff { outline, .. }) => {
-            if let Some(outline_glyph) = outline {
-                canvas.draw_outline_glyph(outline_glyph, glyph_matrix)?;
+impl<'a> PreparedGlyph<'a> {
+    fn draw<C: CanvasBackend>(
+        &mut self,
+        canvas: &mut PdfCanvas<'_, C>,
+        glyph_matrix: &Transform,
+    ) -> Result<(), PdfCanvasError> {
+        match self {
+            Self::Cff(cff_glyph) => {
+                if let Some(outline_glyph) = &cff_glyph.outline {
+                    canvas.draw_outline_glyph(outline_glyph, glyph_matrix)?;
+                }
+            }
+            Self::Classic(classic_glyph) => {
+                classic_glyph.pen.path.transform(glyph_matrix);
+                canvas.draw_glyph_path(&classic_glyph.pen.path)?;
             }
         }
-        (Type1RendererFont::ClassicType1(_), PreparedGlyph::Classic { pen, .. }) => {
-            pen.path.transform(glyph_matrix);
-            canvas.draw_glyph_path(&pen.path)?;
-        }
-        _ => unreachable!("prepared glyph and font format must match"),
+        Ok(())
     }
-    Ok(())
 }
 
-/// Advances the text cursor after a prepared glyph has been drawn.
-fn advance_prepared_type1_glyph<'font, C: CanvasBackend>(
-    font: &Type1RendererFont<'font>,
-    canvas: &mut PdfCanvas<'_, C>,
-    char_code: u16,
-    glyph: &PreparedGlyph<'font>,
-    units_per_em: u16,
-) -> Result<(), PdfCanvasError> {
-    match (font, glyph) {
-        (Type1RendererFont::OpenTypeCff { font_ref, .. }, PreparedGlyph::Cff { gid, .. }) => canvas
-            .current_state_mut()?
-            .text_state
-            .advance_horizontal_glyph(char_code, font_ref, *gid, units_per_em),
-        (
-            Type1RendererFont::ClassicType1(_),
-            PreparedGlyph::Classic {
-                pdf_width,
-                glyph_width,
-                ..
+impl<'a> Type1RendererFont<'a> {
+    fn parse(
+        font_bytes: &'a [u8],
+        program_format: Type1FontProgramFormat,
+        is_cid: bool,
+    ) -> Result<ParsedType1Font<'a>, PdfCanvasError> {
+        match program_format {
+            Type1FontProgramFormat::OpenTypeCff => Self::parse_opentype_cff(font_bytes, is_cid),
+            Type1FontProgramFormat::ClassicType1 => Self::parse_classic_type1(font_bytes),
+        }
+    }
+
+    fn parse_opentype_cff(
+        font_bytes: &'a [u8],
+        is_cid: bool,
+    ) -> Result<ParsedType1Font<'a>, PdfCanvasError> {
+        let font_ref = FontRef::new(font_bytes).map_err(|_| Self::invalid_font_error())?;
+        let units_per_em =
+            normalized_units_per_em(font_ref.head().ok().map(|head| head.units_per_em()));
+        let cid_charset = Self::load_cid_charset(&font_ref, is_cid)?;
+
+        Ok(ParsedType1Font {
+            font: Self::OpenTypeCff {
+                outlines: font_ref.outline_glyphs(),
+                font_ref,
+                cid_charset,
             },
-        ) => {
-            let text_state = &mut canvas.current_state_mut()?.text_state;
-            if let Some(pdf_width) = pdf_width {
-                text_state.advance_horizontal_width(
-                    char_code,
-                    *pdf_width,
-                    TextState::DEFAULT_UNITS_PER_EM,
-                );
-            } else if let Some(glyph_width) = glyph_width {
-                text_state.advance_horizontal_width(char_code, *glyph_width, units_per_em);
-            } else {
-                text_state.advance_horizontal_width(char_code, 0.0, units_per_em);
-            }
-            Ok(())
+            units_per_em,
+        })
+    }
+
+    fn parse_classic_type1(font_bytes: &'a [u8]) -> Result<ParsedType1Font<'a>, PdfCanvasError> {
+        let font = ClassicType1Font::new(font_bytes).map_err(|_| Self::invalid_font_error())?;
+        let units_per_em = normalized_units_per_em(u16::try_from(font.upem()).ok());
+
+        Ok(ParsedType1Font {
+            font: Self::ClassicType1(font),
+            units_per_em,
+        })
+    }
+
+    fn load_cid_charset(
+        font_ref: &FontRef<'a>,
+        is_cid: bool,
+    ) -> Result<Option<CffCharset<'a>>, PdfCanvasError> {
+        if !is_cid {
+            return Ok(None);
         }
-        _ => unreachable!("prepared glyph and font format must match"),
+
+        let cff = font_ref.cff().map_err(|_| Self::cff_table_error())?;
+        let cid_font = CffFontRef::new_cff(cff.offset_data().as_bytes(), 0, None)
+            .map_err(|_| Self::invalid_font_error())?;
+
+        cid_font
+            .charset()
+            .ok_or_else(Self::invalid_font_error)
+            .map(Some)
+    }
+
+    fn invalid_font_error() -> PdfCanvasError {
+        PdfCanvasError::InvalidFont("unrecognized Type 1 font data".into())
+    }
+
+    fn cff_table_error() -> PdfCanvasError {
+        PdfCanvasError::InvalidFont("failed to read the CFF table from the Type 1 font".into())
+    }
+
+    fn cff_charset_error() -> PdfCanvasError {
+        PdfCanvasError::InvalidFont("failed to read the Type 1 font CFF charset".into())
+    }
+
+    fn prepare_glyph<C: CanvasBackend>(
+        &self,
+        canvas: &PdfCanvas<'_, C>,
+        is_cid: bool,
+        char_code: u16,
+    ) -> Result<PreparedGlyph<'a>, PdfCanvasError> {
+        match self {
+            Self::OpenTypeCff {
+                font_ref,
+                outlines,
+                cid_charset,
+            } => {
+                let glyph_id = self.resolve_cff_gid(
+                    canvas,
+                    is_cid,
+                    char_code,
+                    font_ref,
+                    cid_charset.as_ref(),
+                )?;
+                Ok(PreparedGlyph::Cff(CffPreparedGlyph {
+                    gid: glyph_id,
+                    outline: outlines.get(glyph_id),
+                }))
+            }
+            Self::ClassicType1(classic_font) => {
+                self.prepare_classic_glyph(canvas, is_cid, char_code, classic_font)
+            }
+        }
+    }
+
+    fn prepare_classic_glyph<C: CanvasBackend>(
+        &self,
+        canvas: &PdfCanvas<'_, C>,
+        is_cid: bool,
+        char_code: u16,
+        classic_font: &ClassicType1Font,
+    ) -> Result<PreparedGlyph<'a>, PdfCanvasError> {
+        let glyph_id = self.resolve_classic_gid(canvas, is_cid, char_code, classic_font);
+        let pdf_width = canvas
+            .current_state()?
+            .text_state
+            .font
+            .and_then(|font| font.glyph_width(char_code));
+
+        let mut pen = PdfPathPen::default();
+        let glyph_width = classic_font.draw(glyph_id, None, &mut pen).ok().flatten();
+
+        Ok(PreparedGlyph::Classic(ClassicPreparedGlyph {
+            pen,
+            pdf_width,
+            glyph_width,
+        }))
+    }
+
+    fn advance_glyph<C: CanvasBackend>(
+        &self,
+        canvas: &mut PdfCanvas<'_, C>,
+        char_code: u16,
+        glyph: &PreparedGlyph<'a>,
+        units_per_em: u16,
+    ) -> Result<(), PdfCanvasError> {
+        match (self, glyph) {
+            (Self::OpenTypeCff { font_ref, .. }, PreparedGlyph::Cff(cff_glyph)) => canvas
+                .current_state_mut()?
+                .text_state
+                .advance_horizontal_glyph(char_code, font_ref, cff_glyph.gid, units_per_em),
+            (Self::ClassicType1(_), PreparedGlyph::Classic(classic_glyph)) => {
+                classic_glyph.advance(canvas, char_code, units_per_em)
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn resolve_cff_gid<C: CanvasBackend>(
+        &self,
+        canvas: &PdfCanvas<'_, C>,
+        is_cid: bool,
+        char_code: u16,
+        font_ref: &FontRef<'_>,
+        cid_charset: Option<&CffCharset<'_>>,
+    ) -> Result<GlyphId, PdfCanvasError> {
+        if is_cid {
+            return Ok(cid_charset
+                .map(|charset| resolve_cid_cff_gid(char_code, charset))
+                .unwrap_or(GlyphId::NOTDEF));
+        }
+
+        let cff = font_ref.cff().map_err(|_| Self::cff_table_error())?;
+        let charset = cff.charset(0).map_err(|_| Self::cff_charset_error())?;
+        let glyph_name = canvas
+            .current_state()?
+            .text_state
+            .glyph_name(char_code)
+            .unwrap_or(".notdef");
+
+        Ok(charset
+            .and_then(|charset| {
+                charset.iter().find_map(|(gid, cff_glyph_name)| {
+                    cff_glyph_name
+                        .resolve_standard()
+                        .ok()
+                        .filter(|standard_name| *standard_name == glyph_name.as_bytes())
+                        .map(|_| gid)
+                })
+            })
+            .unwrap_or(GlyphId::NOTDEF))
+    }
+
+    fn resolve_classic_gid<C: CanvasBackend>(
+        &self,
+        canvas: &PdfCanvas<'_, C>,
+        is_cid: bool,
+        char_code: u16,
+        font: &ClassicType1Font,
+    ) -> GlyphId {
+        if is_cid {
+            return GlyphId::new(u32::from(char_code));
+        }
+
+        let Ok(state) = canvas.current_state() else {
+            return GlyphId::NOTDEF;
+        };
+        let glyph_name = state.text_state.glyph_name(char_code).unwrap_or(".notdef");
+
+        font.glyph_names()
+            .find_map(|(gid, current_name)| (current_name == glyph_name).then_some(gid))
+            .unwrap_or(GlyphId::NOTDEF)
     }
 }
 
-/// Renders text for a Type 1 font using a single shared glyph loop.
-fn render_type1_text<'font, C: CanvasBackend>(
-    font: &Type1RendererFont<'font>,
-    canvas: &mut PdfCanvas<'_, C>,
-    is_cid: bool,
-    glyph_base_transform: Transform,
-    units_per_em: u16,
-    iter: impl Iterator<Item = u16>,
-) -> Result<(), PdfCanvasError> {
-    for char_code in iter {
-        let glyph_matrix = {
-            let state = canvas.current_state()?;
-            state
-                .text_state
-                .compose_glyph_matrix(glyph_base_transform, &state.transform)
-        };
+impl ClassicPreparedGlyph {
+    fn advance<C: CanvasBackend>(
+        &self,
+        canvas: &mut PdfCanvas<'_, C>,
+        char_code: u16,
+        units_per_em: u16,
+    ) -> Result<(), PdfCanvasError> {
+        let text_state = &mut canvas.current_state_mut()?.text_state;
 
-        let mut glyph = prepare_type1_glyph(font, &*canvas, is_cid, char_code)?;
+        if let Some(pdf_width) = self.pdf_width {
+            text_state.advance_horizontal_width(char_code, pdf_width, 1000);
+            return Ok(());
+        }
 
-        draw_prepared_type1_glyph(font, canvas, &glyph_matrix, &mut glyph)?;
-        advance_prepared_type1_glyph(font, canvas, char_code, &glyph, units_per_em)?;
+        if let Some(glyph_width) = self.glyph_width {
+            text_state.advance_horizontal_width(char_code, glyph_width, units_per_em);
+            return Ok(());
+        }
+
+        text_state.advance_horizontal_width(char_code, 0.0, units_per_em);
+        Ok(())
     }
-    Ok(())
 }
 
 impl<'a, 'b, B: CanvasBackend> Type1FontRenderer<'a, 'b, B> {
@@ -284,49 +338,9 @@ impl<'a, 'b, B: CanvasBackend> Type1FontRenderer<'a, 'b, B> {
         program_format: Type1FontProgramFormat,
         is_cid: bool,
     ) -> Result<Self, PdfCanvasError> {
-        let (font, units_per_em) = match program_format {
-            Type1FontProgramFormat::OpenTypeCff => {
-                let font_ref = FontRef::new(font_bytes).map_err(|_| invalid_type1_font_error())?;
-                let units_per_em =
-                    normalized_units_per_em(font_ref.head().ok().map(|head| head.units_per_em()));
-                let cid_charset = if is_cid {
-                    let cff = font_ref.cff().map_err(|_| {
-                        PdfCanvasError::InvalidFont(
-                            "failed to read the CFF table from the Type 1 font".into(),
-                        )
-                    })?;
-                    let cid_font = CffFontRef::new_cff(cff.offset_data().as_bytes(), 0, None)
-                        .map_err(|_| invalid_type1_font_error())?;
-                    cid_font
-                        .charset()
-                        .ok_or_else(invalid_type1_font_error)
-                        .map(Some)?
-                } else {
-                    None
-                };
-
-                (
-                    Type1RendererFont::OpenTypeCff {
-                        outlines: font_ref.outline_glyphs(),
-                        font_ref,
-                        cid_charset,
-                    },
-                    units_per_em,
-                )
-            }
-            Type1FontProgramFormat::ClassicType1 => {
-                let font =
-                    ClassicType1Font::new(font_bytes).map_err(|_| invalid_type1_font_error())?;
-                let units_per_em = normalized_units_per_em(u16::try_from(font.upem()).ok());
-                (Type1RendererFont::ClassicType1(font), units_per_em)
-            }
-        };
-
-        let upe_inv = 1.0 / f32::from(units_per_em);
-        let glyph_base_transform = canvas
-            .current_state()?
-            .text_state
-            .glyph_base_transform(upe_inv);
+        let ParsedType1Font { font, units_per_em } =
+            Type1RendererFont::parse(font_bytes, program_format, is_cid)?;
+        let glyph_base_transform = glyph_base_transform(&*canvas, units_per_em)?;
 
         Ok(Self {
             canvas,
@@ -336,27 +350,51 @@ impl<'a, 'b, B: CanvasBackend> Type1FontRenderer<'a, 'b, B> {
             units_per_em,
         })
     }
+
+    fn glyph_matrix(&self) -> Result<Transform, PdfCanvasError> {
+        let state = self.canvas.current_state()?;
+        Ok(state
+            .text_state
+            .compose_glyph_matrix(self.glyph_base_transform, &state.transform))
+    }
+
+    fn prepare_glyph(&self, char_code: u16) -> Result<PreparedGlyph<'b>, PdfCanvasError> {
+        self.font
+            .prepare_glyph(&*self.canvas, self.is_cid, char_code)
+    }
+
+    fn draw_glyph(
+        &mut self,
+        glyph: &mut PreparedGlyph<'b>,
+        glyph_matrix: &Transform,
+    ) -> Result<(), PdfCanvasError> {
+        glyph.draw(self.canvas, glyph_matrix)
+    }
+
+    fn advance_text_position(
+        &mut self,
+        char_code: u16,
+        glyph: &PreparedGlyph<'b>,
+    ) -> Result<(), PdfCanvasError> {
+        self.font
+            .advance_glyph(self.canvas, char_code, glyph, self.units_per_em)
+    }
+
+    fn render_char(&mut self, char_code: u16) -> Result<(), PdfCanvasError> {
+        let glyph_matrix = self.glyph_matrix()?;
+        let mut glyph = self.prepare_glyph(char_code)?;
+        self.draw_glyph(&mut glyph, &glyph_matrix)?;
+        self.advance_text_position(char_code, &glyph)
+    }
 }
 
 impl<B: CanvasBackend> TextRenderer for Type1FontRenderer<'_, '_, B> {
     /// Renders text using the configured Type 1 font program.
     fn render_text(&mut self, iter: impl Iterator<Item = u16>) -> Result<(), PdfCanvasError> {
-        let Self {
-            canvas,
-            font,
-            is_cid,
-            glyph_base_transform,
-            units_per_em,
-        } = self;
-
-        render_type1_text(
-            font,
-            canvas,
-            *is_cid,
-            *glyph_base_transform,
-            *units_per_em,
-            iter,
-        )
+        for char_code in iter {
+            self.render_char(char_code)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
- Extract shared glyph lookup and transform helpers.
- Break Type 1 rendering into smaller methods.
- Reuse the shared helpers in the TrueType renderer.