### PR TITLE
pdf-object: share decoded stream data

### DIFF
--- a/crates/pdf-canvas/src/canvas_text_ops.rs
+++ b/crates/pdf-canvas/src/canvas_text_ops.rs
@@ -155,7 +155,7 @@ impl<B: CanvasBackend> TextShowingOps for PdfCanvas<'_, B> {
                 renderer.render_text(iter)
             }
             Font::Type1(type1_font) => {
-                let program = type1_font.font_file.as_slice();
+                let program = type1_font.font_file.as_ref();
                 let iter = to_char_iter(text);
 
                 let mut renderer =
@@ -175,7 +175,7 @@ impl<B: CanvasBackend> TextShowingOps for PdfCanvas<'_, B> {
 
                 match font.program_format {
                     Type0FontProgramFormat::OpenTypeCff => {
-                        let program = font.font_file.as_slice();
+                        let program = font.font_file.as_ref();
                         let program_format = font
                             .type1_program_format
                             .unwrap_or(Type1FontProgramFormat::OpenTypeCff);

--- a/crates/pdf-canvas/src/truetype_font_renderer.rs
+++ b/crates/pdf-canvas/src/truetype_font_renderer.rs
@@ -153,9 +153,9 @@ impl<B: CanvasBackend> TextRenderer for TrueTypeFontRenderer<'_, '_, B> {
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
-
-    use pdf_font::{encoding::Encoding, flags::FontFlags, standard14::Standard14Font};
+    use pdf_font::{
+        encoding::Encoding, flags::FontFlags, font_data::FontData, standard14::Standard14Font,
+    };
 
     use super::*;
 
@@ -186,7 +186,7 @@ mod tests {
     #[test]
     fn simple_truetype_prefers_pdf_unicode_mapping() {
         let font = Font::TrueType(pdf_font::true_type_font::TrueTypeFont {
-            font_file: Standard14Font::Helvetica.fallback_font_bytes(),
+            font_file: Standard14Font::Helvetica.fallback_font_bytes().into(),
             widths: None,
             encoding: Some(Encoding::default()),
             to_unicode: None,
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn symbolic_simple_truetype_still_uses_pdf_unicode_mapping() {
         let font = Font::TrueType(pdf_font::true_type_font::TrueTypeFont {
-            font_file: Standard14Font::Helvetica.fallback_font_bytes(),
+            font_file: Standard14Font::Helvetica.fallback_font_bytes().into(),
             widths: None,
             encoding: Some(Encoding::default()),
             to_unicode: None,
@@ -218,7 +218,7 @@ mod tests {
     #[test]
     fn symbolic_simple_truetype_falls_back_to_unicode_codepoint_mapping() {
         let font = Font::TrueType(pdf_font::true_type_font::TrueTypeFont {
-            font_file: Standard14Font::Helvetica.fallback_font_bytes(),
+            font_file: Standard14Font::Helvetica.fallback_font_bytes().into(),
             widths: None,
             encoding: None,
             to_unicode: None,
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn unmappable_simple_truetype_returns_notdef() {
         let font = Font::TrueType(pdf_font::true_type_font::TrueTypeFont {
-            font_file: Cow::Owned(vec![]),
+            font_file: FontData::Owned(vec![]),
             widths: None,
             encoding: None,
             to_unicode: None,

--- a/crates/pdf-canvas/src/type1_font_renderer.rs
+++ b/crates/pdf-canvas/src/type1_font_renderer.rs
@@ -568,7 +568,7 @@ currentfile eexec
     #[test]
     fn classic_type1_renderer_uses_pdf_widths_for_advance() {
         let font = Font::Type1(Type1Font {
-            font_file: minimal_classic_type1_font(),
+            font_file: minimal_classic_type1_font().into(),
             program_format: Type1FontProgramFormat::ClassicType1,
             widths: Some(HashMap::from([(65, 500.0)])),
             encoding: Encoding::default(),
@@ -587,7 +587,7 @@ currentfile eexec
         let mut renderer = Type1FontRenderer::new(
             &mut canvas,
             match &font {
-                Font::Type1(font) => font.font_file.as_slice(),
+                Font::Type1(font) => font.font_file.as_ref(),
                 _ => unreachable!(),
             },
             Type1FontProgramFormat::ClassicType1,

--- a/crates/pdf-color-space/src/indexed_color_space.rs
+++ b/crates/pdf-color-space/src/indexed_color_space.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pdf_graphics::color::Color;
 use pdf_object::{object_resolver::ObjectResolver, object_variant::ObjectVariant};
 
@@ -16,7 +18,7 @@ pub struct IndexedColorSpace {
     /// Maximum valid index value (0 to 255). The palette contains `hival + 1` entries.
     pub hival: u8,
     /// Raw lookup table bytes. Each entry contains `base.num_color_components()` bytes.
-    pub lookup: Vec<u8>,
+    pub lookup: Arc<Vec<u8>>,
 }
 
 /// Parses an Indexed color space: `[/Indexed base hival lookup]`
@@ -53,11 +55,11 @@ pub(crate) fn parse_indexed_color_space(
 fn extract_lookup_table(
     objects: &dyn ObjectResolver,
     lookup: &ObjectVariant,
-) -> Result<Vec<u8>, ColorSpaceError> {
+) -> Result<Arc<Vec<u8>>, ColorSpaceError> {
     if let Ok(data) = lookup.try_bytes(objects) {
-        return Ok(data.to_vec());
+        return Ok(Arc::new(data.to_vec()));
     }
-    Ok(lookup.try_stream(objects)?.data()?.into_owned())
+    Ok(lookup.try_stream(objects)?.shared_data())
 }
 
 /// Converts a raw palette entry (byte slice) to a [`Color`] using the given base color space.
@@ -152,16 +154,56 @@ impl IndexedColorSpace {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use pdf_object::{
+        dictionary::Dictionary, object_resolver::PassthroughResolver, stream::StreamObject,
+    };
+
     use super::*;
+
+    #[test]
+    fn stream_lookup_shares_decoded_stream_bytes() {
+        let stream = StreamObject::new(
+            1,
+            0,
+            Box::new(Dictionary::new(BTreeMap::new())),
+            vec![1, 2, 3, 4],
+        );
+        let stream_data = stream.shared_data();
+        let lookup = ObjectVariant::Stream(stream);
+
+        let extracted = extract_lookup_table(&PassthroughResolver, &lookup)
+            .expect("stream lookup table should parse");
+
+        assert!(Arc::ptr_eq(&extracted, &stream_data));
+    }
+
+    #[test]
+    fn string_lookups_preserve_their_bytes() {
+        for lookup in [
+            ObjectVariant::LiteralString(vec![1, 2, 3]),
+            ObjectVariant::HexString(vec![4, 5, 6]),
+        ] {
+            let expected = lookup
+                .try_bytes(&PassthroughResolver)
+                .expect("test lookup should contain bytes")
+                .to_vec();
+            let extracted = extract_lookup_table(&PassthroughResolver, &lookup)
+                .expect("string lookup table should parse");
+
+            assert_eq!(extracted.as_slice(), expected.as_slice());
+        }
+    }
 
     fn indexed_rgb() -> IndexedColorSpace {
         IndexedColorSpace {
             base: Box::new(ColorSpace::DeviceRGB),
             hival: 7,
-            lookup: vec![
+            lookup: Arc::new(vec![
                 0, 128, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255, 0, 255, 255, 255, 0, 255, 255, 255, 0,
                 243, 128, 255,
-            ],
+            ]),
         }
     }
 

--- a/crates/pdf-font/src/fallback.rs
+++ b/crates/pdf-font/src/fallback.rs
@@ -65,7 +65,7 @@ pub(crate) fn fallback_true_type_from_dictionary(
     let to_unicode = to_unicode_cmap(dictionary, objects)?;
 
     Ok(TrueTypeFont {
-        font_file: fallback.font_file,
+        font_file: fallback.font_file.into(),
         widths,
         encoding,
         to_unicode,

--- a/crates/pdf-font/src/font.rs
+++ b/crates/pdf-font/src/font.rs
@@ -245,7 +245,9 @@ mod tests {
     use pdf_cmap::Type0EncodingCMap;
 
     use super::*;
-    use crate::{encoding::Encoding, flags::FontFlags, true_type_font::TrueTypeFont};
+    use crate::{
+        encoding::Encoding, flags::FontFlags, font_data::FontData, true_type_font::TrueTypeFont,
+    };
 
     #[test]
     fn test_truetype_encoding_fallback() {
@@ -262,7 +264,7 @@ mod tests {
             .collect();
         let enc = Encoding { names };
         let font = Font::TrueType(TrueTypeFont {
-            font_file: Cow::Owned(vec![]),
+            font_file: FontData::Owned(vec![]),
             widths: None,
             encoding: Some(enc),
             to_unicode: None,
@@ -279,7 +281,7 @@ mod tests {
         let cmap_data = b"beginbfchar\n<01> <FB01FB02>\nendbfchar\n";
         let cmap = ToUnicodeCMap::try_from(cmap_data.as_slice()).unwrap();
         let font = Font::TrueType(TrueTypeFont {
-            font_file: Cow::Owned(vec![]),
+            font_file: FontData::Owned(vec![]),
             widths: None,
             encoding: None,
             to_unicode: Some(cmap),
@@ -334,7 +336,7 @@ mod tests {
             program_format: Type0FontProgramFormat::TrueType {
                 cid_to_unicode: false,
             },
-            font_file: vec![],
+            font_file: FontData::Owned(vec![]),
             type1_program_format: None,
             widths: None,
             encoding: None,

--- a/crates/pdf-font/src/font_data.rs
+++ b/crates/pdf-font/src/font_data.rs
@@ -1,0 +1,92 @@
+use std::{borrow::Cow, ops::Deref, sync::Arc};
+
+/// Storage for a parsed or synthesized font program.
+#[derive(Debug, Clone)]
+pub enum FontData {
+    /// Bundled font bytes with static storage duration.
+    Borrowed(&'static [u8]),
+    /// Independently owned font bytes.
+    Owned(Vec<u8>),
+    /// Font bytes shared with a decoded PDF stream.
+    Shared(SharedFontData),
+}
+
+/// A view over the leading bytes of a shared decoded stream.
+#[derive(Debug, Clone)]
+pub struct SharedFontData {
+    data: Arc<Vec<u8>>,
+    visible_len: usize,
+}
+
+impl FontData {
+    /// Shares an entire decoded stream allocation.
+    pub fn shared(data: Arc<Vec<u8>>) -> Self {
+        let visible_len = data.len();
+        Self::Shared(SharedFontData { data, visible_len })
+    }
+
+    /// Shares a prefix of a decoded stream allocation.
+    ///
+    /// `visible_len` is clamped to the available stream length.
+    pub fn shared_prefix(data: Arc<Vec<u8>>, visible_len: usize) -> Self {
+        let visible_len = visible_len.min(data.len());
+        Self::Shared(SharedFontData { data, visible_len })
+    }
+}
+
+impl Deref for FontData {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Borrowed(data) => data,
+            Self::Owned(data) => data.as_slice(),
+            Self::Shared(data) => data.data.get(..data.visible_len).unwrap_or_default(),
+        }
+    }
+}
+
+impl AsRef<[u8]> for FontData {
+    fn as_ref(&self) -> &[u8] {
+        self
+    }
+}
+
+impl From<Vec<u8>> for FontData {
+    fn from(data: Vec<u8>) -> Self {
+        Self::Owned(data)
+    }
+}
+
+impl From<Arc<Vec<u8>>> for FontData {
+    fn from(data: Arc<Vec<u8>>) -> Self {
+        Self::shared(data)
+    }
+}
+
+impl From<Cow<'static, [u8]>> for FontData {
+    fn from(data: Cow<'static, [u8]>) -> Self {
+        match data {
+            Cow::Borrowed(data) => Self::Borrowed(data),
+            Cow::Owned(data) => Self::Owned(data),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_prefix_reuses_allocation_and_clamps_length() {
+        let data = Arc::new(vec![1, 2, 3, 4]);
+        let original = data.as_ptr();
+
+        let prefix = FontData::shared_prefix(Arc::clone(&data), 2);
+        assert_eq!(prefix.as_ptr(), original);
+        assert_eq!(prefix.as_ref(), [1, 2]);
+
+        let full = FontData::shared_prefix(data, usize::MAX);
+        assert_eq!(full.as_ref(), [1, 2, 3, 4]);
+    }
+}

--- a/crates/pdf-font/src/lib.rs
+++ b/crates/pdf-font/src/lib.rs
@@ -6,6 +6,7 @@ pub mod error;
 mod fallback;
 pub mod flags;
 pub mod font;
+pub mod font_data;
 pub mod glyph_name_to_unicode;
 pub mod glyph_widths_map;
 pub mod simple_font_glyph_map;

--- a/crates/pdf-font/src/true_type_font.rs
+++ b/crates/pdf-font/src/true_type_font.rs
@@ -11,6 +11,7 @@ use crate::{
     error::FontError,
     fallback::fallback_program_from_dictionary,
     flags::FontFlags,
+    font_data::FontData,
     simple_font_glyph_map::SimpleFontGlyphWidthsMap,
     standard14::Standard14Font,
 };
@@ -19,10 +20,9 @@ use crate::{
 pub struct TrueTypeFont {
     /// Font program bytes.
     ///
-    /// `Cow::Borrowed` for bundled Standard 14 fallback fonts (avoids copying
-    /// the static `include_bytes!` data), `Cow::Owned` for fonts embedded in
-    /// the PDF stream.
-    pub font_file: Cow<'static, [u8]>,
+    /// Bundled fallback fonts borrow static data, while embedded fonts share
+    /// the decoded PDF stream allocation.
+    pub font_file: FontData,
     /// Widths for character codes.
     pub widths: Option<HashMap<u16, f32>>,
     /// Optional glyph name encoding, used as AGL fallback when ToUnicode is absent.
@@ -38,7 +38,7 @@ pub struct TrueTypeFont {
 }
 
 struct TrueTypeFontProgram {
-    font_file: Cow<'static, [u8]>,
+    font_file: FontData,
     standard14: Option<Standard14Font>,
     flags: FontFlags,
 }
@@ -114,7 +114,7 @@ impl TrueTypeFont {
     /// when the PDF omitted an explicit `/Encoding`.
     pub fn from_bytes(font_file: Cow<'static, [u8]>, standard14: Option<Standard14Font>) -> Self {
         Self {
-            font_file,
+            font_file: font_file.into(),
             widths: None,
             encoding: Self::default_simple_encoding(FontFlags::empty(), standard14),
             to_unicode: None,
@@ -131,7 +131,7 @@ impl TrueTypeFont {
     /// font dictionary.
     pub fn synthetic_standard14_font(standard14: Standard14Font) -> Self {
         Self {
-            font_file: standard14.fallback_font_bytes(),
+            font_file: standard14.fallback_font_bytes().into(),
             widths: None,
             encoding: Some(Encoding::win_ansi()),
             to_unicode: None,
@@ -156,13 +156,13 @@ impl TrueTypeFont {
     ///
     /// # Returns
     ///
-    /// Returns the font file bytes as a `Cow<'static, [u8]>` or a [`FontError`] if
+    /// Returns the font file bytes as [`FontData`] or a [`FontError`] if
     /// reading or decompressing the font stream fails or if the font dictionary or its
     /// `/FontDescriptor` entry is invalid.
     pub(crate) fn read_font_file(
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
-    ) -> Result<(Cow<'static, [u8]>, FontFlags), FontError> {
+    ) -> Result<(FontData, FontFlags), FontError> {
         let program = Self::read_font_program(dictionary, objects)?;
         Ok((program.font_file, program.flags))
     }
@@ -180,7 +180,7 @@ impl TrueTypeFont {
 
             if let Some(stream) = descriptor.optional_stream("FontFile2", objects)? {
                 return Ok(TrueTypeFontProgram {
-                    font_file: Cow::Owned(stream.data()?.to_vec()),
+                    font_file: FontData::shared(stream.shared_data()),
                     standard14: None,
                     flags,
                 });
@@ -189,7 +189,7 @@ impl TrueTypeFont {
 
         let fallback = fallback_program_from_dictionary(dictionary, objects)?;
         Ok(TrueTypeFontProgram {
-            font_file: fallback.font_file,
+            font_file: fallback.font_file.into(),
             standard14: Some(fallback.standard14),
             flags: fallback.flags,
         })
@@ -198,9 +198,48 @@ impl TrueTypeFont {
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
+    use std::{borrow::Cow, collections::BTreeMap};
+
+    use pdf_object::{
+        object_resolver::PassthroughResolver, object_variant::ObjectVariant, stream::StreamObject,
+    };
 
     use super::*;
+
+    #[test]
+    fn embedded_font_program_shares_stream_bytes() {
+        let stream = StreamObject::new(
+            1,
+            0,
+            Box::new(Dictionary::new(BTreeMap::new())),
+            vec![1, 2, 3, 4],
+        );
+        let stream_bytes = stream.raw_data().as_ptr();
+        let descriptor = Dictionary::new(BTreeMap::from([(
+            "FontFile2".to_string(),
+            ObjectVariant::Stream(stream),
+        )]));
+        let dictionary = Dictionary::new(BTreeMap::from([(
+            "FontDescriptor".to_string(),
+            ObjectVariant::Dictionary(Box::new(descriptor)),
+        )]));
+
+        let font = TrueTypeFont::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect("embedded TrueType font should parse");
+
+        assert!(matches!(&font.font_file, FontData::Shared(_)));
+        assert_eq!(font.font_file.as_ptr(), stream_bytes);
+    }
+
+    #[test]
+    fn bundled_font_program_borrows_static_bytes() {
+        let fallback = Standard14Font::Helvetica.fallback_font_bytes();
+        let fallback_bytes = fallback.as_ptr();
+        let font = TrueTypeFont::from_bytes(fallback, Some(Standard14Font::Helvetica));
+
+        assert!(matches!(&font.font_file, FontData::Borrowed(_)));
+        assert_eq!(font.font_file.as_ptr(), fallback_bytes);
+    }
 
     #[test]
     fn standard14_fallback_fonts_default_to_standard_encoding() {

--- a/crates/pdf-font/src/type0_font.rs
+++ b/crates/pdf-font/src/type0_font.rs
@@ -11,6 +11,7 @@ use crate::{
     cid_system_info::cid_ordering_from_dictionary,
     error::FontError,
     fallback::fallback_program_from_dictionary,
+    font_data::FontData,
     glyph_widths_map::GlyphWidthsMap,
     true_type_font::TrueTypeFont,
     type1_font::{Type1Font, Type1FontProgramFormat},
@@ -24,7 +25,7 @@ pub struct Type0Font {
     /// The actual font program format used for rendering.
     pub program_format: Type0FontProgramFormat,
     /// Font file containing embedded font data.
-    pub font_file: Vec<u8>,
+    pub font_file: FontData,
     /// The embedded Type 1 program format for CIDFontType0 descendants.
     pub type1_program_format: Option<Type1FontProgramFormat>,
     /// A map of individual glyph widths, overriding the default width for specific CIDs.
@@ -97,7 +98,7 @@ impl Type0Font {
         } = read_type0_font_program(descendant.dictionary, descendant.subtype, objects)?;
         let glyph_to_unicode = glyph_to_unicode_map(
             fallback_cid_to_unicode,
-            &font_file,
+            font_file.as_ref(),
             descendant.subtype,
             encoding.as_ref(),
             to_unicode.as_ref(),
@@ -181,7 +182,7 @@ impl<'a> Type0DescendantFont<'a> {
 }
 
 struct Type0FontProgram {
-    font_file: Vec<u8>,
+    font_file: FontData,
     program_format: Type0FontProgramFormat,
     fallback_cid_to_unicode: Option<HashMap<u16, char>>,
 }
@@ -231,8 +232,7 @@ fn parse_to_unicode(
     dictionary
         .get("ToUnicode")
         .and_then(|e| e.try_stream(objects).ok())
-        .and_then(|s| s.data().ok())
-        .map(|data| ToUnicodeCMap::try_from(data.as_ref()))
+        .map(|s| ToUnicodeCMap::try_from(s.raw_data()))
         .transpose()
         .map_err(FontError::from)
 }
@@ -351,9 +351,7 @@ fn read_type0_font_program(
     match subtype {
         CidFontSubType::Type0 => read_cid_font_type0_program(dictionary, objects),
         CidFontSubType::Type2 => Ok(Type0FontProgram {
-            font_file: TrueTypeFont::read_font_file(dictionary, objects)?
-                .0
-                .to_vec(),
+            font_file: TrueTypeFont::read_font_file(dictionary, objects)?.0,
             program_format: Type0FontProgramFormat::TrueType {
                 cid_to_unicode: false,
             },
@@ -410,7 +408,7 @@ fn fallback_type0_program(
     let fallback_cid_to_unicode = cid_to_unicode_map(dictionary, objects)?;
 
     Ok(Type0FontProgram {
-        font_file: fallback.font_file.into_owned(),
+        font_file: fallback.font_file.into(),
         program_format: Type0FontProgramFormat::TrueType {
             cid_to_unicode: fallback_cid_to_unicode.is_some(),
         },
@@ -568,12 +566,10 @@ mod tests {
             "Subtype".to_string(),
             ObjectVariant::Name(b"OpenType".to_vec()),
         );
-        let font_file3 = ObjectVariant::Stream(StreamObject::new(
-            3,
-            0,
-            Box::new(Dictionary::new(file3_dict)),
-            vec![0, 1, 2],
-        ));
+        let font_file3_stream =
+            StreamObject::new(3, 0, Box::new(Dictionary::new(file3_dict)), vec![0, 1, 2]);
+        let font_file3_bytes = font_file3_stream.raw_data().as_ptr();
+        let font_file3 = ObjectVariant::Stream(font_file3_stream);
 
         let mut descriptor_dict = BTreeMap::new();
         descriptor_dict.insert("FontFile3".to_string(), font_file3);
@@ -615,6 +611,8 @@ mod tests {
             Type0Font::from_dictionary(&Dictionary::new(font_dict), &PassthroughResolver).unwrap();
 
         assert_eq!(font.program_format, Type0FontProgramFormat::OpenTypeCff);
+        assert!(matches!(&font.font_file, FontData::Shared(_)));
+        assert_eq!(font.font_file.as_ptr(), font_file3_bytes);
         assert!(font.encoding.is_some());
         assert_eq!(
             font.to_unicode

--- a/crates/pdf-font/src/type1_font.rs
+++ b/crates/pdf-font/src/type1_font.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use pdf_cmap::ToUnicodeCMap;
 use pdf_object::{
@@ -10,6 +10,7 @@ use crate::{
     cff_builder::build_cff_font,
     encoding::{Encoding, FontEncoding},
     error::FontError,
+    font_data::FontData,
     simple_font_glyph_map::SimpleFontGlyphWidthsMap,
 };
 
@@ -25,7 +26,7 @@ pub enum Type1FontProgramFormat {
 /// and defers actual glyph rendering or embedded program parsing.
 pub struct Type1Font {
     /// A stream containing the font program.
-    pub font_file: Vec<u8>,
+    pub font_file: FontData,
     /// The format of `font_file`.
     pub program_format: Type1FontProgramFormat,
     /// Widths map for character codes.
@@ -108,7 +109,7 @@ impl Type1Font {
     pub(crate) fn read_font_file(
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
-    ) -> Result<(Vec<u8>, Type1FontProgramFormat), FontError> {
+    ) -> Result<(FontData, Type1FontProgramFormat), FontError> {
         let descriptor = dictionary.required_dictionary("FontDescriptor", objects)?;
 
         // Path 1: FontFile3 stream with subtype-driven handling.
@@ -116,12 +117,13 @@ impl Type1Font {
             let stream = font_file3.try_stream(objects)?;
             let subtype = stream.dictionary.optional_str("Subtype", objects)?;
 
-            let data = stream.data()?;
-
             return match subtype {
-                Some("Type1C") | Some("CIDFontType0C") => build_cff_font(data.as_ref())
-                    .map(|font| (font, Type1FontProgramFormat::OpenTypeCff)),
-                Some("OpenType") => Ok((data.to_vec(), Type1FontProgramFormat::OpenTypeCff)),
+                Some("Type1C") | Some("CIDFontType0C") => build_cff_font(stream.raw_data())
+                    .map(|font| (font.into(), Type1FontProgramFormat::OpenTypeCff)),
+                Some("OpenType") => Ok((
+                    FontData::shared(stream.shared_data()),
+                    Type1FontProgramFormat::OpenTypeCff,
+                )),
                 Some(other) => Err(FontError::UnsupportedFontSubtype {
                     subtype: other.to_string(),
                 }),
@@ -134,9 +136,9 @@ impl Type1Font {
         // Path 2: classic Type 1 in FontFile.
         if let Some(font_file) = descriptor.get("FontFile") {
             let stream = font_file.try_stream(objects)?;
-            let data = stream.data()?;
-            let normalized = normalize_classic_type1_bytes(descriptor, data.as_ref(), objects)?;
-            read_fonts::ps::type1::Type1Font::new(&normalized).map_err(|_| {
+            let normalized =
+                normalize_classic_type1_bytes(descriptor, stream.shared_data(), objects)?;
+            read_fonts::ps::type1::Type1Font::new(normalized.as_ref()).map_err(|_| {
                 FontError::UnsupportedFontSubtype {
                     subtype: "FontFile".to_string(),
                 }
@@ -151,22 +153,22 @@ impl Type1Font {
 
 fn normalize_classic_type1_bytes(
     descriptor: &Dictionary,
-    data: &[u8],
+    data: Arc<Vec<u8>>,
     objects: &dyn ObjectResolver,
-) -> Result<Vec<u8>, FontError> {
-    if is_pfb(data) {
-        return Ok(data.to_vec());
+) -> Result<FontData, FontError> {
+    if is_pfb(data.as_slice()) {
+        return Ok(FontData::shared(data));
     }
 
-    let trimmed = trim_classic_type1_by_lengths(descriptor, data, objects)?;
-    Ok(trimmed.unwrap_or_else(|| data.to_vec()))
+    let visible_len = classic_type1_length(descriptor, data.len(), objects)?.unwrap_or(data.len());
+    Ok(FontData::shared_prefix(data, visible_len))
 }
 
-fn trim_classic_type1_by_lengths(
+fn classic_type1_length(
     descriptor: &Dictionary,
-    data: &[u8],
+    data_len: usize,
     objects: &dyn ObjectResolver,
-) -> Result<Option<Vec<u8>>, FontError> {
+) -> Result<Option<usize>, FontError> {
     let length1 = descriptor.optional_number::<usize>("Length1", objects)?;
     let length2 = descriptor.optional_number::<usize>("Length2", objects)?;
     let length3 = descriptor.optional_number::<usize>("Length3", objects)?;
@@ -183,9 +185,7 @@ fn trim_classic_type1_by_lengths(
         return Ok(None);
     };
 
-    Ok(data
-        .get(..total_length.min(data.len()))
-        .map(ToOwned::to_owned))
+    Ok(Some(total_length.min(data_len)))
 }
 
 fn is_pfb(data: &[u8]) -> bool {
@@ -337,17 +337,27 @@ currentfile eexec
         let (parsed, format) = Type1Font::read_font_file(&dict, &PassthroughResolver).unwrap();
         let expected = build_cff_font(&cff_bytes).unwrap();
         assert_eq!(format, Type1FontProgramFormat::OpenTypeCff);
-        assert_eq!(parsed, expected);
+        assert_eq!(parsed.as_ref(), expected.as_slice());
+        assert!(matches!(parsed, FontData::Owned(_)));
     }
 
     #[test]
     fn font_file3_opentype_is_returned_as_is() {
         let opentype_bytes = vec![0, 1, 2, 3, 4, 5];
         let dict = make_font_dict_with_font_file3(Some("OpenType"), opentype_bytes.clone());
+        let stream_bytes = dict
+            .required_dictionary("FontDescriptor", &PassthroughResolver)
+            .unwrap()
+            .required_stream("FontFile3", &PassthroughResolver)
+            .unwrap()
+            .raw_data()
+            .as_ptr();
 
         let (parsed, format) = Type1Font::read_font_file(&dict, &PassthroughResolver).unwrap();
         assert_eq!(format, Type1FontProgramFormat::OpenTypeCff);
-        assert_eq!(parsed, opentype_bytes);
+        assert_eq!(parsed.as_ref(), opentype_bytes.as_slice());
+        assert_eq!(parsed.as_ptr(), stream_bytes);
+        assert!(matches!(parsed, FontData::Shared(_)));
     }
 
     #[test]
@@ -380,20 +390,36 @@ currentfile eexec
     fn font_file_pfa_is_returned_as_classic_type1() {
         let (bytes, lengths) = minimal_pfa_font();
         let dict = make_font_dict_with_font_file(bytes.clone(), Some(lengths));
+        let stream_bytes = dict
+            .required_dictionary("FontDescriptor", &PassthroughResolver)
+            .unwrap()
+            .required_stream("FontFile", &PassthroughResolver)
+            .unwrap()
+            .raw_data()
+            .as_ptr();
 
         let (parsed, format) = Type1Font::read_font_file(&dict, &PassthroughResolver).unwrap();
         assert_eq!(format, Type1FontProgramFormat::ClassicType1);
-        assert_eq!(parsed, bytes);
+        assert_eq!(parsed.as_ref(), bytes.as_slice());
+        assert_eq!(parsed.as_ptr(), stream_bytes);
     }
 
     #[test]
     fn font_file_pfb_is_returned_as_classic_type1() {
         let bytes = minimal_pfb_font();
         let dict = make_font_dict_with_font_file(bytes.clone(), None);
+        let stream_bytes = dict
+            .required_dictionary("FontDescriptor", &PassthroughResolver)
+            .unwrap()
+            .required_stream("FontFile", &PassthroughResolver)
+            .unwrap()
+            .raw_data()
+            .as_ptr();
 
         let (parsed, format) = Type1Font::read_font_file(&dict, &PassthroughResolver).unwrap();
         assert_eq!(format, Type1FontProgramFormat::ClassicType1);
-        assert_eq!(parsed, bytes);
+        assert_eq!(parsed.as_ref(), bytes.as_slice());
+        assert_eq!(parsed.as_ptr(), stream_bytes);
     }
 
     #[test]
@@ -401,11 +427,19 @@ currentfile eexec
         let (mut bytes, lengths) = minimal_pfa_font();
         bytes.extend_from_slice(b"trailing junk");
         let dict = make_font_dict_with_font_file(bytes, Some(lengths));
+        let stream_bytes = dict
+            .required_dictionary("FontDescriptor", &PassthroughResolver)
+            .unwrap()
+            .required_stream("FontFile", &PassthroughResolver)
+            .unwrap()
+            .raw_data()
+            .as_ptr();
 
         let (parsed, format) = Type1Font::read_font_file(&dict, &PassthroughResolver).unwrap();
         assert_eq!(format, Type1FontProgramFormat::ClassicType1);
         let expected_len = lengths.0 + lengths.1 + lengths.2;
         assert_eq!(parsed.len(), expected_len);
+        assert_eq!(parsed.as_ptr(), stream_bytes);
     }
 
     #[test]

--- a/crates/pdf-object-collection/src/object_collection.rs
+++ b/crates/pdf-object-collection/src/object_collection.rs
@@ -2,6 +2,7 @@ use pdf_object::indirect_object::IndirectObject;
 use pdf_object::object_resolver::ObjectResolver;
 use pdf_object::stream::StreamObject;
 use pdf_object::{error::ObjectError, object_variant::ObjectVariant};
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 #[cfg(feature = "json")]
@@ -78,8 +79,11 @@ impl ObjectCollection {
             }
             ObjectVariant::Stream(stream) => {
                 let data = pdf_filter::filter::decode_with_resolver(&stream, self)
-                    .map(|data| data.into_owned())
-                    .unwrap_or_else(|_| stream.raw_data().to_vec());
+                    .map(|data| match data {
+                        Cow::Borrowed(_) => stream.shared_data(),
+                        Cow::Owned(data) => data.into(),
+                    })
+                    .unwrap_or_else(|_| stream.shared_data());
                 let StreamObject {
                     object_number,
                     generation_number,
@@ -261,7 +265,32 @@ impl ObjectCollection {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use pdf_object::{dictionary::Dictionary, stream::StreamObject};
+
     use super::*;
+
+    #[test]
+    fn inserting_unfiltered_stream_preserves_the_byte_allocation() {
+        let data = vec![1, 2, 3, 4];
+        let original = data.as_ptr();
+        let stream = StreamObject::new(1, 0, Box::new(Dictionary::new(BTreeMap::new())), data);
+        let mut collection = ObjectCollection::default();
+
+        collection
+            .insert(ObjectVariant::Stream(stream))
+            .expect("stream insert failed");
+
+        let stored = collection
+            .get(1)
+            .and_then(|object| match object {
+                ObjectVariant::Stream(stream) => Some(stream),
+                _ => None,
+            })
+            .expect("inserted stream should be present");
+        assert_eq!(stored.raw_data().as_ptr(), original);
+    }
 
     #[test]
     fn resolve_object_reports_direct_self_reference_cycle() {
@@ -291,10 +320,7 @@ mod tests {
 
     #[test]
     fn insert_decodes_stream_with_indirect_decode_parms() {
-        use pdf_object::{
-            dictionary::Dictionary, indirect_object::IndirectObject, stream::StreamObject,
-        };
-        use std::collections::BTreeMap;
+        use pdf_object::indirect_object::IndirectObject;
         use std::io::Write;
 
         let mut encoded_row = Vec::from([2u8]);

--- a/crates/pdf-object/src/stream.rs
+++ b/crates/pdf-object/src/stream.rs
@@ -1,6 +1,6 @@
-use std::borrow::Cow;
+use std::sync::Arc;
 
-use crate::{dictionary::Dictionary, error::ObjectError};
+use crate::dictionary::Dictionary;
 
 /// Represents a PDF stream object.
 ///
@@ -8,10 +8,6 @@ use crate::{dictionary::Dictionary, error::ObjectError};
 /// can store large amounts of data in a stream that it would not be practical
 /// to store in a string. Streams are used for objects such as images, page
 /// content descriptions, and font definitions.
-///
-/// Stream data is decoded (decompressed) at insertion time by
-/// [`ObjectCollection`], so the [`data`](Self::data) field always contains the
-/// fully decoded bytes.
 #[derive(Debug, PartialEq, Clone)]
 pub struct StreamObject {
     /// The object number, identifying this stream as an indirect object.
@@ -20,12 +16,13 @@ pub struct StreamObject {
     pub generation_number: usize,
     /// The dictionary associated with this stream.
     pub dictionary: Box<Dictionary>,
-    /// The decoded (decompressed) byte data of the stream.
+    /// Shared decoded (decompressed) byte data of the stream.
     ///
     /// Filter chains declared in the `/Filter` dictionary entry are applied
     /// when the stream is first inserted into the object collection, so this
-    /// field always holds the final, usable bytes.
-    pub data: Vec<u8>,
+    /// field always holds the final, usable bytes. Cloning the [`Arc`] shares
+    /// the allocation rather than copying the bytes.
+    pub data: Arc<Vec<u8>>,
 }
 
 impl StreamObject {
@@ -34,13 +31,13 @@ impl StreamObject {
         object_number: usize,
         generation_number: usize,
         dictionary: Box<Dictionary>,
-        data: Vec<u8>,
+        data: impl Into<Arc<Vec<u8>>>,
     ) -> Self {
         StreamObject {
             object_number,
             generation_number,
             dictionary,
-            data,
+            data: data.into(),
         }
     }
 
@@ -49,15 +46,13 @@ impl StreamObject {
     /// Because stream data is decoded at insertion time, this always returns
     /// the fully decompressed content.
     pub fn raw_data(&self) -> &[u8] {
-        &self.data
+        self.data.as_slice()
     }
 
-    /// Returns the stream bytes as a borrowed [`Cow`].
+    /// Returns shared ownership of the decoded stream bytes.
     ///
-    /// This method exists for API compatibility with callers that expect a
-    /// `Result<Cow<'_, [u8]>, ObjectError>`. Since stream data is already
-    /// decoded, it always succeeds.
-    pub fn data(&self) -> Result<Cow<'_, [u8]>, ObjectError> {
-        Ok(Cow::Borrowed(&self.data))
+    /// Cloning the returned [`Arc`] does not copy the underlying byte buffer.
+    pub fn shared_data(&self) -> Arc<Vec<u8>> {
+        Arc::clone(&self.data)
     }
 }

--- a/crates/pdf-parser/src/indirect_object.rs
+++ b/crates/pdf-parser/src/indirect_object.rs
@@ -252,7 +252,7 @@ mod tests {
         {
             assert_eq!(stream.object_number, 1);
             assert_eq!(stream.generation_number, 0);
-            assert_eq!(stream.data, b"Hello");
+            assert_eq!(stream.raw_data(), b"Hello");
         } else {
             panic!("Expected Stream variant");
         }


### PR DESCRIPTION
Store decoded stream bytes behind Arc so consumers can retain them without copying.

Use shared storage for embedded Type0, Type1, and TrueType font programs, including trimmed Type1 prefixes, and for indexed color lookup tables. Keep generated and bundled font data in a common storage type.