### PR TITLE
pdf-page: recover dictionary-only form xobjects

### DIFF
--- a/crates/pdf-object/src/object_variant.rs
+++ b/crates/pdf-object/src/object_variant.rs
@@ -417,4 +417,21 @@ mod tests {
 
         assert_eq!(err, ObjectError::TypeMismatch("Number", "Array"));
     }
+
+    #[test]
+    fn try_stream_returns_type_mismatch_for_non_stream() {
+        let null_object = ObjectVariant::Null;
+        let null_err = null_object
+            .try_stream(&PassthroughResolver)
+            .expect_err("null object should not decode as a stream");
+        assert_eq!(null_err, ObjectError::TypeMismatch("Stream", "Null"));
+
+        let dict_object = ObjectVariant::Dictionary(Box::new(crate::dictionary::Dictionary::new(
+            std::collections::BTreeMap::new(),
+        )));
+        let dict_err = dict_object
+            .try_stream(&PassthroughResolver)
+            .expect_err("dictionary object should not decode as a stream");
+        assert_eq!(dict_err, ObjectError::TypeMismatch("Stream", "Dictionary"));
+    }
 }

--- a/crates/pdf-page/src/form.rs
+++ b/crates/pdf-page/src/form.rs
@@ -24,14 +24,17 @@ pub struct FormXObject {
 }
 
 impl FormXObject {
-    /// Parses a Form XObject from its dictionary and stream data.
-    pub fn read_xobject(
-        content: &ObjectVariant,
+    /// Builds a form XObject from parsed dictionary fields and a prepared content stream.
+    ///
+    /// This helper centralizes the shared `/BBox`, `/Matrix`, and `/Resources`
+    /// parsing used by both stream-backed forms and dictionary-only fallback forms.
+    fn from_dictionary_parts(
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
         cache: &mut dyn ResourceCache,
         cycle_tracker: &mut ReadCycleTracker,
         id_allocator: &mut ContentStreamIdAllocator,
+        content_stream: ContentStream,
     ) -> Result<Self, PdfPagesError> {
         // Retrieve the `/BBox` entry.
         let bbox = Rect::from(
@@ -47,15 +50,54 @@ impl FormXObject {
         // Parse the `/Resources` entry if present, mapping any errors.
         let resources = Resources::read(dictionary, objects, cache, cycle_tracker, id_allocator)?;
 
-        // Parse the content stream data.
-        let content_stream = ContentStream::new(content, objects, id_allocator)?;
-
         Ok(FormXObject {
             bbox,
             matrix,
             resources,
             content_stream,
         })
+    }
+
+    /// Parses a Form XObject from its dictionary and stream data.
+    pub fn read_xobject(
+        content: &ObjectVariant,
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+        cache: &mut dyn ResourceCache,
+        cycle_tracker: &mut ReadCycleTracker,
+        id_allocator: &mut ContentStreamIdAllocator,
+    ) -> Result<Self, PdfPagesError> {
+        let content_stream = ContentStream::new(content, objects, id_allocator)?;
+        Self::from_dictionary_parts(
+            dictionary,
+            objects,
+            cache,
+            cycle_tracker,
+            id_allocator,
+            content_stream,
+        )
+    }
+
+    /// Parses a dictionary-only Form XObject and treats it as an empty form.
+    pub fn empty_from_dictionary(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+        cache: &mut dyn ResourceCache,
+        cycle_tracker: &mut ReadCycleTracker,
+        id_allocator: &mut ContentStreamIdAllocator,
+    ) -> Result<Self, PdfPagesError> {
+        let content_stream = ContentStream {
+            operators: Vec::new(),
+            id: id_allocator.next_id()?,
+        };
+        Self::from_dictionary_parts(
+            dictionary,
+            objects,
+            cache,
+            cycle_tracker,
+            id_allocator,
+            content_stream,
+        )
     }
 }
 
@@ -65,6 +107,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use pdf_content_stream::ContentStreamIdAllocator;
+    use pdf_graphics::transform::Transform;
     use pdf_object::{
         dictionary::Dictionary, object_resolver::PassthroughResolver,
         object_variant::ObjectVariant, stream::StreamObject,
@@ -107,5 +150,55 @@ mod tests {
         assert_eq!(form.bbox.top, 43.3206);
         assert_eq!(form.bbox.right, 301.321);
         assert_eq!(form.bbox.bottom, 71.8304);
+    }
+
+    #[test]
+    fn empty_from_dictionary_creates_empty_content_stream() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            (
+                "BBox".to_string(),
+                ObjectVariant::Array(vec![
+                    ObjectVariant::Real(0.0),
+                    ObjectVariant::Real(0.0),
+                    ObjectVariant::Real(10.0),
+                    ObjectVariant::Real(10.0),
+                ]),
+            ),
+            ("Subtype".to_string(), ObjectVariant::Name(b"Form".to_vec())),
+            (
+                "Matrix".to_string(),
+                ObjectVariant::Array(vec![
+                    ObjectVariant::Real(2.0),
+                    ObjectVariant::Real(0.0),
+                    ObjectVariant::Real(0.0),
+                    ObjectVariant::Real(3.0),
+                    ObjectVariant::Real(4.0),
+                    ObjectVariant::Real(5.0),
+                ]),
+            ),
+        ]));
+        let mut cache = DefaultResourceCache::default();
+        let mut cycle_tracker = ReadCycleTracker::default();
+        let mut id_allocator = ContentStreamIdAllocator::new();
+
+        let form = FormXObject::empty_from_dictionary(
+            &dictionary,
+            &PassthroughResolver,
+            &mut cache,
+            &mut cycle_tracker,
+            &mut id_allocator,
+        )
+        .expect("dictionary-only form should parse");
+
+        assert_eq!(form.bbox.left, 0.0);
+        assert_eq!(form.bbox.top, 0.0);
+        assert_eq!(form.bbox.right, 10.0);
+        assert_eq!(form.bbox.bottom, 10.0);
+        assert_eq!(
+            form.matrix,
+            Some(Transform::from_row(2.0, 0.0, 0.0, 3.0, 4.0, 5.0))
+        );
+        assert_eq!(form.content_stream.id, 0);
+        assert!(form.content_stream.operators.is_empty());
     }
 }

--- a/crates/pdf-page/src/object_reader.rs
+++ b/crates/pdf-page/src/object_reader.rs
@@ -23,12 +23,12 @@ impl ReadCycleTracker {
     /// Marks the object as currently being parsed.
     ///
     /// Returns `false` when the object is already in progress, indicating a cycle.
-    fn begin_read(&mut self, obj_num: usize) -> bool {
+    pub(crate) fn begin_read(&mut self, obj_num: usize) -> bool {
         self.in_progress.insert(obj_num)
     }
 
     /// Clears the in-progress marker for the object.
-    fn end_read(&mut self, obj_num: usize) {
+    pub(crate) fn end_read(&mut self, obj_num: usize) {
         self.in_progress.remove(&obj_num);
     }
 }

--- a/crates/pdf-page/src/resources.rs
+++ b/crates/pdf-page/src/resources.rs
@@ -9,7 +9,9 @@ use std::rc::Rc;
 
 use pdf_content_stream::ContentStreamIdAllocator;
 use pdf_font::font::Font;
-use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
+use pdf_object::{
+    dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
+};
 
 use crate::{
     error::PdfPagesError,
@@ -18,12 +20,11 @@ use crate::{
     pattern::Pattern,
     resource::Resource,
     resource_cache::{ResourceCache, read_resource_lazy},
+    resources_reference::ResourcesReference,
     shading::Shading,
     xobject::XObject,
 };
 use pdf_color_space::color_space::ColorSpace;
-
-pub use crate::resources_reference::ResourcesReference;
 
 /// Contains all resources referenced by a PDF content stream, organized per PDF sub-dictionary.
 ///
@@ -194,6 +195,99 @@ fn read_patterns(
 }
 
 /// Parses all XObject resources from the `/XObject` sub-dictionary.
+fn read_xobject_resource(
+    value: &ObjectVariant,
+    objects: &dyn ObjectResolver,
+    cache: &mut dyn ResourceCache,
+    cycle_tracker: &mut ReadCycleTracker,
+    id_allocator: &mut ContentStreamIdAllocator,
+) -> Result<Option<Resource>, PdfPagesError> {
+    let resolved = objects.resolve_object(value)?;
+
+    match resolved {
+        ObjectVariant::Stream(stream) => {
+            if let Some(cached) = cache.get(&stream.object_number) {
+                return Ok(Some(cached.clone()));
+            }
+
+            let resource = match XObject::read_xobject(
+                value,
+                &stream.dictionary,
+                stream,
+                objects,
+                cache,
+                cycle_tracker,
+                id_allocator,
+            ) {
+                Ok(Some(xobject)) => Resource::XObject(Rc::new(xobject)),
+                Ok(None) => return Ok(None),
+                Err(err) => return Err(err),
+            };
+
+            cache.insert(stream.object_number, resource.clone());
+            Ok(Some(resource))
+        }
+        ObjectVariant::Dictionary(dictionary) => {
+            let subtype = dictionary.get_or_err("Subtype")?.try_str(objects)?;
+            if subtype.as_ref() != "Form" {
+                return Err(crate::error::PdfPagesError::UnsupportedXObjectSubtype {
+                    subtype: subtype.into_owned(),
+                });
+            }
+
+            let object_number = dictionary.object_number;
+            if let Some(object_number) = object_number
+                && let Some(cached) = cache.get(&object_number)
+            {
+                return Ok(Some(cached.clone()));
+            }
+
+            let form = if let Some(object_number) = object_number {
+                if !cycle_tracker.begin_read(object_number) {
+                    return Ok(None);
+                }
+
+                let form = crate::form::FormXObject::empty_from_dictionary(
+                    dictionary,
+                    objects,
+                    cache,
+                    cycle_tracker,
+                    id_allocator,
+                );
+                cycle_tracker.end_read(object_number);
+                form?
+            } else {
+                crate::form::FormXObject::empty_from_dictionary(
+                    dictionary,
+                    objects,
+                    cache,
+                    cycle_tracker,
+                    id_allocator,
+                )?
+            };
+
+            let resource = Resource::XObject(Rc::new(XObject::Form(Box::new(form))));
+
+            if let Some(object_number) = object_number {
+                cache.insert(object_number, resource.clone());
+            }
+
+            Ok(Some(resource))
+        }
+        _ => Err(pdf_object::error::ObjectError::TypeMismatch(
+            "Stream or Form Dictionary",
+            resolved.name(),
+        )
+        .into()),
+    }
+}
+
+/// Parses all XObject resources from the `/XObject` sub-dictionary.
+///
+/// Stream-backed XObjects are parsed through the normal XObject reader. If a
+/// resource resolves to a dictionary with `/Subtype /Form`, it is recovered as
+/// an empty Form XObject so the resource remains paintable even without stream
+/// bytes. Any other non-stream entry is rejected with a typed error.
 fn read_xobjects(
     resources: &Dictionary,
     objects: &dyn ObjectResolver,
@@ -207,27 +301,11 @@ fn read_xobjects(
 
     let mut result = HashMap::new();
     for (name, value) in &xobject_dict.dictionary {
-        let stream = value.try_stream(objects)?;
-        if let Some(cached) = cache.get(&stream.object_number) {
-            result.insert(name.clone(), cached.clone());
+        let Some(resource) =
+            read_xobject_resource(value, objects, cache, cycle_tracker, id_allocator)?
+        else {
             continue;
-        }
-
-        let resource = match XObject::read_xobject(
-            value,
-            &stream.dictionary,
-            stream,
-            objects,
-            cache,
-            cycle_tracker,
-            id_allocator,
-        ) {
-            Ok(Some(xobject)) => Resource::XObject(Rc::new(xobject)),
-            Ok(None) => continue,
-            Err(err) => return Err(err),
         };
-
-        cache.insert(stream.object_number, resource.clone());
         result.insert(name.clone(), resource);
     }
     Ok(result)
@@ -491,6 +569,7 @@ mod tests {
 
     use pdf_content_stream::ContentStreamIdAllocator;
     use pdf_font::font::Font;
+    use pdf_graphics::transform::Transform;
     use pdf_object::{
         dictionary::Dictionary, indirect_object::IndirectObject,
         object_resolver::PassthroughResolver, object_variant::ObjectVariant, stream::StreamObject,
@@ -740,6 +819,86 @@ mod tests {
             .expect("Later should be a form XObject");
 
         assert_eq!(later_id, 2);
+    }
+
+    #[test]
+    fn dictionary_only_form_xobjects_are_loaded_as_empty_forms() {
+        let page_dict = Dictionary::new(BTreeMap::from([(
+            "Resources".to_string(),
+            ObjectVariant::Reference(100),
+        )]));
+
+        let resources_dict = Dictionary::new(BTreeMap::from([(
+            "XObject".to_string(),
+            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+                "Meta6".to_string(),
+                ObjectVariant::Reference(101),
+            )])))),
+        )]));
+
+        let form_dict = Dictionary::new(BTreeMap::from([
+            ("Subtype".to_string(), ObjectVariant::Name(b"Form".to_vec())),
+            (
+                "BBox".to_string(),
+                ObjectVariant::Array(vec![integer(10), integer(20), integer(30), integer(40)]),
+            ),
+            (
+                "Matrix".to_string(),
+                ObjectVariant::Array(vec![
+                    real(2.0),
+                    real(0.0),
+                    real(0.0),
+                    real(3.0),
+                    real(4.0),
+                    real(5.0),
+                ]),
+            ),
+        ]));
+
+        let mut objects = ObjectCollection::default();
+        objects
+            .insert(ObjectVariant::IndirectObject(Box::new(
+                IndirectObject::new(
+                    100,
+                    0,
+                    Some(ObjectVariant::Dictionary(Box::new(resources_dict))),
+                ),
+            )))
+            .expect("resources dictionary should insert");
+        objects
+            .insert(ObjectVariant::IndirectObject(Box::new(
+                IndirectObject::new(101, 0, Some(ObjectVariant::Dictionary(Box::new(form_dict)))),
+            )))
+            .expect("dictionary-only form should insert");
+
+        let mut cache = DefaultResourceCache::default();
+        let mut cycle_tracker = ReadCycleTracker::default();
+        let mut ids = ContentStreamIdAllocator::new();
+
+        let resources = Resources::read(
+            &page_dict,
+            &objects,
+            &mut cache,
+            &mut cycle_tracker,
+            &mut ids,
+        )
+        .expect("resources should parse")
+        .expect("page resources should exist");
+
+        let Some(XObject::Form(form)) = resources.xobject("Meta6") else {
+            panic!("expected dictionary-only form xobject");
+        };
+
+        assert_eq!(form.bbox.left, 10.0);
+        assert_eq!(form.bbox.top, 20.0);
+        assert_eq!(form.bbox.right, 30.0);
+        assert_eq!(form.bbox.bottom, 40.0);
+        assert_eq!(
+            form.matrix,
+            Some(Transform::from_row(2.0, 0.0, 0.0, 3.0, 4.0, 5.0))
+        );
+        assert_eq!(form.content_stream.id, 0);
+        assert!(form.content_stream.operators.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Treat malformed /Subtype /Form entries in /XObject resources as empty forms so they remain resolvable at paint time. Also return a typed TypeMismatch from ObjectVariant::try_stream instead of panicking.

Add regression tests for the typed error path and the dictionary-only form resource flow.