### PR TITLE
pdf-image: normalize inline indexed color spaces

### DIFF
--- a/crates/pdf-image/src/image_xobject.rs
+++ b/crates/pdf-image/src/image_xobject.rs
@@ -935,6 +935,38 @@ mod tests {
     }
 
     #[test]
+    fn decode_inline_image_accepts_abbreviated_indexed_color_space() {
+        let image = InlineImage::new(
+            Dictionary::new(BTreeMap::from([
+                ("BPC".to_string(), ObjectVariant::Integer(1)),
+                (
+                    "CS".to_string(),
+                    ObjectVariant::Array(vec![
+                        ObjectVariant::Name(b"I".to_vec()),
+                        ObjectVariant::Name(b"RGB".to_vec()),
+                        ObjectVariant::Integer(1),
+                        ObjectVariant::HexString(vec![10, 11, 12, 20, 21, 22]),
+                    ]),
+                ),
+                ("H".to_string(), ObjectVariant::Integer(1)),
+                ("W".to_string(), ObjectVariant::Integer(4)),
+            ])),
+            vec![0b1010_0000],
+        );
+
+        let decoded = ImageXObject::decode_inline_image(&image, &PassthroughResolver, None)
+            .expect("inline image with abbreviated indexed color space should decode");
+
+        assert_eq!(decoded.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
+        assert_eq!(
+            decoded.data,
+            vec![
+                20, 21, 22, 255, 10, 11, 12, 255, 20, 21, 22, 255, 10, 11, 12, 255
+            ]
+        );
+    }
+
+    #[test]
     fn decode_normalized_1bpc_image_expands_samples() {
         let dictionary = Dictionary::new(BTreeMap::from([
             ("BitsPerComponent".to_string(), ObjectVariant::Integer(1)),

--- a/crates/pdf-image/src/inline_image.rs
+++ b/crates/pdf-image/src/inline_image.rs
@@ -79,15 +79,20 @@ fn normalize_inline_image_value(key: &str, value: &ObjectVariant) -> ObjectVaria
         return value.clone();
     }
 
-    let ObjectVariant::Name(name) = value else {
-        return value.clone();
-    };
-
-    match name.as_slice() {
-        b"G" => ObjectVariant::Name(b"DeviceGray".to_vec()),
-        b"RGB" => ObjectVariant::Name(b"DeviceRGB".to_vec()),
-        b"CMYK" => ObjectVariant::Name(b"DeviceCMYK".to_vec()),
-        b"I" => ObjectVariant::Name(b"Indexed".to_vec()),
+    match value {
+        ObjectVariant::Name(name) => match name.as_slice() {
+            b"G" => ObjectVariant::Name(b"DeviceGray".to_vec()),
+            b"RGB" => ObjectVariant::Name(b"DeviceRGB".to_vec()),
+            b"CMYK" => ObjectVariant::Name(b"DeviceCMYK".to_vec()),
+            b"I" => ObjectVariant::Name(b"Indexed".to_vec()),
+            _ => value.clone(),
+        },
+        ObjectVariant::Array(values) => ObjectVariant::Array(
+            values
+                .iter()
+                .map(|item| normalize_inline_image_value("ColorSpace", item))
+                .collect(),
+        ),
         _ => value.clone(),
     }
 }
@@ -160,6 +165,31 @@ mod tests {
                 Some(&ObjectVariant::Name(canonical.as_bytes().to_vec()))
             );
         }
+    }
+
+    #[test]
+    fn normalize_inline_image_dictionary_expands_indexed_color_space_arrays() {
+        let dictionary = pdf_object::dictionary::Dictionary::new(BTreeMap::from([(
+            "CS".to_string(),
+            ObjectVariant::Array(vec![
+                ObjectVariant::Name(b"I".to_vec()),
+                ObjectVariant::Name(b"RGB".to_vec()),
+                ObjectVariant::Integer(1),
+                ObjectVariant::HexString(vec![10, 11, 12, 20, 21, 22]),
+            ]),
+        )]));
+
+        let normalized = normalize_inline_image_dictionary(&dictionary);
+
+        assert_eq!(
+            normalized.dictionary.get("ColorSpace"),
+            Some(&ObjectVariant::Array(vec![
+                ObjectVariant::Name(b"Indexed".to_vec()),
+                ObjectVariant::Name(b"DeviceRGB".to_vec()),
+                ObjectVariant::Integer(1),
+                ObjectVariant::HexString(vec![10, 11, 12, 20, 21, 22]),
+            ]))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Recurse through inline-image ColorSpace arrays so abbreviated indexed forms are normalized before the shared color-space parser runs.

Add regression coverage for CS [/I /RGB ...] normalization and inline indexed image decode expansion.