### PR TITLE
pdf-filter: decode borrowed stream data directly

### DIFF
--- a/crates/pdf-color-space/src/icc_based_color_space.rs
+++ b/crates/pdf-color-space/src/icc_based_color_space.rs
@@ -60,7 +60,7 @@ pub(crate) fn parse_icc_based_color_space(
         .transpose()?
         .map(Box::new);
 
-    let profile_data: Arc<[u8]> = stream.data()?.into_owned().into();
+    let profile_data: Arc<[u8]> = stream.raw_data().to_vec().into();
 
     Ok(ColorSpace::ICCBased(ICCBasedColorSpace {
         num_components,

--- a/crates/pdf-document/src/decryption.rs
+++ b/crates/pdf-document/src/decryption.rs
@@ -212,10 +212,10 @@ impl DocumentDecryptor {
     /// unchanged when the encryption dictionary sets `/EncryptMetadata false`.
     pub(crate) fn decrypt_stream_object(
         &self,
-        stream: &StreamObject,
+        stream: StreamObject,
     ) -> Result<StreamObject, DecryptionError> {
         if should_skip_stream_decryption(&stream.dictionary, self.encrypt_metadata) {
-            return Ok(stream.clone());
+            return Ok(stream);
         }
 
         let decrypted_data = self.decrypt_stream(
@@ -227,7 +227,7 @@ impl DocumentDecryptor {
         Ok(StreamObject::new(
             stream.object_number,
             stream.generation_number,
-            stream.dictionary.clone(),
+            stream.dictionary,
             decrypted_data,
         ))
     }
@@ -342,7 +342,7 @@ impl DocumentDecryptor {
     fn decrypt_stream_value(&self, stream: StreamObject) -> Result<ObjectVariant, DecryptionError> {
         let object_number = stream.object_number;
         let generation_number = stream.generation_number;
-        let stream = self.decrypt_stream_object(&stream)?;
+        let stream = self.decrypt_stream_object(stream)?;
         let dictionary =
             self.decrypt_dictionary(*stream.dictionary, object_number, generation_number)?;
         Ok(ObjectVariant::Stream(StreamObject::new(
@@ -851,10 +851,12 @@ mod tests {
         let decryptor = make_decryptor(true);
         let data = vec![0x42; 422];
         let stream = make_stream(Some(b"XRef"), data.clone());
+        let data_ptr = stream.raw_data().as_ptr();
 
-        let decrypted = decryptor.decrypt_stream_object(&stream).unwrap();
+        let decrypted = decryptor.decrypt_stream_object(stream).unwrap();
 
         assert_eq!(decrypted.raw_data(), data.as_slice());
+        assert_eq!(decrypted.raw_data().as_ptr(), data_ptr);
     }
 
     #[test]
@@ -862,7 +864,7 @@ mod tests {
         let decryptor = make_decryptor(true);
         let stream = make_stream(None, vec![0x42; 422]);
 
-        let error = decryptor.decrypt_stream_object(&stream).unwrap_err();
+        let error = decryptor.decrypt_stream_object(stream).unwrap_err();
 
         assert!(
             matches!(error, DecryptionError::InvalidData(message) if message == "AES ciphertext length must be a multiple of 16")
@@ -872,15 +874,16 @@ mod tests {
     #[test]
     fn test_metadata_stream_decryption_is_skipped_only_when_encrypt_metadata_is_false() {
         let data = vec![0x42; 422];
-        let stream = make_stream(Some(b"Metadata"), data.clone());
+        let skipped_stream = make_stream(Some(b"Metadata"), data.clone());
 
         let skipped = make_decryptor(false)
-            .decrypt_stream_object(&stream)
+            .decrypt_stream_object(skipped_stream)
             .unwrap();
         assert_eq!(skipped.raw_data(), data.as_slice());
 
+        let encrypted_stream = make_stream(Some(b"Metadata"), data);
         let error = make_decryptor(true)
-            .decrypt_stream_object(&stream)
+            .decrypt_stream_object(encrypted_stream)
             .unwrap_err();
         assert!(
             matches!(error, DecryptionError::InvalidData(message) if message == "AES ciphertext length must be a multiple of 16")

--- a/crates/pdf-document/src/object_stream.rs
+++ b/crates/pdf-document/src/object_stream.rs
@@ -38,10 +38,10 @@ pub(crate) fn read_object_stream(
     let first = dict.required_number::<usize>("First", objects)?;
 
     // Decode stream data (applies filters)
-    let data = stream.data()?;
+    let data = stream.raw_data();
 
     // Parse the header: N pairs of (object_number, relative_byte_offset)
-    let mut header_parser = PdfParser::from(data.as_ref());
+    let mut header_parser = PdfParser::from(data);
     let mut object_entries = Vec::with_capacity(n);
 
     for _ in 0..n {

--- a/crates/pdf-filter/src/filter.rs
+++ b/crates/pdf-filter/src/filter.rs
@@ -260,29 +260,31 @@ impl Filter {
     }
 }
 
-/// Decodes a [`StreamObject`] by applying its full filter chain.
+/// Decodes borrowed stream data by applying the filter chain from its dictionary.
 ///
-/// Reads the `/Filter` entry from the stream's dictionary and applies each
-/// filter in order. Returns the fully decoded bytes, or `Cow::Borrowed` if
-/// no filters are present.
+/// Reads the `/Filter` entry from `dictionary` and applies each filter in order.
+/// Returns the fully decoded bytes, or `Cow::Borrowed` if no filters are present.
 ///
-/// This is the main entry point for stream decoding in the `pdf-filter` crate.
+/// This entry point accepts a dictionary and data slice separately so callers
+/// such as inline-image decoders do not need to construct a temporary
+/// [`StreamObject`].
 ///
 /// # Errors
 ///
 /// Returns [`FilterError`] if any filter in the chain fails or is unsupported.
-pub fn decode_with_resolver<'a>(
-    stream: &'a StreamObject,
+pub fn decode_data_with_resolver<'a>(
+    dictionary: &Dictionary,
+    stream_data: &'a [u8],
     objects: &dyn ObjectResolver,
 ) -> Result<Cow<'a, [u8]>, FilterError> {
-    let mut data: Cow<'a, [u8]> = Cow::Borrowed(&stream.data);
-    let filters = Filter::from_dictionary(&stream.dictionary, objects)?;
+    let mut data: Cow<'a, [u8]> = Cow::Borrowed(stream_data);
+    let filters = Filter::from_dictionary(dictionary, objects)?;
 
     let Some(filters) = &filters else {
         return Ok(data);
     };
 
-    let decode_params = parse_decode_params(&stream.dictionary, filters, objects)?;
+    let decode_params = parse_decode_params(dictionary, filters, objects)?;
 
     for (filter, params) in filters.iter().zip(decode_params.iter()) {
         match filter {
@@ -332,7 +334,7 @@ pub fn decode_with_resolver<'a>(
                 data = Cow::Owned(decoded);
             }
             Filter::JBIG2Decode => {
-                let (width, height) = resolve_jbig2_dimensions(&stream.dictionary, objects)?;
+                let (width, height) = resolve_jbig2_dimensions(dictionary, objects)?;
                 let globals = match params {
                     DecodeParms::Jbig2 { globals } => globals.as_deref(),
                     _ => None,
@@ -354,6 +356,21 @@ pub fn decode_with_resolver<'a>(
         }
     }
     Ok(data)
+}
+
+/// Decodes a [`StreamObject`] by applying its full filter chain.
+///
+/// This compatibility entry point forwards the stream's dictionary and raw
+/// data to [`decode_data_with_resolver`].
+///
+/// # Errors
+///
+/// Returns [`FilterError`] if any filter in the chain fails or is unsupported.
+pub fn decode_with_resolver<'a>(
+    stream: &'a StreamObject,
+    objects: &dyn ObjectResolver,
+) -> Result<Cow<'a, [u8]>, FilterError> {
+    decode_data_with_resolver(&stream.dictionary, stream.raw_data(), objects)
 }
 
 /// Decodes a [`StreamObject`] by applying its full filter chain.
@@ -530,6 +547,34 @@ mod tests {
         let filter = Filter::from("JBIG2Decode");
         assert_eq!(filter, Filter::JBIG2Decode);
         assert_eq!(filter.to_string(), "JBIG2Decode");
+    }
+
+    #[test]
+    fn decode_data_without_filters_borrows_input() {
+        let dictionary = Dictionary::new(BTreeMap::new());
+        let data = b"borrowed stream data";
+
+        let decoded = decode_data_with_resolver(&dictionary, data, &PassthroughResolver)
+            .expect("unfiltered data should decode");
+
+        assert!(matches!(&decoded, Cow::Borrowed(_)));
+        assert_eq!(decoded.as_ref().as_ptr(), data.as_ptr());
+        assert_eq!(decoded.as_ref(), data);
+    }
+
+    #[test]
+    fn decode_data_with_filter_returns_decoded_owned_data() {
+        let dictionary = Dictionary::new(BTreeMap::from([(
+            "Filter".to_string(),
+            ObjectVariant::Name(b"ASCIIHexDecode".to_vec()),
+        )]));
+
+        let decoded =
+            decode_data_with_resolver(&dictionary, b"48 65 6c 6c 6f>", &PassthroughResolver)
+                .expect("filtered data should decode");
+
+        assert!(matches!(&decoded, Cow::Owned(_)));
+        assert_eq!(decoded.as_ref(), b"Hello");
     }
 
     #[test]

--- a/crates/pdf-filter/src/lib.rs
+++ b/crates/pdf-filter/src/lib.rs
@@ -14,7 +14,9 @@
 //!
 //! The main entry point is [`filter::decode`], which accepts a
 //! [`StreamObject`](pdf_object::stream::StreamObject) and applies the full
-//! filter chain declared in its `/Filter` dictionary entry.
+//! filter chain declared in its `/Filter` dictionary entry. Callers that hold
+//! a dictionary and borrowed data separately can use
+//! [`filter::decode_data_with_resolver`] without constructing a stream object.
 
 pub(crate) mod ascii85;
 pub(crate) mod asciihex;

--- a/crates/pdf-font/src/fallback.rs
+++ b/crates/pdf-font/src/fallback.rs
@@ -199,8 +199,7 @@ fn to_unicode_cmap(
     dictionary
         .get("ToUnicode")
         .and_then(|e| e.try_stream(objects).ok())
-        .and_then(|s| s.data().ok())
-        .map(|data| ToUnicodeCMap::try_from(data.as_ref()))
+        .map(|s| ToUnicodeCMap::try_from(s.raw_data()))
         .transpose()
         .map_err(FontError::from)
 }

--- a/crates/pdf-font/src/true_type_font.rs
+++ b/crates/pdf-font/src/true_type_font.rs
@@ -92,8 +92,7 @@ impl TrueTypeFont {
         let to_unicode = dictionary
             .get("ToUnicode")
             .and_then(|e| e.try_stream(objects).ok())
-            .and_then(|s| s.data().ok())
-            .map(|data| ToUnicodeCMap::try_from(data.as_ref()))
+            .map(|s| ToUnicodeCMap::try_from(s.raw_data()))
             .transpose()?;
 
         Ok(Self {

--- a/crates/pdf-font/src/type0_font.rs
+++ b/crates/pdf-font/src/type0_font.rs
@@ -206,7 +206,7 @@ fn parse_encoding(
             let resolved = objects.resolve_object(value)?;
             match resolved {
                 ObjectVariant::Stream(stream) => {
-                    Ok(Type0EncodingCMap::from_bytes(&stream.data()?)?)
+                    Ok(Type0EncodingCMap::from_bytes(stream.raw_data())?)
                 }
                 _ => Ok(Type0EncodingCMap::from_name(value.try_str(objects)?)?),
             }

--- a/crates/pdf-font/src/type1_font.rs
+++ b/crates/pdf-font/src/type1_font.rs
@@ -67,8 +67,7 @@ impl Type1Font {
         let to_unicode = dictionary
             .get("ToUnicode")
             .and_then(|e| e.try_stream(objects).ok())
-            .and_then(|s| s.data().ok())
-            .map(|data| ToUnicodeCMap::try_from(data.as_ref()))
+            .map(|s| ToUnicodeCMap::try_from(s.raw_data()))
             .transpose()?;
 
         Ok(Self {

--- a/crates/pdf-font/src/type3_font.rs
+++ b/crates/pdf-font/src/type3_font.rs
@@ -75,8 +75,7 @@ impl Type3Font {
         let to_unicode = dictionary
             .get("ToUnicode")
             .and_then(|e| e.try_stream(objects).ok())
-            .and_then(|s| s.data().ok())
-            .map(|data| ToUnicodeCMap::try_from(data.as_ref()))
+            .map(|s| ToUnicodeCMap::try_from(s.raw_data()))
             .transpose()?;
 
         Ok(Type3Font {

--- a/crates/pdf-function/src/postscript_calculator.rs
+++ b/crates/pdf-function/src/postscript_calculator.rs
@@ -126,9 +126,7 @@ impl FunctionImpl for PostScriptCalculatorFunction {
         let range = stream.dictionary.required_vec_of::<f32>("Range", objects)?;
 
         // Parse PostScript code: add spaces around braces for tokenization
-        let stream_data = stream.data()?;
-
-        let code_str = String::from_utf8_lossy(&stream_data);
+        let code_str = String::from_utf8_lossy(stream.raw_data());
         let code_with_spaces = code_str.replace('{', " { ").replace('}', " } ");
         let tokens: Vec<&str> = code_with_spaces.split_whitespace().collect();
         let operators = pdf_postscript::parser::parse_tokens(&tokens)?;

--- a/crates/pdf-function/src/sampled.rs
+++ b/crates/pdf-function/src/sampled.rs
@@ -298,10 +298,8 @@ impl FunctionImpl for SampledFunction {
             .checked_mul(output_count)
             .ok_or(FunctionReadError::InvalidSizeArray)?;
 
-        let stream = stream.data()?;
-
         // Decode samples from the stream
-        let samples = decode_normalized_samples(&stream, bits_per_sample, samples_count)?;
+        let samples = decode_normalized_samples(stream.raw_data(), bits_per_sample, samples_count)?;
 
         Ok(Function::Sampled(SampledFunction {
             size,

--- a/crates/pdf-image/src/image_xobject.rs
+++ b/crates/pdf-image/src/image_xobject.rs
@@ -1,6 +1,6 @@
 use pdf_color_space::{color_space::ColorSpace, indexed_color_space::IndexedColorSpace};
 use pdf_decode::{DecodeMap, SampleLayout, decode_sample_codes};
-use pdf_filter::filter::{Filter, decode_with_resolver};
+use pdf_filter::filter::{Filter, decode_data_with_resolver, decode_with_resolver};
 use pdf_graphics::PixelFormat;
 use pdf_object::{
     dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
@@ -55,10 +55,9 @@ impl ImageXObject {
         objects: &dyn ObjectResolver,
         soft_mask: Option<ImageXObject>,
     ) -> Result<Self, PdfImageError> {
-        let raw_data = stream_data.data()?;
         match Self::decode_normalized_image(
             dictionary,
-            raw_data.as_ref(),
+            stream_data.raw_data(),
             objects,
             soft_mask.clone(),
         ) {
@@ -79,8 +78,7 @@ impl ImageXObject {
         soft_mask: Option<ImageXObject>,
     ) -> Result<Self, PdfImageError> {
         let dictionary = image.normalized_dictionary();
-        let stream = StreamObject::new(0, 0, Box::new(dictionary.clone()), image.data().to_vec());
-        let decoded = decode_with_resolver(&stream, objects)?;
+        let decoded = decode_data_with_resolver(&dictionary, image.data(), objects)?;
 
         Self::decode_normalized_image(&dictionary, decoded.as_ref(), objects, soft_mask)
     }

--- a/crates/pdf-object-collection/src/object_collection.rs
+++ b/crates/pdf-object-collection/src/object_collection.rs
@@ -78,7 +78,7 @@ impl ObjectCollection {
             }
             ObjectVariant::Stream(stream) => {
                 let data = pdf_filter::filter::decode_with_resolver(&stream, self)
-                    .map(|data| data.to_vec())
+                    .map(|data| data.into_owned())
                     .unwrap_or_else(|_| stream.raw_data().to_vec());
                 let StreamObject {
                     object_number,

--- a/crates/pdf-resources/src/external_graphics_state.rs
+++ b/crates/pdf-resources/src/external_graphics_state.rs
@@ -267,10 +267,11 @@ fn parse_soft_mask(
             let mask_type = parse_mask_mode(dict.required_str("S", objects)?)?;
 
             // Parse the "G" key for the `XObject`
-            let stream = dict.required_stream("G", objects)?;
+            let content = dict.get_or_err("G")?;
+            let stream = content.try_stream(objects)?;
 
             let shape = match XObject::read_xobject(
-                &ObjectVariant::Stream(stream.clone()),
+                content,
                 &stream.dictionary,
                 stream,
                 objects,

--- a/crates/pdf-resources/src/xobject.rs
+++ b/crates/pdf-resources/src/xobject.rs
@@ -93,7 +93,7 @@ fn resolve_image_soft_mask(
     let stream = resolved.try_stream(objects)?;
 
     match XObject::read_xobject(
-        &ObjectVariant::Stream(stream.clone()),
+        resolved,
         &stream.dictionary,
         stream,
         objects,


### PR DESCRIPTION
Add a filter entry point that accepts a dictionary and borrowed data, letting inline images decode without constructing a temporary stream.

Use raw stream data throughout document, font, function, image, and resource parsing, and move streams through decryption to avoid redundant decoding, cloning, and allocation.