### PR TITLE
pdf-resources: tolerate malformed image dimensions

### DIFF
--- a/crates/pdf-canvas/src/canvas_external_object_ops.rs
+++ b/crates/pdf-canvas/src/canvas_external_object_ops.rs
@@ -86,6 +86,7 @@ impl<B: CanvasBackend> XObjectOps for PdfCanvas<'_, B> {
 
         match xobj {
             XObject::Image(image) => self.render_image_xobject(image)?,
+            XObject::UnavailableImage => {}
             XObject::Form(form) => self.render_content_stream(
                 &form.content_stream,
                 form.matrix,

--- a/crates/pdf-canvas/tests/pdf_canvas.rs
+++ b/crates/pdf-canvas/tests/pdf_canvas.rs
@@ -141,6 +141,26 @@ fn still_renders_nested_streams_with_distinct_ids() {
 }
 
 #[test]
+fn unavailable_image_xobject_is_a_no_op() {
+    let stream = content_stream(1, b"/Im Do");
+    let resources = Resources {
+        xobjects: HashMap::from([(
+            "Im".to_string(),
+            Resource::XObject(Rc::new(XObject::UnavailableImage)),
+        )]),
+        ..Default::default()
+    };
+    let mut recording = RecordingCanvas::new(100.0, 100.0);
+
+    render(&mut recording, &stream, Some(&resources))
+        .expect("an unavailable image should not abort page rendering");
+
+    let observer = replay(&recording);
+    assert!(observer.images.is_empty());
+    assert!(observer.inline_images.is_empty());
+}
+
+#[test]
 fn inline_image_render_path_matches_image_xobject_path() {
     let image = pdf_image::ImageXObject::decode_normalized_image(
         &image_dictionary(),

--- a/crates/pdf-document/tests/reader.rs
+++ b/crates/pdf-document/tests/reader.rs
@@ -269,6 +269,48 @@ fn build_xobject_image_pdf() -> Vec<u8> {
     data
 }
 
+fn build_xobject_with_malformed_dimensions_pdf() -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(b"%PDF-1.7\n");
+
+    let obj1_offset = data.len();
+    data.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let obj2_offset = data.len();
+    data.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let obj3_offset = data.len();
+    data.extend_from_slice(
+        b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 50] /Resources << /XObject << /I1 4 0 R >> >> /Contents 5 0 R >>\nendobj\n",
+    );
+
+    let obj4_offset = data.len();
+    data.extend_from_slice(
+        b"4 0 obj\n<< /Type /XObject /Subtype /Image /Width /Height /ColorSpace /DeviceGray /BitsPerComponent 8 /Length 1 >>\nstream\nA\nendstream\nendobj\n",
+    );
+
+    let obj5_offset = data.len();
+    data.extend_from_slice(
+        b"5 0 obj\n<< /Length 12 >>\nstream\nq\n/I1 Do\nQ\n\nendstream\nendobj\n",
+    );
+
+    let xref_offset = data.len();
+    data.extend_from_slice(b"xref\n0 6\n");
+    data.extend_from_slice(format_xref_entry(0, 65_535, false).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj1_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj2_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj3_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj4_offset, 0, true).as_bytes());
+    data.extend_from_slice(format_xref_entry(obj5_offset, 0, true).as_bytes());
+
+    data.extend_from_slice(b"trailer\n<< /Size 6 /Root 1 0 R >>\n");
+    data.extend_from_slice(b"startxref\n");
+    data.extend_from_slice(format!("{}\n", xref_offset).as_bytes());
+    data.extend_from_slice(b"%%EOF");
+
+    data
+}
+
 fn build_xobject_image_with_flat_xref_rows_pdf() -> Vec<u8> {
     let mut data = Vec::new();
     data.extend_from_slice(b"%PDF-1.4\n");
@@ -810,6 +852,25 @@ fn test_xobject_image_pdf_loads_normally() {
     let doc = result.unwrap();
     assert_eq!(doc.page_count(), 1);
     assert!(doc.get_page(0).is_some());
+}
+
+#[test]
+fn test_xobject_with_malformed_dimensions_loads_normally() {
+    let data = build_xobject_with_malformed_dimensions_pdf();
+    let doc = PdfReader
+        .read_from_bytes(&data, None)
+        .expect("a malformed image should not prevent the document from loading");
+    let page = doc.get_page(0).expect("the page should remain available");
+    let xobject = page
+        .resources
+        .as_ref()
+        .and_then(|resources| resources.xobject("I1"));
+
+    assert!(matches!(
+        xobject,
+        Some(pdf_resources::xobject::XObject::UnavailableImage)
+    ));
+    assert!(page.contents.is_some());
 }
 
 #[test]

--- a/crates/pdf-resources/src/resources.rs
+++ b/crates/pdf-resources/src/resources.rs
@@ -754,7 +754,7 @@ mod tests {
         match resource {
             Resource::XObject(xobject) => match xobject.as_ref() {
                 XObject::Form(form) => Some(form.content_stream.id),
-                XObject::Image(_) => None,
+                XObject::Image(_) | XObject::UnavailableImage => None,
             },
             _ => None,
         }

--- a/crates/pdf-resources/src/xobject.rs
+++ b/crates/pdf-resources/src/xobject.rs
@@ -19,6 +19,8 @@ use pdf_object::{
 pub enum XObject {
     /// An image XObject, representing a raster image.
     Image(ImageXObject),
+    /// An image XObject whose dimensions are malformed and cannot be rendered.
+    UnavailableImage,
     /// A form XObject, which is a self-contained sequence of graphics objects
     /// that can be painted as a single unit.
     Form(Box<FormXObject>),
@@ -36,6 +38,10 @@ impl ReadXObject for XObject {
     ) -> Result<Self, PdfPagesError> {
         match dictionary.required_str("Subtype", objects)? {
             "Image" => {
+                if !has_valid_image_dimensions(dictionary, objects) {
+                    return Ok(XObject::UnavailableImage);
+                }
+
                 let soft_mask = resolve_image_soft_mask(
                     dictionary,
                     objects,
@@ -63,6 +69,20 @@ impl ReadXObject for XObject {
             }),
         }
     }
+}
+
+/// Returns whether an image dictionary contains usable dimensions.
+///
+/// Malformed dimensions make the image impossible to decode, but should not
+/// prevent otherwise valid page content from being loaded and rendered.
+fn has_valid_image_dimensions(dictionary: &Dictionary, objects: &dyn ObjectResolver) -> bool {
+    matches!(
+        (
+            dictionary.required_number::<usize>("Width", objects),
+            dictionary.required_number::<usize>("Height", objects),
+        ),
+        (Ok(width), Ok(height)) if width > 0 && height > 0
+    )
 }
 
 /// Resolves an image XObject `/SMask` entry through the page-level XObject reader.
@@ -102,6 +122,7 @@ fn resolve_image_soft_mask(
         id_allocator,
     ) {
         Ok(Some(XObject::Image(image))) => Ok(Some(image)),
+        Ok(Some(XObject::UnavailableImage)) => Ok(None),
         Ok(Some(_)) => Err(PdfImageError::InvalidSoftMaskXObject),
         Ok(None) => Ok(None),
         Err(PdfPagesError::Image(err)) => Err(err),
@@ -126,7 +147,7 @@ mod tests {
         resource_cache::DefaultResourceCache,
     };
 
-    use super::XObject;
+    use super::{XObject, has_valid_image_dimensions};
 
     struct MapResolver {
         objects: BTreeMap<usize, ObjectVariant>,
@@ -264,7 +285,80 @@ mod tests {
                     vec![0x20, 0x20, 0x20, 0x10, 0xC0, 0xC0, 0xC0, 0xE0]
                 );
             }
+            XObject::UnavailableImage => panic!("expected a decoded image xobject"),
             XObject::Form(_) => panic!("expected an image xobject"),
         }
+    }
+
+    #[test]
+    fn malformed_image_dimensions_produce_unavailable_xobject() {
+        let stream = StreamObject::new(
+            9,
+            0,
+            Box::new(Dictionary::new(BTreeMap::from([
+                (
+                    "Subtype".to_string(),
+                    ObjectVariant::Name(b"Image".to_vec()),
+                ),
+                ("Width".to_string(), ObjectVariant::Name(b"Height".to_vec())),
+                ("BitsPerComponent".to_string(), ObjectVariant::Integer(8)),
+                (
+                    "ColorSpace".to_string(),
+                    ObjectVariant::Name(b"DeviceGray".to_vec()),
+                ),
+            ]))),
+            vec![0],
+        );
+        let resolver = MapResolver {
+            objects: BTreeMap::new(),
+        };
+        let mut cache = DefaultResourceCache::default();
+        let mut cycle_tracker = ReadCycleTracker::default();
+        let mut id_allocator = ContentStreamIdAllocator::new();
+
+        let xobject = XObject::read_xobject(
+            &ObjectVariant::Stream(stream.clone()),
+            &stream.dictionary,
+            &stream,
+            &resolver,
+            &mut cache,
+            &mut cycle_tracker,
+            &mut id_allocator,
+        )
+        .expect("malformed image dimensions should be recoverable")
+        .expect("the unavailable image resource should be preserved");
+
+        assert!(matches!(xobject, XObject::UnavailableImage));
+    }
+
+    #[test]
+    fn image_dimensions_must_be_positive_numbers() {
+        let valid = Dictionary::new(BTreeMap::from([
+            ("Width".to_string(), ObjectVariant::Integer(2)),
+            ("Height".to_string(), ObjectVariant::Integer(3)),
+        ]));
+        let named_width = Dictionary::new(BTreeMap::from([
+            ("Width".to_string(), ObjectVariant::Name(b"Height".to_vec())),
+            ("Height".to_string(), ObjectVariant::Integer(3)),
+        ]));
+        let missing_height = Dictionary::new(BTreeMap::from([(
+            "Width".to_string(),
+            ObjectVariant::Integer(2),
+        )]));
+        let zero_width = Dictionary::new(BTreeMap::from([
+            ("Width".to_string(), ObjectVariant::Integer(0)),
+            ("Height".to_string(), ObjectVariant::Integer(3)),
+        ]));
+        let negative_height = Dictionary::new(BTreeMap::from([
+            ("Width".to_string(), ObjectVariant::Integer(2)),
+            ("Height".to_string(), ObjectVariant::Integer(-1)),
+        ]));
+
+        let resolver = pdf_object::object_resolver::PassthroughResolver;
+        assert!(has_valid_image_dimensions(&valid, &resolver));
+        assert!(!has_valid_image_dimensions(&named_width, &resolver));
+        assert!(!has_valid_image_dimensions(&missing_height, &resolver));
+        assert!(!has_valid_image_dimensions(&zero_width, &resolver));
+        assert!(!has_valid_image_dimensions(&negative_height, &resolver));
     }
 }


### PR DESCRIPTION
Preserve image XObject resource names when Width or Height is missing, non-numeric, or non-positive by representing the image as unavailable. Treat unavailable images as no-ops during rendering and as absent when used as soft masks.

Add resource, canvas, and document regressions for issue4575-style malformed image dictionaries.