### PR TITLE
pdf-canvas: tolerate malformed generic device colors

### DIFF
--- a/crates/pdf-canvas/src/canvas_color_ops.rs
+++ b/crates/pdf-canvas/src/canvas_color_ops.rs
@@ -1,4 +1,5 @@
 use pdf_color_space::color_space::ColorSpace;
+use pdf_color_space::error::ColorSpaceError;
 use pdf_content_stream_operators::pdf_operator_backend::ColorOps;
 
 use crate::{
@@ -6,6 +7,30 @@ use crate::{
     pdf_canvas::PdfCanvas,
 };
 use pdf_graphics::color::Color;
+
+fn color_from_generic_components(components: &[f32]) -> Option<Color> {
+    match *components {
+        [gray] => Some(Color::from_gray(gray)),
+        [r, g, b] => Some(Color::from_rgb(r, g, b)),
+        [c, m, y, k] => Some(Color::from_cmyk(c, m, y, k)),
+        _ => None,
+    }
+}
+
+fn apply_content_stream_color(
+    color_space: &ColorSpace,
+    components: &[f32],
+) -> Result<Color, ColorSpaceError> {
+    match color_space.apply(components) {
+        Ok(color) => Ok(color),
+        Err(err @ ColorSpaceError::InsufficientComponents(_, _))
+            if color_space.is_device_space() =>
+        {
+            color_from_generic_components(components).ok_or(err)
+        }
+        Err(err) => Err(err),
+    }
+}
 
 impl<B: CanvasBackend> ColorOps for PdfCanvas<'_, B> {
     type ErrorType = PdfCanvasError;
@@ -25,7 +50,7 @@ impl<B: CanvasBackend> ColorOps for PdfCanvas<'_, B> {
             return Err(PdfCanvasError::ColorSpaceNotSet);
         };
 
-        state.stroke_color = color_space.apply(components)?;
+        state.stroke_color = apply_content_stream_color(color_space, components)?;
         Ok(())
     }
 
@@ -37,7 +62,7 @@ impl<B: CanvasBackend> ColorOps for PdfCanvas<'_, B> {
             return Err(PdfCanvasError::ColorSpaceNotSet);
         };
 
-        state.fill_color = color_space.apply(components)?;
+        state.fill_color = apply_content_stream_color(color_space, components)?;
         Ok(())
     }
 
@@ -55,8 +80,10 @@ impl<B: CanvasBackend> ColorOps for PdfCanvas<'_, B> {
             // For uncolored tiling patterns the components belong to the underlying
             // color space wrapped inside Pattern, not to the Pattern space itself.
             let color = match cs {
-                ColorSpace::Pattern(Some(inner_cs)) => inner_cs.apply(components)?,
-                _ => cs.apply(components)?,
+                ColorSpace::Pattern(Some(inner_cs)) => {
+                    apply_content_stream_color(inner_cs, components)?
+                }
+                _ => apply_content_stream_color(cs, components)?,
             };
             state.fill_color = color;
         }
@@ -78,8 +105,10 @@ impl<B: CanvasBackend> ColorOps for PdfCanvas<'_, B> {
             // For uncolored tiling patterns the components belong to the underlying
             // color space wrapped inside Pattern, not to the Pattern space itself.
             let color = match cs {
-                ColorSpace::Pattern(Some(inner_cs)) => inner_cs.apply(components)?,
-                _ => cs.apply(components)?,
+                ColorSpace::Pattern(Some(inner_cs)) => {
+                    apply_content_stream_color(inner_cs, components)?
+                }
+                _ => apply_content_stream_color(cs, components)?,
             };
             state.stroke_color = color;
         }
@@ -139,5 +168,181 @@ impl<B: CanvasBackend> ColorOps for PdfCanvas<'_, B> {
         state.fill_pattern = None;
         state.fill_color_space = Some(&CanvasState::DEVICE_CMYK_COLOR_SPACE);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pdf_color_space::error::ColorSpaceError;
+    use pdf_content_stream_operators::pdf_operator_backend::ColorOps;
+    use pdf_graphics::{
+        BlendMode, MaskMode, PathFillType, color::Color, pdf_path::PdfPath, rect::Rect,
+        transform::Transform,
+    };
+    use pdf_page::page::PdfPage;
+    use std::sync::Arc;
+
+    use crate::{
+        canvas_backend::{CanvasBackend, Image, Shader},
+        recording_canvas::RecordingCanvas,
+    };
+
+    use super::PdfCanvas;
+
+    #[derive(Default)]
+    struct TestCanvas;
+
+    impl CanvasBackend for TestCanvas {
+        fn fill_path(
+            &mut self,
+            _path: &PdfPath,
+            _fill_type: PathFillType,
+            _color: Color,
+            _shader: &Option<Shader>,
+            _blend_mode: Option<BlendMode>,
+        ) -> Result<(), crate::error::PdfCanvasError> {
+            Ok(())
+        }
+
+        fn stroke_path(
+            &mut self,
+            _path: &PdfPath,
+            _color: Color,
+            _line_width: f32,
+            _stroke_style: &crate::stroke_style::StrokeStyle,
+            _shader: &Option<Shader>,
+            _blend_mode: Option<BlendMode>,
+        ) -> Result<(), crate::error::PdfCanvasError> {
+            Ok(())
+        }
+
+        fn set_clip_region(
+            &mut self,
+            _path: &PdfPath,
+            _mode: PathFillType,
+        ) -> Result<(), crate::error::PdfCanvasError> {
+            Ok(())
+        }
+
+        fn width(&self) -> f32 {
+            100.0
+        }
+
+        fn height(&self) -> f32 {
+            100.0
+        }
+
+        fn save(&mut self) -> Result<(), crate::error::PdfCanvasError> {
+            Ok(())
+        }
+
+        fn restore(&mut self) -> Result<(), crate::error::PdfCanvasError> {
+            Ok(())
+        }
+
+        fn draw_image_rect(
+            &mut self,
+            _image: &Image<'_>,
+            _blend_mode: Option<BlendMode>,
+            _dest_rect: Rect,
+            _image_rotation: Option<f32>,
+        ) -> Result<(), crate::error::PdfCanvasError> {
+            Ok(())
+        }
+
+        fn draw_inline_image(
+            &mut self,
+            _image: &Image<'_>,
+            _blend_mode: Option<BlendMode>,
+            _dest_rect: Rect,
+            _image_rotation: Option<f32>,
+        ) -> Result<(), crate::error::PdfCanvasError> {
+            Ok(())
+        }
+
+        fn begin_mask_layer(
+            &mut self,
+            _mask: &Arc<RecordingCanvas>,
+            _transform: &Transform,
+            _mask_mode: MaskMode,
+        ) -> Result<(), crate::error::PdfCanvasError> {
+            Ok(())
+        }
+
+        fn end_mask_layer(
+            &mut self,
+            _mask: &Arc<RecordingCanvas>,
+            _transform: &Transform,
+            _mask_mode: MaskMode,
+        ) -> Result<(), crate::error::PdfCanvasError> {
+            Ok(())
+        }
+    }
+
+    fn page() -> PdfPage {
+        PdfPage {
+            contents: None,
+            media_box: None,
+            resources: None,
+        }
+    }
+
+    #[test]
+    fn default_device_gray_scn_with_three_components_falls_back_to_rgb() {
+        let page = page();
+        let mut backend = TestCanvas;
+        let mut canvas = PdfCanvas::new(&mut backend, &page, None).expect("canvas should build");
+
+        canvas
+            .set_non_stroking_color(&[0.294_118, 0.019_608, 0.196_078])
+            .expect("rgb fallback should apply");
+
+        assert_eq!(
+            canvas
+                .current_state()
+                .expect("state should exist")
+                .fill_color,
+            Color::from_rgb(0.294_118, 0.019_608, 0.196_078)
+        );
+    }
+
+    #[test]
+    fn device_rgb_scn_with_three_components_still_uses_active_space() {
+        let page = page();
+        let mut backend = TestCanvas;
+        let mut canvas = PdfCanvas::new(&mut backend, &page, None).expect("canvas should build");
+
+        canvas
+            .set_non_stroking_color_space("DeviceRGB")
+            .expect("device rgb should resolve");
+        canvas
+            .set_non_stroking_color(&[0.0, 0.0, 0.0])
+            .expect("rgb color should apply");
+
+        assert_eq!(
+            canvas
+                .current_state()
+                .expect("state should exist")
+                .fill_color,
+            Color::from_rgb(0.0, 0.0, 0.0)
+        );
+    }
+
+    #[test]
+    fn invalid_generic_operand_count_still_returns_component_error() {
+        let page = page();
+        let mut backend = TestCanvas;
+        let mut canvas = PdfCanvas::new(&mut backend, &page, None).expect("canvas should build");
+
+        let err = canvas
+            .set_non_stroking_color(&[0.2, 0.4])
+            .expect_err("two generic components should still fail");
+
+        assert!(matches!(
+            err,
+            crate::error::PdfCanvasError::ColorSpaceError(ColorSpaceError::InsufficientComponents(
+                1, 2
+            ))
+        ));
     }
 }


### PR DESCRIPTION
Fall back to gray, RGB, or CMYK when SC/sc/SCN/scn operands do not match the active device color space but the generic operand count clearly identifies a device color.

Keep ColorSpace::apply strict for non-content-stream callers and add regression tests for the DeviceGray-to-RGB fallback, normal DeviceRGB handling, and invalid generic operand counts.