### PR TITLE
pdf-canvas: share image pixels with Arc

### DIFF
--- a/crates/pdf-annotation-form/tests/form.rs
+++ b/crates/pdf-annotation-form/tests/form.rs
@@ -145,7 +145,7 @@ impl CanvasBackend for CountingCanvas {
 
     fn draw_image_rect(
         &mut self,
-        _image: &Image<'_>,
+        _image: &Image,
         _blend_mode: Option<BlendMode>,
         _dest_rect: Rect,
         _image_rotation: Option<f32>,

--- a/crates/pdf-annotations/tests/render.rs
+++ b/crates/pdf-annotations/tests/render.rs
@@ -78,7 +78,7 @@ impl CanvasBackend for CountingCanvas {
 
     fn draw_image_rect(
         &mut self,
-        _image: &Image<'_>,
+        _image: &Image,
         _blend_mode: Option<BlendMode>,
         _dest_rect: Rect,
         _image_rotation: Option<f32>,

--- a/crates/pdf-canvas/src/canvas_backend.rs
+++ b/crates/pdf-canvas/src/canvas_backend.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-use std::ops::Deref;
 use std::sync::Arc;
 
 use pdf_graphics::{
@@ -9,56 +7,6 @@ use pdf_graphics::{
 use pdf_shading::paint::ShadingPaint;
 
 use crate::{error::PdfCanvasError, recording_canvas::RecordingCanvas, stroke_style::StrokeStyle};
-
-/// Image data storage that supports zero-copy sharing via `Arc`.
-///
-/// `ImageData` replaces `Cow<'a, [u8]>` for image pixel buffers, adding
-/// a `Shared` variant backed by `Arc<[u8]>`. Once an image is recorded,
-/// all subsequent clones of the recording share the same allocation
-/// instead of deep-copying the pixel buffer.
-#[derive(Clone)]
-pub enum ImageData<'a> {
-    /// Borrowed pixel data (zero-copy reference into an existing buffer).
-    Borrowed(&'a [u8]),
-    /// Owned pixel data (unique allocation).
-    Owned(Vec<u8>),
-    /// Reference-counted pixel data shared across recordings.
-    Shared(Arc<[u8]>),
-}
-
-impl Deref for ImageData<'_> {
-    type Target = [u8];
-
-    fn deref(&self) -> &[u8] {
-        match self {
-            ImageData::Borrowed(b) => b,
-            ImageData::Owned(v) => v,
-            ImageData::Shared(a) => a,
-        }
-    }
-}
-
-impl ImageData<'_> {
-    /// Returns a `Shared` variant that can be cheaply cloned.
-    ///
-    /// - `Borrowed` / `Owned`: copies the data into a new `Arc<[u8]>` once.
-    /// - `Shared`: bumps the reference count (no copy).
-    pub fn to_shared(&self) -> ImageData<'static> {
-        match self {
-            ImageData::Shared(a) => ImageData::Shared(Arc::clone(a)),
-            other => ImageData::Shared(Arc::from(&**other)),
-        }
-    }
-}
-
-impl<'a> From<Cow<'a, [u8]>> for ImageData<'a> {
-    fn from(cow: Cow<'a, [u8]>) -> Self {
-        match cow {
-            Cow::Borrowed(b) => ImageData::Borrowed(b),
-            Cow::Owned(v) => ImageData::Owned(v),
-        }
-    }
-}
 
 /// Represents a shader used for advanced fill and stroke operations in PDF rendering.
 #[derive(Clone)]
@@ -85,9 +33,9 @@ pub enum Shader<'a> {
 /// The `Image` struct encapsulates raw image data, dimensions, encoding, and optional
 /// transformation or masking information.
 #[derive(Clone)]
-pub struct Image<'a> {
-    /// The raw image data.
-    pub data: ImageData<'a>,
+pub struct Image {
+    /// Shared raw image data.
+    pub data: Arc<[u8]>,
     /// The width of the image in pixels.
     pub width: usize,
     /// The height of the image in pixels.
@@ -173,7 +121,7 @@ pub trait CanvasBackend {
     /// - `image_rotation`: An optional rotation (in degrees) to apply to the image.
     fn draw_image_rect(
         &mut self,
-        image: &Image<'_>,
+        image: &Image,
         blend_mode: Option<BlendMode>,
         dest_rect: Rect,
         image_rotation: Option<f32>,
@@ -184,7 +132,7 @@ pub trait CanvasBackend {
     /// The default implementation forwards to [`CanvasBackend::draw_image_rect`].
     fn draw_inline_image(
         &mut self,
-        image: &Image<'_>,
+        image: &Image,
         blend_mode: Option<BlendMode>,
         dest_rect: Rect,
         image_rotation: Option<f32>,

--- a/crates/pdf-canvas/src/canvas_external_object_ops.rs
+++ b/crates/pdf-canvas/src/canvas_external_object_ops.rs
@@ -8,6 +8,8 @@
 //! between PDF image space (top-left origin, Y down) and PDF user space
 //! (bottom-left origin, Y up).
 
+use std::sync::Arc;
+
 use pdf_content_stream_operators::pdf_operator_backend::XObjectOps;
 use pdf_graphics::{rect::Rect, transform::Transform};
 use pdf_image::{ImageXObject, InlineImage};
@@ -15,7 +17,7 @@ use pdf_object::object_resolver::PassthroughResolver;
 use pdf_resources::xobject::XObject;
 
 use crate::{
-    canvas_backend::{CanvasBackend, Image, ImageData},
+    canvas_backend::{CanvasBackend, Image},
     error::PdfCanvasError,
     pdf_canvas::PdfCanvas,
 };
@@ -127,7 +129,7 @@ impl<B: CanvasBackend> PdfCanvas<'_, B> {
         let dest_rect = Self::compute_destination_rect(&transform, rotation_degrees);
 
         let rendered_image = Image {
-            data: ImageData::Owned(image.data.clone()),
+            data: Arc::clone(&image.data),
             width: image.width,
             height: image.height,
             pixel_format: image.pixel_format,

--- a/crates/pdf-canvas/src/recording_canvas.rs
+++ b/crates/pdf-canvas/src/recording_canvas.rs
@@ -35,13 +35,13 @@ enum RecordingCommand {
     Save,
     Restore,
     DrawImage {
-        image: BackendImage<'static>,
+        image: BackendImage,
         blend_mode: Option<BlendMode>,
         dest_rect: Rect,
         image_rotation: Option<f32>,
     },
     DrawInlineImage {
-        image: BackendImage<'static>,
+        image: BackendImage,
         blend_mode: Option<BlendMode>,
         dest_rect: Rect,
         image_rotation: Option<f32>,
@@ -261,18 +261,13 @@ impl CanvasBackend for RecordingCanvas {
 
     fn draw_image_rect(
         &mut self,
-        image: &BackendImage<'_>,
+        image: &BackendImage,
         blend_mode: Option<BlendMode>,
         dest_rect: Rect,
         image_rotation: Option<f32>,
     ) -> Result<(), PdfCanvasError> {
         self.commands.push(RecordingCommand::DrawImage {
-            image: BackendImage {
-                data: image.data.to_shared(),
-                width: image.width,
-                height: image.height,
-                pixel_format: image.pixel_format,
-            },
+            image: image.clone(),
             blend_mode,
             dest_rect,
             image_rotation,
@@ -282,18 +277,13 @@ impl CanvasBackend for RecordingCanvas {
 
     fn draw_inline_image(
         &mut self,
-        image: &BackendImage<'_>,
+        image: &BackendImage,
         blend_mode: Option<BlendMode>,
         dest_rect: Rect,
         image_rotation: Option<f32>,
     ) -> Result<(), PdfCanvasError> {
         self.commands.push(RecordingCommand::DrawInlineImage {
-            image: BackendImage {
-                data: image.data.to_shared(),
-                width: image.width,
-                height: image.height,
-                pixel_format: image.pixel_format,
-            },
+            image: image.clone(),
             blend_mode,
             dest_rect,
             image_rotation,
@@ -327,5 +317,36 @@ impl CanvasBackend for RecordingCanvas {
             mask: Arc::clone(mask),
         });
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pdf_graphics::PixelFormat;
+
+    use super::*;
+
+    #[test]
+    fn recorded_image_shares_pixel_data() {
+        let data: Arc<[u8]> = vec![1, 2, 3, 4].into();
+        let image = BackendImage {
+            data: Arc::clone(&data),
+            width: 1,
+            height: 1,
+            pixel_format: PixelFormat::RGBA8888,
+        };
+        let mut canvas = RecordingCanvas::new(1.0, 1.0);
+
+        canvas
+            .draw_image_rect(&image, None, Rect::UNIT_RECT, None)
+            .expect("image should be recorded");
+
+        assert!(canvas.commands.iter().any(|command| {
+            matches!(
+                command,
+                RecordingCommand::DrawImage { image, .. }
+                    if Arc::ptr_eq(&image.data, &data)
+            )
+        }));
     }
 }

--- a/crates/pdf-canvas/tests/common/mod.rs
+++ b/crates/pdf-canvas/tests/common/mod.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::arithmetic_side_effects, clippy::expect_used)]
 
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use pdf_canvas::{
     canvas_backend::{CanvasBackend, Image, Shader},
@@ -42,13 +42,13 @@ pub struct ObservingCanvas {
 
 impl ObservingCanvas {
     fn observed_image(
-        image: &Image<'_>,
+        image: &Image,
         blend_mode: Option<BlendMode>,
         dest_rect: Rect,
         image_rotation: Option<f32>,
     ) -> ObservedImage {
         ObservedImage {
-            data: image.data.deref().to_vec(),
+            data: image.data.to_vec(),
             width: image.width,
             height: image.height,
             pixel_format: image.pixel_format,
@@ -113,7 +113,7 @@ impl CanvasBackend for ObservingCanvas {
 
     fn draw_image_rect(
         &mut self,
-        image: &Image<'_>,
+        image: &Image,
         blend_mode: Option<BlendMode>,
         dest_rect: Rect,
         image_rotation: Option<f32>,
@@ -129,7 +129,7 @@ impl CanvasBackend for ObservingCanvas {
 
     fn draw_inline_image(
         &mut self,
-        image: &Image<'_>,
+        image: &Image,
         blend_mode: Option<BlendMode>,
         dest_rect: Rect,
         image_rotation: Option<f32>,

--- a/crates/pdf-graphics-femtovg/src/femtovg_canvas_backend.rs
+++ b/crates/pdf-graphics-femtovg/src/femtovg_canvas_backend.rs
@@ -119,7 +119,7 @@ impl CanvasBackend for CanvasImpl<'_> {
 
     fn draw_image_rect(
         &mut self,
-        _image: &Image<'_>,
+        _image: &Image,
         _blend_mode: Option<BlendMode>,
         _dest_rect: pdf_graphics::rect::Rect,
         _image_rotation: Option<f32>,

--- a/crates/pdf-graphics-skia/src/skia_canvas_backend.rs
+++ b/crates/pdf-graphics-skia/src/skia_canvas_backend.rs
@@ -97,7 +97,7 @@ fn to_skia_a8_mask_image(
 /// # Returns
 ///
 /// - A Skia `Image` ready to be drawn with `draw_image`/`draw_image_rect`.
-fn to_skia_image(image: &Image<'_>) -> Result<skia_safe::Image, PdfCanvasError> {
+fn to_skia_image(image: &Image) -> Result<skia_safe::Image, PdfCanvasError> {
     let width = image.width;
     let height = image.height;
     let pixel_format = image.pixel_format;
@@ -317,7 +317,7 @@ fn to_skia_shader(shader: &Shader) -> Result<skia_safe::Shader, PdfCanvasError> 
             transform,
         }) => {
             let image = to_skia_image(&Image {
-                data: pixels.clone().into(),
+                data: Arc::clone(pixels),
                 width: *width,
                 height: *height,
                 pixel_format: PixelFormat::RGBA8888,
@@ -461,7 +461,7 @@ impl CanvasBackend for SkiaCanvasBackend<'_> {
 
     fn draw_image_rect(
         &mut self,
-        image: &Image<'_>,
+        image: &Image,
         blend_mode: Option<BlendMode>,
         dest_rect: pdf_graphics::rect::Rect,
         image_rotation: Option<f32>,

--- a/crates/pdf-image/src/image_xobject.rs
+++ b/crates/pdf-image/src/image_xobject.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pdf_color_space::{color_space::ColorSpace, indexed_color_space::IndexedColorSpace};
 use pdf_decode::{DecodeMap, SampleLayout, decode_sample_bytes};
 use pdf_filter::filter::{Filter, decode_data_with_resolver, decode_with_resolver};
@@ -20,8 +22,8 @@ pub struct ImageXObject {
     pub height: usize,
     /// The number of bits used to represent each color component.
     pub bits_per_component: usize,
-    /// The raw image stream data (with soft mask alpha applied if present).
-    pub data: Vec<u8>,
+    /// The shared image stream data (with soft mask alpha applied if present).
+    pub data: Arc<[u8]>,
     /// The pixel format of the image data.
     pub pixel_format: PixelFormat,
     /// The color space of the image samples.
@@ -103,7 +105,7 @@ impl ImageXObject {
             width: metadata.width,
             height: metadata.height,
             bits_per_component: decoded_samples.bits_per_component,
-            data,
+            data: data.into(),
             pixel_format,
             color_space: decoded_samples.stored_color_space,
         })
@@ -519,7 +521,7 @@ impl ImageXObject {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, sync::Arc};
 
     use pdf_object::{
         dictionary::Dictionary, error::ObjectError, object_resolver::PassthroughResolver,
@@ -528,6 +530,23 @@ mod tests {
 
     use super::{ImageXObject, InlineImage};
     use crate::error::PdfImageError;
+
+    #[test]
+    fn cloned_image_xobject_shares_data() {
+        let data: Arc<[u8]> = vec![1, 2, 3, 4].into();
+        let image = ImageXObject {
+            width: 1,
+            height: 1,
+            bits_per_component: 8,
+            data: Arc::clone(&data),
+            pixel_format: pdf_graphics::PixelFormat::RGBA8888,
+            color_space: None,
+        };
+
+        let cloned = image.clone();
+
+        assert!(Arc::ptr_eq(&cloned.data, &data));
+    }
 
     #[test]
     fn decode_normalized_1bpc_gray_inverts_samples() {
@@ -554,7 +573,7 @@ mod tests {
         .expect("1-bpc decoded grayscale image should decode");
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::Gray8);
-        assert_eq!(image.data, vec![0x00, 0xFF, 0x00, 0xFF]);
+        assert_eq!(image.data.as_ref(), &[0x00, 0xFF, 0x00, 0xFF]);
     }
 
     #[test]
@@ -582,7 +601,7 @@ mod tests {
         .expect("8-bpc decoded grayscale image should decode");
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::Gray8);
-        assert_eq!(image.data, vec![0x00, 0x80]);
+        assert_eq!(image.data.as_ref(), &[0x00, 0x80]);
     }
 
     #[test]
@@ -615,7 +634,7 @@ mod tests {
         .expect("decoded indexed image should decode");
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
-        assert_eq!(image.data, vec![10, 11, 12, 255, 20, 21, 22, 255]);
+        assert_eq!(image.data.as_ref(), &[10, 11, 12, 255, 20, 21, 22, 255]);
     }
 
     #[test]
@@ -668,7 +687,7 @@ mod tests {
         .expect("grayscale image without /Decode should decode");
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::Gray8);
-        assert_eq!(image.data, vec![12, 34]);
+        assert_eq!(image.data.as_ref(), &[12, 34]);
     }
 
     #[test]
@@ -688,9 +707,9 @@ mod tests {
         .expect("image masks should default missing BitsPerComponent to 1");
 
         assert_eq!(image.bits_per_component, 1);
-        assert!(matches!(image.color_space, None));
+        assert!(image.color_space.is_none());
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::Gray8);
-        assert_eq!(image.data, vec![0x00, 0xFF, 0x00, 0xFF]);
+        assert_eq!(image.data.as_ref(), &[0x00, 0xFF, 0x00, 0xFF]);
     }
 
     #[test]
@@ -718,7 +737,7 @@ mod tests {
             Some(pdf_color_space::color_space::ColorSpace::DeviceRGB)
         ));
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
-        assert_eq!(image.data, vec![1, 2, 3, 255, 4, 5, 6, 255]);
+        assert_eq!(image.data.as_ref(), &[1, 2, 3, 255, 4, 5, 6, 255]);
     }
 
     #[test]
@@ -767,7 +786,7 @@ mod tests {
         .expect("DCT-decoded RGB bytes should not be validated as CMYK samples");
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
-        assert_eq!(image.data, vec![10, 20, 30, 255, 40, 50, 60, 255]);
+        assert_eq!(image.data.as_ref(), &[10, 20, 30, 255, 40, 50, 60, 255]);
         assert!(matches!(
             image.color_space,
             Some(pdf_color_space::color_space::ColorSpace::DeviceRGB)
@@ -829,8 +848,8 @@ mod tests {
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
         assert_eq!(
-            image.data,
-            vec![0xAA, 0x10, 0x20, 255, 0xAA, 0x10, 0x20, 255]
+            image.data.as_ref(),
+            &[0xAA, 0x10, 0x20, 255, 0xAA, 0x10, 0x20, 255]
         );
         assert!(matches!(
             image.color_space,
@@ -853,7 +872,7 @@ mod tests {
             width: 2,
             height: 1,
             bits_per_component: 8,
-            data: vec![0x10, 0xE0],
+            data: vec![0x10, 0xE0].into(),
             pixel_format: pdf_graphics::PixelFormat::Gray8,
             color_space: None,
         };
@@ -868,8 +887,8 @@ mod tests {
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
         assert_eq!(
-            image.data,
-            vec![0x20, 0x20, 0x20, 0x10, 0xC0, 0xC0, 0xC0, 0xE0]
+            image.data.as_ref(),
+            &[0x20, 0x20, 0x20, 0x10, 0xC0, 0xC0, 0xC0, 0xE0]
         );
     }
 
@@ -896,7 +915,7 @@ mod tests {
             .expect("inline image should decode");
 
         assert_eq!(decoded.pixel_format, pdf_graphics::PixelFormat::Gray8);
-        assert_eq!(decoded.data, vec![0x2A]);
+        assert_eq!(decoded.data.as_ref(), &[0x2A]);
     }
 
     #[test]
@@ -915,7 +934,7 @@ mod tests {
             .expect("inline image with abbreviated gray color space should decode");
 
         assert_eq!(decoded.pixel_format, pdf_graphics::PixelFormat::Gray8);
-        assert_eq!(decoded.data, vec![0xFF, 0x00, 0xFF, 0x00]);
+        assert_eq!(decoded.data.as_ref(), &[0xFF, 0x00, 0xFF, 0x00]);
     }
 
     #[test]
@@ -943,8 +962,8 @@ mod tests {
 
         assert_eq!(decoded.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
         assert_eq!(
-            decoded.data,
-            vec![
+            decoded.data.as_ref(),
+            &[
                 20, 21, 22, 255, 10, 11, 12, 255, 20, 21, 22, 255, 10, 11, 12, 255
             ]
         );
@@ -972,8 +991,8 @@ mod tests {
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::Gray8);
         assert_eq!(
-            image.data,
-            vec![0xFF, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0x00]
+            image.data.as_ref(),
+            &[0xFF, 0x00, 0xFF, 0xFF, 0x00, 0x00, 0xFF, 0x00]
         );
     }
 
@@ -990,8 +1009,8 @@ mod tests {
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
         assert_eq!(
-            image.data,
-            vec![
+            image.data.as_ref(),
+            &[
                 20, 21, 22, 255, 10, 11, 12, 255, 20, 21, 22, 255, 10, 11, 12, 255
             ]
         );
@@ -1006,8 +1025,8 @@ mod tests {
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
         assert_eq!(
-            image.data,
-            vec![
+            image.data.as_ref(),
+            &[
                 10, 11, 12, 255, 20, 21, 22, 255, 30, 31, 32, 255, 40, 41, 42, 255,
             ]
         );
@@ -1026,8 +1045,8 @@ mod tests {
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
         assert_eq!(
-            image.data,
-            vec![
+            image.data.as_ref(),
+            &[
                 10, 11, 12, 255, 20, 21, 22, 255, 30, 31, 32, 255, 40, 41, 42, 255
             ]
         );
@@ -1046,8 +1065,8 @@ mod tests {
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
         assert_eq!(
-            image.data,
-            vec![
+            image.data.as_ref(),
+            &[
                 10, 11, 12, 255, 20, 21, 22, 255, 30, 31, 32, 255, 40, 41, 42, 255
             ]
         );

--- a/crates/pdf-renderer/src/lib.rs
+++ b/crates/pdf-renderer/src/lib.rs
@@ -215,7 +215,7 @@ impl CanvasBackend for NoopCanvasBackend {
 
     fn draw_image_rect(
         &mut self,
-        _image: &Image<'_>,
+        _image: &Image,
         _blend_mode: Option<BlendMode>,
         _dest_rect: Rect,
         _image_rotation: Option<f32>,

--- a/crates/pdf-resources/src/xobject.rs
+++ b/crates/pdf-resources/src/xobject.rs
@@ -212,7 +212,7 @@ mod tests {
             assert_eq!(image.width, 1);
             assert_eq!(image.height, 1);
             assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::Gray8);
-            assert_eq!(image.data, vec![0xAA]);
+            assert_eq!(image.data.as_ref(), &[0xAA]);
         }
     }
 
@@ -281,8 +281,8 @@ mod tests {
             XObject::Image(image) => {
                 assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
                 assert_eq!(
-                    image.data,
-                    vec![0x20, 0x20, 0x20, 0x10, 0xC0, 0xC0, 0xC0, 0xE0]
+                    image.data.as_ref(),
+                    &[0x20, 0x20, 0x20, 0x10, 0xC0, 0xC0, 0xC0, 0xE0]
                 );
             }
             XObject::UnavailableImage => panic!("expected a decoded image xobject"),

--- a/crates/pdf-shading/src/paint.rs
+++ b/crates/pdf-shading/src/paint.rs
@@ -1,6 +1,6 @@
 //! Backend-facing shading paint descriptions and builders.
 
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 use pdf_graphics::{color::Color, rect::Rect, transform::Transform};
 
@@ -53,8 +53,8 @@ pub enum ShadingPaint<'a> {
     },
     /// A rasterized mesh shading paint.
     RasterImage {
-        /// RGBA8 image data for the rasterized shading.
-        pixels: Cow<'a, [u8]>,
+        /// Shared RGBA8 image data for the rasterized shading.
+        pixels: Arc<[u8]>,
         /// Raster width in pixels.
         width: usize,
         /// Raster height in pixels.
@@ -115,7 +115,7 @@ impl<'a> ShadingPaint<'a> {
                 dest_rect,
                 transform,
             } => ShadingPaint::RasterImage {
-                pixels: Cow::Owned(pixels.to_vec()),
+                pixels: Arc::clone(pixels),
                 width: *width,
                 height: *height,
                 dest_rect: *dest_rect,
@@ -191,7 +191,7 @@ pub fn build_shading_paint<'a>(
             );
 
             Ok(ShadingPaint::RasterImage {
-                pixels: Cow::Owned(raster.pixels),
+                pixels: raster.pixels.into(),
                 width: raster.width,
                 height: raster.height,
                 dest_rect: raster.bounds,
@@ -201,5 +201,32 @@ pub fn build_shading_paint<'a>(
         Shading::Unsupported { name } => Err(PdfShadingError::UnsupportedFeature(format!(
             "Shading type '{name}' not implemented"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raster_image_to_static_shares_pixels() {
+        let pixels: Arc<[u8]> = vec![1, 2, 3, 4].into();
+        let paint = ShadingPaint::RasterImage {
+            pixels: Arc::clone(&pixels),
+            width: 1,
+            height: 1,
+            dest_rect: Rect::UNIT_RECT,
+            transform: None,
+        };
+
+        let static_paint = paint.to_static();
+        assert!(matches!(&static_paint, ShadingPaint::RasterImage { .. }));
+        if let ShadingPaint::RasterImage {
+            pixels: static_pixels,
+            ..
+        } = static_paint
+        {
+            assert!(Arc::ptr_eq(&static_pixels, &pixels));
+        }
     }
 }


### PR DESCRIPTION
Store canvas, image XObject, and raster shading pixels in Arc-backed slices so resource and recording clones reuse the same allocations.

Remove the ImageData ownership enum and the lifetime from the canvas Image type. Update backends and test implementations for the shared-only API, with regressions covering allocation reuse.