### PR TITLE
pdf-document: tolerate malformed optional objects

### DIFF
--- a/crates/pdf-content-stream/src/content_stream.rs
+++ b/crates/pdf-content-stream/src/content_stream.rs
@@ -123,7 +123,13 @@ impl ContentStream {
             return Ok(None);
         };
 
-        Ok(Some(Self::new(contents, objects, id_allocator)?))
+        match Self::new(contents, objects, id_allocator) {
+            Ok(contents) => Ok(Some(contents)),
+            Err(PdfOperatorError::Object(ObjectError::FailedResolveObjectReference { .. })) => {
+                Ok(None)
+            }
+            Err(error) => Err(error),
+        }
     }
 }
 

--- a/crates/pdf-document/src/reader.rs
+++ b/crates/pdf-document/src/reader.rs
@@ -70,22 +70,25 @@ impl PdfReader {
 
         // Check for encryption and handle it before loading other objects.
         let decryptor = if let Some(encrypt_ref) = trailer.dictionary.take("Encrypt") {
-            // Load the encryption object first (it's unencrypted per PDF spec).
-            let encryption = load_encrypt_dictionary(encrypt_ref, &entries, &mut parser)?;
+            match load_encrypt_dictionary(encrypt_ref, &entries, &mut parser) {
+                Ok(encryption) => {
+                    // Get the document ID from the trailer (required for encryption)
+                    let document_id = extract_document_id(&trailer)?;
 
-            // Get the document ID from the trailer (required for encryption)
-            let document_id = extract_document_id(&trailer)?;
+                    const EMPTY_PASSWORD: &[u8] = b"";
 
-            const EMPTY_PASSWORD: &[u8] = b"";
+                    // Create the decryptor by authenticating with the password
+                    let decryptor = DocumentDecryptor::new(
+                        &encryption,
+                        &document_id,
+                        password.unwrap_or(EMPTY_PASSWORD),
+                    )?;
 
-            // Create the decryptor by authenticating with the password
-            let decryptor = DocumentDecryptor::new(
-                &encryption,
-                &document_id,
-                password.unwrap_or(EMPTY_PASSWORD),
-            )?;
-
-            Some(decryptor)
+                    Some(decryptor)
+                }
+                Err(error) if is_recoverable_optional_object_error(&error) => None,
+                Err(error) => return Err(error),
+            }
         } else {
             None
         };
@@ -276,6 +279,7 @@ fn load_objects_with_decryption(
             ))) => {
                 unresolved.push(byte_offset);
             }
+            Err(e) if is_recoverable_optional_object_error(&e) => {}
             Err(e) => return Err(e),
         }
     }
@@ -298,6 +302,7 @@ fn load_objects_with_decryption(
                 ))) => {
                     still_unresolved.push(*byte_offset);
                 }
+                Err(e) if is_recoverable_optional_object_error(&e) => {}
                 Err(e) => return Err(e),
             }
         }
@@ -328,6 +333,15 @@ fn load_objects_with_decryption(
     load_available_compressed_objects(entries, &mut objects, &mut parsed_obj_streams, true)?;
 
     Ok(objects)
+}
+
+/// Returns whether a bulk-loaded object can be skipped until a required reference proves otherwise.
+fn is_recoverable_optional_object_error(error: &PdfReaderError) -> bool {
+    matches!(
+        error,
+        PdfReaderError::ParserError(_)
+            | PdfReaderError::ObjectError(ObjectError::DecompressionError(_))
+    )
 }
 
 /// Unpacks compressed xref entries whose object streams are already available.

--- a/crates/pdf-document/tests/reader.rs
+++ b/crates/pdf-document/tests/reader.rs
@@ -102,6 +102,43 @@ fn build_issue1293_like_pdf() -> Vec<u8> {
     data
 }
 
+fn build_pdfbox4352_like_pdf() -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"%PDF-1.7\n");
+
+    let obj1_offset = data.len();
+    data.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let obj2_offset = data.len();
+    data.extend_from_slice(b"2 0 obj\n<< /Count 1 /Kids [3 0 R] /Type /Pages >>\nendobj\n");
+
+    let obj3_offset = data.len();
+    data.extend_from_slice(
+        b"3 0 obj\n<< /Contents 4 0 R /MediaBox [0 0 200 50] /Parent 2 0 R /Type /Page >>\nendobj\n",
+    );
+
+    let obj4_offset = data.len();
+    data.extend_from_slice(b"4 0 obj\n<< /Length 4 /Filter /FlateDecode >>\nstream\n");
+    data.extend_from_slice(&[0, 1, 2, 3]);
+    data.extend_from_slice(b"\nendstream\nendobj\n");
+
+    let obj5_offset = data.len();
+    data.extend_from_slice(b"5 0 obj\nE< /Filter /Standard /V 5 /R 6 /Length 256 >>\nendobj\n");
+
+    let xref_offset = data.len();
+    data.extend_from_slice(b"xref\n0 6\n");
+    data.extend_from_slice(format_xref_entry(0, 65_535, false).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj1_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj2_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj3_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj4_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj5_offset, 0, true).as_bytes());
+    data.extend_from_slice(b"trailer\n<< /Size 6 /Root 1 0 R /Encrypt 5 0 R >>\n");
+    data.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF").as_bytes());
+
+    data
+}
+
 fn build_issue10438_like_pdf() -> Vec<u8> {
     let mut data = Vec::new();
     data.extend_from_slice(b"%PDF-1.7\n");
@@ -660,6 +697,21 @@ fn test_issue1293_pdf_loads_normally() {
     assert!(
         result.is_ok(),
         "issue1293r.pdf should load with missing /Length recovery: {:?}",
+        result.err()
+    );
+    let doc = result.unwrap();
+    assert_eq!(doc.page_count(), 1);
+    assert!(doc.get_page(0).is_some());
+}
+
+#[test]
+fn test_pdfbox4352_pdf_loads_normally() {
+    let reader = PdfReader;
+    let data = build_pdfbox4352_like_pdf();
+    let result = reader.read_from_bytes(&data, None);
+    assert!(
+        result.is_ok(),
+        "PDFBOX-4352-style PDF should load despite malformed optional encryption object: {:?}",
         result.err()
     );
     let doc = result.unwrap();

--- a/crates/pdf-parser/src/indirect_object.rs
+++ b/crates/pdf-parser/src/indirect_object.rs
@@ -341,6 +341,7 @@ mod tests {
             b"123".as_slice(),
             b"1 0 object".as_slice(),
             b"1 0 Rextra".as_slice(),
+            b"1 0 ]".as_slice(),
         ] {
             let mut parser = PdfParser::from(input);
 

--- a/crates/pdf-parser/tests/xref_builder.rs
+++ b/crates/pdf-parser/tests/xref_builder.rs
@@ -790,6 +790,44 @@ fn build_xref_table_repairs_issue139_offsets() {
 }
 
 #[test]
+fn build_xref_table_repair_ignores_numeric_array_entries() {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"%PDF-1.4\n");
+
+    let obj1_offset = data.len();
+    data.extend_from_slice(
+        b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R /OpenAction [1 0] >>\nendobj\n",
+    );
+
+    let obj2_offset = data.len();
+    data.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n");
+
+    let false_header_offset = data
+        .windows(b"1 0]".len())
+        .position(|window| window == b"1 0]")
+        .expect("fixture should contain numeric array entry");
+
+    let xref_offset = data.len();
+    data.extend_from_slice(b"xref\n0 3\n");
+    data.extend_from_slice(format_xref_entry(0, 65_535, false).as_bytes());
+    data.extend_from_slice(format_xref_entry(false_header_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj2_offset, 0, true).as_bytes());
+    data.extend_from_slice(b"trailer\n<< /Size 3 /Root 1 0 R >>\n");
+    data.extend_from_slice(format!("startxref\n{xref_offset}\n%%EOF").as_bytes());
+
+    let mut parser = PdfParser::from(data.as_slice());
+    let table = parser.build_xref_table().unwrap();
+
+    assert_eq!(
+        table
+            .entries
+            .get(&1)
+            .and_then(CrossReferenceEntry::byte_offset),
+        Some(obj1_offset)
+    );
+}
+
+#[test]
 fn build_xref_table_recovers_distant_shifted_xref_offsets() {
     let (data, expected_offsets) = build_far_shifted_xref_pdf(500, 105_359);
     let mut parser = PdfParser::from(data.as_slice());


### PR DESCRIPTION
Recover from malformed optional objects while loading PDF documents. This keeps unreadable encryption dictionaries and corrupt optional streams from aborting page tree loading when the required page structure is still usable.