### PR TITLE
pdf-document: use Rect for page media boxes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,6 +2204,7 @@ dependencies = [
  "pdf-annotation-types",
  "pdf-color-space",
  "pdf-content-stream",
+ "pdf-graphics",
  "pdf-object",
  "pdf-object-collection",
  "pdf-parser",

--- a/crates/pdf-annotation-form/src/interaction_viewport.rs
+++ b/crates/pdf-annotation-form/src/interaction_viewport.rs
@@ -39,7 +39,7 @@ impl AnnotationViewport {
         let page_units_per_device_x = media_width / width;
         let page_units_per_device_y = media_height / height;
         let device_origin_x = -(media_box.left * device_units_per_page_x);
-        let device_origin_y = height + media_box.bottom * device_units_per_page_y;
+        let device_origin_y = height + media_box.top * device_units_per_page_y;
         if !device_units_per_page_x.is_finite()
             || !device_units_per_page_y.is_finite()
             || !page_units_per_device_x.is_finite()
@@ -59,13 +59,7 @@ impl AnnotationViewport {
                 device_origin_x,
                 device_origin_y,
             ),
-            page_bounds: Rect {
-                left: media_box.left,
-                top: media_box.bottom,
-                right: media_box.right,
-                bottom: media_box.top,
-            }
-            .normalized(),
+            page_bounds: media_box.normalized(),
             page_units_per_device_x,
             page_units_per_device_y,
         })
@@ -99,18 +93,16 @@ impl AnnotationViewport {
 
 #[cfg(test)]
 mod tests {
-    use pdf_resources::media_box::MediaBox;
-
     use super::*;
 
     #[test]
     fn maps_media_boxes_with_nonzero_origins() {
         let page = PdfPage {
-            media_box: Some(MediaBox {
+            media_box: Some(Rect {
                 left: 50.0,
-                top: 125.0,
+                top: 25.0,
                 right: 250.0,
-                bottom: 25.0,
+                bottom: 125.0,
             }),
             ..Default::default()
         };
@@ -131,22 +123,22 @@ mod tests {
     #[test]
     fn rejects_non_finite_derived_scale() {
         let page = PdfPage {
-            media_box: Some(MediaBox {
+            media_box: Some(Rect {
                 left: 0.0,
-                top: f32::MAX,
+                top: 0.0,
                 right: f32::MAX,
-                bottom: 0.0,
+                bottom: f32::MAX,
             }),
             ..Default::default()
         };
         assert!(AnnotationViewport::from_page(&page, f32::MIN_POSITIVE, 1.0).is_none());
 
         let page = PdfPage {
-            media_box: Some(MediaBox {
+            media_box: Some(Rect {
                 left: 1.0e30,
-                top: 100.0,
+                top: 0.0,
                 right: 1.000_001e30,
-                bottom: 0.0,
+                bottom: 100.0,
             }),
             ..Default::default()
         };

--- a/crates/pdf-annotation-form/tests/interaction.rs
+++ b/crates/pdf-annotation-form/tests/interaction.rs
@@ -16,7 +16,6 @@ use pdf_annotation_form::{
 use pdf_annotation_types::{AnnotationKind, annotation_id::AnnotationId};
 use pdf_document::{document::PdfDocument, page::PdfPage};
 use pdf_graphics::{point::Point, rect::Rect};
-use pdf_resources::media_box::MediaBox;
 
 trait TestAnnotationController {
     fn test_pointer_pressed(
@@ -77,11 +76,11 @@ impl TestAnnotationController for AnnotationController {
 
 fn document_with_free_text(rect: Rect) -> (PdfDocument, AnnotationId) {
     let mut page = PdfPage {
-        media_box: Some(MediaBox {
+        media_box: Some(Rect {
             left: 0.0,
-            top: 100.0,
+            top: 0.0,
             right: 200.0,
-            bottom: 0.0,
+            bottom: 100.0,
         }),
         ..Default::default()
     };

--- a/crates/pdf-document/Cargo.toml
+++ b/crates/pdf-document/Cargo.toml
@@ -10,6 +10,7 @@ pdf-object-collection = { path = "../pdf-object-collection" }
 pdf-object = { path = "../pdf-object" }
 pdf-parser = { path = "../pdf-parser" }
 pdf-resources = { path = "../pdf-resources" }
+pdf-graphics = { path = "../pdf-graphics" }
 thiserror = "2.0.12"
 
 md-5 = "0.10.6"

--- a/crates/pdf-document/src/page.rs
+++ b/crates/pdf-document/src/page.rs
@@ -1,5 +1,6 @@
 use pdf_annotation_types::{Annotation, AnnotationError, annotation_id::AnnotationId};
 use pdf_content_stream::{ContentStream, ContentStreamIdAllocator};
+use pdf_graphics::rect::Rect;
 use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 use pdf_resources::{
     error::PdfPagesError, media_box::MediaBox, object_reader::ReadCycleTracker,
@@ -19,7 +20,7 @@ pub struct PdfPage {
     /// The raw annotation dictionaries attached to the page.
     pub annotations: Option<Vec<Annotation>>,
     /// `/MediaBox` attribute which defines the page boundaries.
-    pub media_box: Option<MediaBox>,
+    pub media_box: Option<Rect>,
     /// `/Resources` attribute which defines the resources used by the page.
     pub resources: Option<Resources>,
     /// Next page-scoped annotation identifier.

--- a/crates/pdf-document/src/pages.rs
+++ b/crates/pdf-document/src/pages.rs
@@ -1,5 +1,6 @@
 use crate::page::PdfPage;
 use pdf_content_stream::ContentStreamIdAllocator;
+use pdf_graphics::rect::Rect;
 use pdf_object::{
     dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
 };
@@ -101,10 +102,10 @@ impl PdfPages {
     /// Per PDF spec §7.7.3.4, `/MediaBox` is an inheritable attribute.  A page
     /// that does not carry its own `/MediaBox` receives the nearest ancestor's
     /// value.  Pages that already have a `/MediaBox` are left unchanged.
-    fn apply_media_box_inheritance(pages: &mut [PdfPage], media_box: &MediaBox) {
+    fn apply_media_box_inheritance(pages: &mut [PdfPage], media_box: &Rect) {
         for page in pages {
             if page.media_box.is_none() {
-                page.media_box = Some(media_box.clone());
+                page.media_box = Some(*media_box);
             }
         }
     }
@@ -263,11 +264,11 @@ mod tests {
 
     #[test]
     fn leaf_page_without_media_box_inherits_parent_media_box() {
-        let parent_mb = MediaBox {
+        let parent_mb = Rect {
             left: 0.0,
-            bottom: 0.0,
+            top: 0.0,
             right: 595.0,
-            top: 842.0,
+            bottom: 842.0,
         };
 
         let mut page = PdfPage {
@@ -284,23 +285,23 @@ mod tests {
             .media_box
             .expect("page should have inherited media box");
         assert_eq!(inherited.right, 595.0);
-        assert_eq!(inherited.top, 842.0);
+        assert_eq!(inherited.bottom, 842.0);
     }
 
     #[test]
     fn leaf_page_with_own_media_box_is_not_overwritten() {
-        let parent_mb = MediaBox {
+        let parent_mb = Rect {
             left: 0.0,
-            bottom: 0.0,
+            top: 0.0,
             right: 595.0,
-            top: 842.0,
+            bottom: 842.0,
         };
 
-        let child_mb = MediaBox {
+        let child_mb = Rect {
             left: 0.0,
-            bottom: 0.0,
+            top: 0.0,
             right: 200.0,
-            top: 300.0,
+            bottom: 300.0,
         };
 
         let mut page = PdfPage {
@@ -319,7 +320,7 @@ mod tests {
             "child MediaBox should not be overwritten"
         );
         assert_eq!(
-            result.top, 300.0,
+            result.bottom, 300.0,
             "child MediaBox should not be overwritten"
         );
     }

--- a/crates/pdf-document/tests/pages.rs
+++ b/crates/pdf-document/tests/pages.rs
@@ -194,7 +194,7 @@ fn inherited_resources_and_media_box_apply_to_leaf_pages() {
         .as_ref()
         .expect("page should inherit media box");
     assert_eq!(media_box.right, 595.0);
-    assert_eq!(media_box.top, 842.0);
+    assert_eq!(media_box.bottom, 842.0);
 }
 
 #[test]
@@ -257,5 +257,5 @@ fn child_resources_keep_their_own_entries_while_inheriting_missing_ones() {
         .as_ref()
         .expect("page should keep own media box");
     assert_eq!(media_box.right, 200.0);
-    assert_eq!(media_box.top, 300.0);
+    assert_eq!(media_box.bottom, 300.0);
 }

--- a/crates/pdf-document/tests/reader.rs
+++ b/crates/pdf-document/tests/reader.rs
@@ -1090,7 +1090,7 @@ fn test_cyclic_page_tree_does_not_overflow() {
         .as_ref()
         .expect("page should inherit MediaBox from parent /Pages");
     assert_eq!(mb.right, 595.0);
-    assert_eq!(mb.top, 842.0);
+    assert_eq!(mb.bottom, 842.0);
 }
 
 #[test]

--- a/crates/pdf-resources/src/media_box.rs
+++ b/crates/pdf-resources/src/media_box.rs
@@ -1,32 +1,10 @@
+use pdf_graphics::rect::Rect;
 use pdf_object::error::ObjectError;
 use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 
-/// Defines the page boundaries within a PDF document.
-///
-/// The `MediaBox` is a rectangle, expressed in default user space units,
-/// that defines the boundaries of the physical medium on which the page
-/// is intended to be displayed or printed.
+/// Reads the page boundaries from a PDF document.
 #[derive(Default, Debug, Clone)]
-pub struct MediaBox {
-    /// The x-coordinate of the lower-left corner of the rectangle.
-    pub left: f32,
-    /// The y-coordinate of the upper-right corner of the rectangle.
-    pub top: f32,
-    /// The x-coordinate of the upper-right corner of the rectangle.
-    pub right: f32,
-    /// The y-coordinate of the lower-left corner of the rectangle.
-    pub bottom: f32,
-}
-
-impl MediaBox {
-    pub fn width(&self) -> f32 {
-        self.right - self.left
-    }
-
-    pub fn height(&self) -> f32 {
-        self.top - self.bottom
-    }
-}
+pub struct MediaBox;
 
 impl MediaBox {
     const KEY: &'static str = "MediaBox";
@@ -34,19 +12,80 @@ impl MediaBox {
     pub fn from_dictionary(
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
-    ) -> Result<Option<MediaBox>, ObjectError> {
+    ) -> Result<Option<Rect>, ObjectError> {
         let Some(media_box_obj) = dictionary.get(Self::KEY) else {
             return Ok(None);
         };
 
         // PDF MediaBox is an array of four numbers: [LLx, LLy, URx, URy]
-        let [left, bottom, right, top] = media_box_obj.try_array_of::<f32, 4>(objects)?;
+        let rect = Rect::from(media_box_obj.try_array_of::<f32, 4>(objects)?);
 
-        Ok(Some(MediaBox {
-            left,
-            top,
-            right,
-            bottom,
-        }))
+        Ok(Some(rect))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use pdf_object::{object_resolver::PassthroughResolver, object_variant::ObjectVariant};
+
+    use super::*;
+
+    #[test]
+    fn missing_media_box_returns_none() {
+        let dictionary = Dictionary::new(BTreeMap::new());
+
+        assert_eq!(
+            MediaBox::from_dictionary(&dictionary, &PassthroughResolver)
+                .expect("missing MediaBox should parse"),
+            None
+        );
+    }
+
+    #[test]
+    fn media_box_is_parsed_as_rect() {
+        let dictionary = Dictionary::new(BTreeMap::from([(
+            "MediaBox".to_owned(),
+            ObjectVariant::Array(vec![
+                ObjectVariant::Integer(10),
+                ObjectVariant::Integer(20),
+                ObjectVariant::Integer(210),
+                ObjectVariant::Integer(320),
+            ]),
+        )]));
+
+        let media_box = MediaBox::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect("MediaBox should parse")
+            .expect("MediaBox should be present");
+
+        assert_eq!(
+            media_box,
+            Rect {
+                left: 10.0,
+                top: 20.0,
+                right: 210.0,
+                bottom: 320.0,
+            }
+        );
+        assert_eq!(media_box.width(), 200.0);
+        assert_eq!(media_box.height(), 300.0);
+    }
+
+    #[test]
+    fn malformed_media_box_returns_error() {
+        let dictionary = Dictionary::new(BTreeMap::from([(
+            "MediaBox".to_owned(),
+            ObjectVariant::Array(vec![
+                ObjectVariant::Integer(10),
+                ObjectVariant::Integer(20),
+                ObjectVariant::Integer(210),
+            ]),
+        )]));
+
+        assert!(
+            MediaBox::from_dictionary(&dictionary, &PassthroughResolver).is_err(),
+            "MediaBox arrays must contain four numbers"
+        );
     }
 }


### PR DESCRIPTION
Store parsed page media boxes as the shared graphics Rect type and keep MediaBox as a fieldless dictionary parser.

Update page-tree inheritance and annotation viewport coordinate handling for Rect edge semantics, with parser and integration coverage.