### PR TITLE
pdf-canvas: tolerate unmatched graphics state restores

### DIFF
--- a/crates/pdf-canvas/src/canvas_graphics_state_ops.rs
+++ b/crates/pdf-canvas/src/canvas_graphics_state_ops.rs
@@ -18,7 +18,8 @@ impl<B: CanvasBackend> GraphicsStateOps for PdfCanvas<'_, B> {
     }
 
     fn restore_graphics_state(&mut self) -> Result<(), Self::ErrorType> {
-        self.restore()
+        self.restore();
+        Ok(())
     }
 
     fn concat_matrix(&mut self, transform: &Transform) -> Result<(), Self::ErrorType> {

--- a/crates/pdf-canvas/src/error.rs
+++ b/crates/pdf-canvas/src/error.rs
@@ -23,8 +23,6 @@ pub enum PdfCanvasError {
     PatternNotFound(String),
     #[error("Graphics state stack is empty while accessing the current state")]
     EmptyGraphicsStateStack,
-    #[error("Cannot restore graphics state because the stack is already at its base state")]
-    GraphicsStateStackUnderflow,
     #[error("Failed to parse TrueType font data: {0}")]
     TrueTypeFontParse(String),
     #[error("External object (XObject) '{0}' was not found in page resources")]

--- a/crates/pdf-canvas/src/pdf_canvas.rs
+++ b/crates/pdf-canvas/src/pdf_canvas.rs
@@ -653,7 +653,7 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
             op.call(self)?;
         }
 
-        self.restore()?;
+        self.restore();
 
         let _ = self.active_content_stream_ids.remove(&content_stream.id);
         Ok(())
@@ -672,19 +672,19 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
     /// Restores the most recently saved graphics state from the stack.
     ///
     /// If the restored state included a clipping path, the clipping path is reset on the backend.
-    pub(crate) fn restore(&mut self) -> Result<(), PdfCanvasError> {
+    pub(crate) fn restore(&mut self) {
         // Do not allow popping the initial/base graphics state. There is no
-        // corresponding backend `save()` for it, so treating this as an
-        // underflow keeps the canvas stack and backend stack in sync.
+        // corresponding backend `save()` for it, so ignore unmatched restore
+        // operations to keep the canvas stack and backend stack in sync.
         if self.canvas_stack.len() <= 1 {
-            return Err(PdfCanvasError::GraphicsStateStackUnderflow);
+            return;
         }
 
         // At this point there is at least one saved state beyond the base,
         // so popping is safe and has a matching backend `save()`.
         let _ = self.canvas_stack.pop();
 
-        self.canvas.restore()
+        let _ = self.canvas.restore();
     }
 
     /// Sets the current color space for stroking or filling operations.

--- a/crates/pdf-canvas/src/shading.rs
+++ b/crates/pdf-canvas/src/shading.rs
@@ -34,6 +34,7 @@ impl<B: CanvasBackend> ShadingOps for PdfCanvas<'_, B> {
             blend_mode,
         )?;
 
-        self.restore()
+        self.restore();
+        Ok(())
     }
 }

--- a/crates/pdf-canvas/tests/canvas_graphics_state_ops.rs
+++ b/crates/pdf-canvas/tests/canvas_graphics_state_ops.rs
@@ -41,6 +41,18 @@ fn graphics_state_resource(params: Vec<ExternalGraphicsStateKey>) -> Resources {
 }
 
 #[test]
+fn unmatched_restore_graphics_state_is_ignored() {
+    let resources = Resources::default();
+    let stream = content_stream(1, b"Q q Q Q");
+
+    let recording = render(&stream, &resources).expect("unmatched restores should be ignored");
+
+    let observer = replay(&recording);
+    assert_eq!(observer.save_count, 2);
+    assert_eq!(observer.restore_count, 2);
+}
+
+#[test]
 fn external_graphics_state_dash_pattern_is_used_for_strokes() {
     let resources = graphics_state_resource(vec![ExternalGraphicsStateKey::DashPattern(
         DashPattern::new(&[3.0, 1.0], 2.0)


### PR DESCRIPTION
Ignore restore operators when the canvas stack is already at its base state. This allows malformed PDFs with unmatched Q operators to keep rendering without disturbing the backend graphics state.