### PR TITLE
pdf-document: recover malformed JBIG2 image PDFs

### DIFF
--- a/crates/pdf-document/tests/reader.rs
+++ b/crates/pdf-document/tests/reader.rs
@@ -269,6 +269,48 @@ fn build_xobject_image_pdf() -> Vec<u8> {
     data
 }
 
+fn build_xobject_image_with_flat_xref_rows_pdf() -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"%PDF-1.4\n");
+
+    let obj1_offset = data.len();
+    data.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let obj2_offset = data.len();
+    data.extend_from_slice(
+        b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 /MediaBox [0 0 1 1] >>\nendobj\n",
+    );
+
+    let obj3_offset = data.len();
+    data.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 1 1] /Contents 4 0 R /Resources << /XObject << /Im 5 0 R >> >> >>\nendobj\n",
+    );
+
+    let obj4_offset = data.len();
+    data.extend_from_slice(b"4 0 obj\n<< /Length 6 >>\nstream\n/Im Do\nendstream\nendobj\n");
+
+    let obj5_offset = data.len();
+    data.extend_from_slice(
+        b"5 0 obj\n<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceGray /BitsPerComponent 8 /Length 1 >>\nstream\nA\nendstream\nendobj\n",
+    );
+
+    let xref_offset = data.len();
+    data.extend_from_slice(b"xref\n");
+    data.extend_from_slice(format_xref_entry(0, 65_535, false).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj1_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj2_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj3_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj4_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj5_offset, 0, true).as_bytes());
+
+    data.extend_from_slice(b"trailer\n<< /Size 6 /Root 1 0 R >>\n");
+    data.extend_from_slice(b"startxref\n");
+    data.extend_from_slice(format!("{}\n", xref_offset).as_bytes());
+    data.extend_from_slice(b"%%EOF");
+
+    data
+}
+
 fn build_hybrid_xref_pdf() -> Vec<u8> {
     fn push_xref_stream_entry(data: &mut Vec<u8>, entry_type: u8, field2: u16, field3: u8) {
         data.push(entry_type);
@@ -757,6 +799,21 @@ fn test_xobject_image_pdf_loads_normally() {
     assert!(
         result.is_ok(),
         "xobject-image.pdf should load after traditional xref entry repair: {:?}",
+        result.err()
+    );
+    let doc = result.unwrap();
+    assert_eq!(doc.page_count(), 1);
+    assert!(doc.get_page(0).is_some());
+}
+
+#[test]
+fn test_xobject_image_with_flat_xref_rows_pdf_loads_normally() {
+    let reader = PdfReader;
+    let data = build_xobject_image_with_flat_xref_rows_pdf();
+    let result = reader.read_from_bytes(&data, None);
+    assert!(
+        result.is_ok(),
+        "xobject image with xref keyword and flat rows should load: {:?}",
         result.err()
     );
     let doc = result.unwrap();

--- a/crates/pdf-image/src/image_xobject.rs
+++ b/crates/pdf-image/src/image_xobject.rs
@@ -53,7 +53,20 @@ impl ImageXObject {
         soft_mask: Option<ImageXObject>,
     ) -> Result<Self, PdfImageError> {
         let raw_data = stream_data.data()?;
-        Self::decode_normalized_image(dictionary, raw_data.as_ref(), objects, soft_mask)
+        match Self::decode_normalized_image(
+            dictionary,
+            raw_data.as_ref(),
+            objects,
+            soft_mask.clone(),
+        ) {
+            Ok(image) => Ok(image),
+            Err(original_error) if Filter::from_dictionary(dictionary, objects)?.is_some() => {
+                let decoded = decode_with_resolver(stream_data, objects)?;
+                Self::decode_normalized_image(dictionary, decoded.as_ref(), objects, soft_mask)
+                    .map_err(|_| original_error)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// Decodes an inline image, including its filter chain and normalized sample data.

--- a/crates/pdf-jbig2/src/huffman/symbol_id.rs
+++ b/crates/pdf-jbig2/src/huffman/symbol_id.rs
@@ -149,6 +149,7 @@ impl SymbolIdRunCodeTable {
 pub(crate) struct SymbolIdHuffmanTable {
     codes: Vec<HuffmanCode>,
     tree: DecodeTree,
+    fallback_tree: Option<DecodeTree>,
 }
 
 impl SymbolIdHuffmanTable {
@@ -159,7 +160,18 @@ impl SymbolIdHuffmanTable {
     fn new(lengths: &[u8]) -> Result<Self, Jbig2Error> {
         let codes = assign_canonical_codes(lengths)?;
         let tree = DecodeTree::new(&codes)?;
-        Ok(Self { codes, tree })
+        let fallback_tree = shifted_nonzero_lengths(lengths)
+            .filter(|shifted| shifted.as_slice() != lengths)
+            .and_then(|shifted| {
+                assign_canonical_codes(&shifted)
+                    .ok()
+                    .and_then(|codes| DecodeTree::new(&codes).ok())
+            });
+        Ok(Self {
+            codes,
+            tree,
+            fallback_tree,
+        })
     }
 
     /// Decode one symbol ID from a text-region Huffman body.
@@ -167,7 +179,18 @@ impl SymbolIdHuffmanTable {
     /// This is the symbol ID lookup step described by ITU-T T.88 /
     /// ISO/IEC 14492 section 6.4.10.
     fn decode(&self, reader: &mut BitReader<'_>) -> Result<usize, Jbig2Error> {
-        self.tree.decode(reader, SYMBOL_ID_STREAM)
+        let mark = reader.pos();
+        match self.tree.decode(reader, SYMBOL_ID_STREAM) {
+            Ok(symbol) => Ok(symbol),
+            Err(Jbig2Error::InvalidTable(SYMBOL_ID_STREAM)) => {
+                let Some(fallback_tree) = &self.fallback_tree else {
+                    return Err(Jbig2Error::InvalidTable(SYMBOL_ID_STREAM));
+                };
+                reader.set_pos(mark);
+                fallback_tree.decode(reader, SYMBOL_ID_STREAM)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     /// Return canonical symbol-ID codes for focused unit tests.
@@ -203,6 +226,18 @@ pub(crate) fn decode_symbol_id(
     table: &SymbolIdHuffmanTable,
 ) -> Result<usize, Jbig2Error> {
     table.decode(reader)
+}
+
+/// Builds a compatibility table for streams that encode nonzero symbol code
+/// lengths one greater than the effective prefix length.
+fn shifted_nonzero_lengths(lengths: &[u8]) -> Option<Vec<u8>> {
+    lengths
+        .iter()
+        .map(|length| match *length {
+            0 => Some(0),
+            value => value.checked_sub(1),
+        })
+        .collect()
 }
 
 /// Read the 35 run-code table lengths from `reader`.
@@ -395,6 +430,20 @@ mod tests {
         let table = decode_symbol_id_huffman_table(&mut reader, 10).expect("table");
 
         assert_code_lengths(&table, &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn decodes_shifted_nonzero_symbol_lengths_as_fallback() {
+        let mut data = symbol_id_table_stream(&[(0, 1), (2, 1)], &[(1, 1), (0, 1), (1, 1)]);
+        data.push(0b1100_0000);
+        let mut reader = BitReader::new(&data);
+        let table = decode_symbol_id_huffman_table(&mut reader, 3).expect("table");
+        reader.align_to_byte_boundary();
+
+        let symbol_id = decode_symbol_id(&mut reader, &table).expect("symbol id");
+
+        assert_code_lengths(&table, &[2, 0, 2]);
+        assert_eq!(symbol_id, 2);
     }
 
     #[test]

--- a/crates/pdf-jbig2/src/text_region/huffman.rs
+++ b/crates/pdf-jbig2/src/text_region/huffman.rs
@@ -23,7 +23,6 @@ use crate::{
 };
 use pdf_utils::BitReader;
 
-const TEXT_REGION_BODY: &str = "text region body";
 const TEXT_REGION_STRIP_INDEX: &str = "text region strip index";
 const TEXT_REGION_REFINEMENT_TABLES: &str = "text-region refinement Huffman tables";
 const TEXT_REGION_REFINEMENT_FLAG: &str = "text region refinement flag";
@@ -42,7 +41,7 @@ struct HuffmanTextRegionDecodeContext<'a> {
     dt_table: HuffmanDecoder,
     symbol_id_table: SymbolIdHuffmanTable,
     refinement_tables: Option<TextRegionRefinementTables>,
-    body: &'a [u8],
+    body_reader: BitReader<'a>,
 }
 
 /// Standard Huffman tables used by refinement-coded text regions.
@@ -95,9 +94,6 @@ impl<'a> HuffmanTextRegionDecodeContext<'a> {
         let symbol_id_table =
             decode_symbol_id_huffman_table(&mut body_reader, shared.symbols_len())?;
         body_reader.align_to_byte_boundary();
-        let body = body_reader
-            .remaining_from_byte()
-            .ok_or(Jbig2Error::Truncated(TEXT_REGION_BODY))?;
         let refinement_tables = if parsed.flags.contains(TextRegionFlagBits::SBREFINE) {
             Some(TextRegionRefinementTables::new(
                 &mut custom_tables,
@@ -114,7 +110,7 @@ impl<'a> HuffmanTextRegionDecodeContext<'a> {
             dt_table,
             symbol_id_table,
             refinement_tables,
-            body,
+            body_reader,
         })
     }
 }
@@ -175,7 +171,7 @@ impl<'a> HuffmanTextRegionDecoder<'a> {
         parsed: ParsedTextRegion<'a>,
     ) -> Result<Self, Jbig2Error> {
         let context = HuffmanTextRegionDecodeContext::new(context, parsed)?;
-        let mut body_reader = BitReader::new(context.body);
+        let mut body_reader = context.body_reader.clone();
         let initial_stript = context.dt_table.decode_value(&mut body_reader)?;
         let state = TextRegionDecodeState::from_initial_delta(
             initial_stript,

--- a/crates/pdf-object-collection/src/object_collection.rs
+++ b/crates/pdf-object-collection/src/object_collection.rs
@@ -77,7 +77,9 @@ impl ObjectCollection {
                 }
             }
             ObjectVariant::Stream(stream) => {
-                let data = pdf_filter::filter::decode_with_resolver(&stream, self)?.to_vec();
+                let data = pdf_filter::filter::decode_with_resolver(&stream, self)
+                    .map(|data| data.to_vec())
+                    .unwrap_or_else(|_| stream.raw_data().to_vec());
                 let StreamObject {
                     object_number,
                     generation_number,

--- a/crates/pdf-parser/src/xref_builder.rs
+++ b/crates/pdf-parser/src/xref_builder.rs
@@ -237,8 +237,17 @@ impl<'parser, 'input> XrefBuilder<'parser, 'input> {
 
         self.at_position(offset, |builder| {
             builder.parser.skip_whitespace_and_comments();
+            builder.skip_optional_xref_keyword();
             builder.parse_malformed_rows()
         })
+    }
+
+    /// Consumes an `xref` keyword when malformed row recovery starts at it.
+    fn skip_optional_xref_keyword(&mut self) {
+        let mark = self.parser.tokenizer.position;
+        if self.parser.read_keyword(XREF_KEYWORD).is_err() {
+            self.parser.tokenizer.position = mark;
+        }
     }
 
     /// Parses malformed rows while preserving the cursor on failure.

--- a/crates/pdf-parser/tests/xref_builder.rs
+++ b/crates/pdf-parser/tests/xref_builder.rs
@@ -983,6 +983,50 @@ fn build_xref_table_recovers_missing_xref_command() {
 }
 
 #[test]
+fn build_xref_table_recovers_xref_keyword_with_flat_entries() {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"%PDF-1.4\n");
+
+    let obj1_offset = data.len();
+    data.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let obj2_offset = data.len();
+    data.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let obj3_offset = data.len();
+    data.extend_from_slice(b"3 0 obj\n<< /Type /Page /Parent 2 0 R /Resources << /XObject << /Im 5 0 R >> >> >>\nendobj\n");
+
+    let obj4_offset = data.len();
+    data.extend_from_slice(b"4 0 obj\n<< /Length 0 >>\nstream\n\nendstream\nendobj\n");
+
+    let obj5_offset = data.len();
+    data.extend_from_slice(b"5 0 obj\n<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceGray /BitsPerComponent 8 /Length 1 >>\nstream\nA\nendstream\nendobj\n");
+
+    let xref_offset = data.len();
+    data.extend_from_slice(b"xref\n");
+    data.extend_from_slice(format_xref_entry(0, 65_535, false).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj1_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj2_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj3_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj4_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj5_offset, 0, true).as_bytes());
+    data.extend_from_slice(
+        format!("trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF").as_bytes(),
+    );
+
+    let mut parser = PdfParser::from(data.as_slice());
+    let table = parser.build_xref_table().unwrap();
+
+    assert_eq!(
+        table
+            .entries
+            .get(&5)
+            .and_then(CrossReferenceEntry::byte_offset),
+        Some(obj5_offset)
+    );
+}
+
+#[test]
 fn build_xref_table_normalizes_malformed_incremental_subsection_numbering() {
     let (data, expected_offsets) = build_malformed_incremental_xref_subsection_pdf();
     let mut parser = PdfParser::from(data.as_slice());


### PR DESCRIPTION
Recover flat xref rows that still include the xref keyword so page resources referenced by malformed PDFs remain reachable. Keep image streams available when eager filter decoding fails, then retry declared filters when image resources are parsed.

Add a JBIG2 symbol-ID compatibility fallback for streams that encode nonzero symbol code lengths one greater than their effective prefix length, preserving the existing canonical path for normal streams.