### PR TITLE
pdf-shading: share gradient stops with Arc

### DIFF
--- a/crates/pdf-canvas/src/canvas_backend.rs
+++ b/crates/pdf-canvas/src/canvas_backend.rs
@@ -10,9 +10,9 @@ use crate::{error::PdfCanvasError, recording_canvas::RecordingCanvas, stroke_sty
 
 /// Represents a shader used for advanced fill and stroke operations in PDF rendering.
 #[derive(Clone)]
-pub enum Shader<'a> {
+pub enum Shader {
     /// A shading-backed shader such as an axial gradient, radial gradient, or mesh raster.
-    Shading(ShadingPaint<'a>),
+    Shading(ShadingPaint),
     /// Represents a tiling pattern image shader for filling or stroking paths with a repeated image.
     ///
     /// Used to define how an image is tiled across a region, with optional transformation and spacing.

--- a/crates/pdf-canvas/src/pdf_canvas.rs
+++ b/crates/pdf-canvas/src/pdf_canvas.rs
@@ -267,11 +267,11 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
     /// # Returns
     ///
     /// An appropriate `Shader` if supported, or an error if not implemented.
-    pub(crate) fn build_shading_shader<'b>(
+    pub(crate) fn build_shading_shader(
         &mut self,
-        shading: &'b Shading,
+        shading: &Shading,
         transform: &Option<Transform>,
-    ) -> Result<Shader<'b>, PdfCanvasError> {
+    ) -> Result<Shader, PdfCanvasError> {
         build_shading_paint(shading, *transform)
             .map(Shader::Shading)
             .map_err(|error| PdfCanvasError::UnsupportedFeature(error.to_string()))
@@ -282,7 +282,7 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
     /// # Returns
     ///
     /// An optional `Shader` or an error if pattern rendering fails.
-    fn compute_shader(&mut self, for_stroke: bool) -> Result<Option<Shader<'a>>, PdfCanvasError> {
+    fn compute_shader(&mut self, for_stroke: bool) -> Result<Option<Shader>, PdfCanvasError> {
         let state: &CanvasState<'_> = self.current_state()?;
         let pattern = if for_stroke {
             &state.stroke_pattern

--- a/crates/pdf-canvas/src/recording_canvas.rs
+++ b/crates/pdf-canvas/src/recording_canvas.rs
@@ -17,7 +17,7 @@ enum RecordingCommand {
         path: PdfPath,
         fill_type: PathFillType,
         color: Color,
-        shader: Option<Shader<'static>>,
+        shader: Option<Shader>,
         blend_mode: Option<BlendMode>,
     },
     StrokePath {
@@ -25,7 +25,7 @@ enum RecordingCommand {
         color: Color,
         line_width: f32,
         stroke_style: StrokeStyle,
-        shader: Option<Shader<'static>>,
+        shader: Option<Shader>,
         blend_mode: Option<BlendMode>,
     },
     SetClipRegion {
@@ -71,28 +71,6 @@ pub struct RecordingCanvas {
     pub height: f32,
     /// Ordered list of recorded drawing commands.
     commands: Vec<RecordingCommand>,
-}
-
-impl<'a> Shader<'a> {
-    /// Converts this shader into a `Shader<'static>` by performing a deep clone
-    /// of all borrowed data into owned storage. This is useful for storing
-    /// shaders in recording commands that must outlive the original borrow.
-    fn to_static(&self) -> Shader<'static> {
-        match self {
-            Shader::Shading(shading) => Shader::Shading(shading.to_static()),
-            Shader::TilingPatternImage {
-                image,
-                transform,
-                x_step,
-                y_step,
-            } => Shader::TilingPatternImage {
-                image: Arc::clone(image),
-                transform: *transform,
-                x_step: *x_step,
-                y_step: *y_step,
-            },
-        }
-    }
 }
 
 impl RecordingCanvas {
@@ -203,7 +181,7 @@ impl CanvasBackend for RecordingCanvas {
             path: path.clone(),
             fill_type,
             color,
-            shader: shader.as_ref().map(|s| s.to_static()),
+            shader: shader.clone(),
             blend_mode,
         });
         Ok(())
@@ -223,7 +201,7 @@ impl CanvasBackend for RecordingCanvas {
             color,
             line_width,
             stroke_style: stroke_style.clone(),
-            shader: shader.as_ref().map(|s| s.to_static()),
+            shader: shader.clone(),
             blend_mode,
         });
         Ok(())
@@ -323,6 +301,7 @@ impl CanvasBackend for RecordingCanvas {
 #[cfg(test)]
 mod tests {
     use pdf_graphics::PixelFormat;
+    use pdf_shading::paint::ShadingPaint;
 
     use super::*;
 
@@ -348,5 +327,54 @@ mod tests {
                     if Arc::ptr_eq(&image.data, &data)
             )
         }));
+    }
+
+    #[test]
+    fn recorded_gradient_and_canvas_clone_share_color_stops() {
+        let colors: Arc<[Color]> = [
+            Color::from_rgb(0.0, 0.0, 0.0),
+            Color::from_rgb(1.0, 1.0, 1.0),
+        ]
+        .into();
+        let positions: Arc<[f32]> = [0.0, 1.0].into();
+        let shader = Some(Shader::Shading(ShadingPaint::LinearGradient {
+            x0: 0.0,
+            y0: 0.0,
+            x1: 1.0,
+            y1: 1.0,
+            transform: None,
+            colors: Arc::clone(&colors),
+            positions: Arc::clone(&positions),
+        }));
+        let mut canvas = RecordingCanvas::new(1.0, 1.0);
+
+        canvas
+            .fill_path(
+                &PdfPath::default(),
+                PathFillType::Winding,
+                Color::from_rgb(0.0, 0.0, 0.0),
+                &shader,
+                None,
+            )
+            .expect("gradient should be recorded");
+        let cloned_canvas = canvas.clone();
+
+        for recording in [&canvas, &cloned_canvas] {
+            assert!(recording.commands.iter().any(|command| {
+                matches!(
+                    command,
+                    RecordingCommand::FillPath {
+                        shader:
+                            Some(Shader::Shading(ShadingPaint::LinearGradient {
+                                colors: recorded_colors,
+                                positions: recorded_positions,
+                                ..
+                            })),
+                        ..
+                    } if Arc::ptr_eq(recorded_colors, &colors)
+                        && Arc::ptr_eq(recorded_positions, &positions)
+                )
+            }));
+        }
     }
 }

--- a/crates/pdf-shading/src/color_stops.rs
+++ b/crates/pdf-shading/src/color_stops.rs
@@ -1,5 +1,7 @@
 //! Color-stop sampling helpers for PDF shadings.
 
+use std::sync::Arc;
+
 use pdf_color_space::color_space::ColorSpace;
 use pdf_function::function::{Function, FunctionImpl};
 use pdf_graphics::color::Color;
@@ -13,9 +15,9 @@ const DEFAULT_DOMAIN: [f32; 2] = [0.0, 1.0];
 #[derive(Debug, Clone, Default)]
 pub struct ColorStops {
     /// The colors at each stop position.
-    pub colors: Vec<Color>,
+    pub colors: Arc<[Color]>,
     /// The normalized stop positions in the inclusive `0.0..=1.0` range.
-    pub positions: Vec<f32>,
+    pub positions: Arc<[f32]>,
 }
 
 impl ColorStops {
@@ -47,7 +49,10 @@ impl ColorStops {
             colors.push(color);
         }
 
-        Ok(Self { colors, positions })
+        Ok(Self {
+            colors: colors.into(),
+            positions: positions.into(),
+        })
     }
 }
 

--- a/crates/pdf-shading/src/paint.rs
+++ b/crates/pdf-shading/src/paint.rs
@@ -1,6 +1,6 @@
 //! Backend-facing shading paint descriptions and builders.
 
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 use pdf_graphics::{color::Color, rect::Rect, transform::Transform};
 
@@ -12,7 +12,7 @@ use crate::{
 
 /// A backend-ready representation of a parsed PDF shading.
 #[derive(Clone)]
-pub enum ShadingPaint<'a> {
+pub enum ShadingPaint {
     /// A linear gradient shading paint.
     LinearGradient {
         /// Gradient start point x-coordinate.
@@ -26,9 +26,9 @@ pub enum ShadingPaint<'a> {
         /// Optional transform mapping shading space into device space.
         transform: Option<Transform>,
         /// Gradient colors.
-        colors: Cow<'a, [Color]>,
+        colors: Arc<[Color]>,
         /// Gradient stop positions.
-        positions: Cow<'a, [f32]>,
+        positions: Arc<[f32]>,
     },
     /// A radial gradient shading paint.
     RadialGradient {
@@ -45,9 +45,9 @@ pub enum ShadingPaint<'a> {
         /// End circle radius.
         end_r: f32,
         /// Gradient colors.
-        colors: Cow<'a, [Color]>,
+        colors: Arc<[Color]>,
         /// Gradient stop positions.
-        positions: Cow<'a, [f32]>,
+        positions: Arc<[f32]>,
         /// Optional transform mapping shading space into device space.
         transform: Option<Transform>,
     },
@@ -66,70 +66,11 @@ pub enum ShadingPaint<'a> {
     },
 }
 
-impl<'a> ShadingPaint<'a> {
-    /// Converts this shading paint into an owned `'static` value.
-    pub fn to_static(&self) -> ShadingPaint<'static> {
-        match self {
-            Self::LinearGradient {
-                x0,
-                y0,
-                x1,
-                y1,
-                transform,
-                colors,
-                positions,
-            } => ShadingPaint::LinearGradient {
-                x0: *x0,
-                y0: *y0,
-                x1: *x1,
-                y1: *y1,
-                transform: *transform,
-                colors: Cow::Owned(colors.to_vec()),
-                positions: Cow::Owned(positions.to_vec()),
-            },
-            Self::RadialGradient {
-                start_x,
-                start_y,
-                start_r,
-                end_x,
-                end_y,
-                end_r,
-                colors,
-                positions,
-                transform,
-            } => ShadingPaint::RadialGradient {
-                start_x: *start_x,
-                start_y: *start_y,
-                start_r: *start_r,
-                end_x: *end_x,
-                end_y: *end_y,
-                end_r: *end_r,
-                colors: Cow::Owned(colors.to_vec()),
-                positions: Cow::Owned(positions.to_vec()),
-                transform: *transform,
-            },
-            Self::RasterImage {
-                pixels,
-                width,
-                height,
-                dest_rect,
-                transform,
-            } => ShadingPaint::RasterImage {
-                pixels: Arc::clone(pixels),
-                width: *width,
-                height: *height,
-                dest_rect: *dest_rect,
-                transform: *transform,
-            },
-        }
-    }
-}
-
 /// Builds backend-facing paint data for a parsed shading and optional transform.
-pub fn build_shading_paint<'a>(
-    shading: &'a Shading,
+pub fn build_shading_paint(
+    shading: &Shading,
     transform: Option<Transform>,
-) -> Result<ShadingPaint<'a>, PdfShadingError> {
+) -> Result<ShadingPaint, PdfShadingError> {
     match shading {
         Shading::Axial {
             coords: [x0, y0, x1, y1],
@@ -140,8 +81,8 @@ pub fn build_shading_paint<'a>(
             y0: *y0,
             x1: *x1,
             y1: *y1,
-            colors: Cow::Borrowed(&color_stops.colors),
-            positions: Cow::Borrowed(&color_stops.positions),
+            colors: Arc::clone(&color_stops.colors),
+            positions: Arc::clone(&color_stops.positions),
             transform,
         }),
         Shading::Radial {
@@ -155,8 +96,8 @@ pub fn build_shading_paint<'a>(
             end_x: *end_x,
             end_y: *end_y,
             end_r: *end_r,
-            colors: Cow::Borrowed(&color_stops.colors),
-            positions: Cow::Borrowed(&color_stops.positions),
+            colors: Arc::clone(&color_stops.colors),
+            positions: Arc::clone(&color_stops.positions),
             transform,
         }),
         Shading::FunctionBased { .. } => Err(PdfShadingError::UnsupportedFeature(
@@ -201,32 +142,5 @@ pub fn build_shading_paint<'a>(
         Shading::Unsupported { name } => Err(PdfShadingError::UnsupportedFeature(format!(
             "Shading type '{name}' not implemented"
         ))),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn raster_image_to_static_shares_pixels() {
-        let pixels: Arc<[u8]> = vec![1, 2, 3, 4].into();
-        let paint = ShadingPaint::RasterImage {
-            pixels: Arc::clone(&pixels),
-            width: 1,
-            height: 1,
-            dest_rect: Rect::UNIT_RECT,
-            transform: None,
-        };
-
-        let static_paint = paint.to_static();
-        assert!(matches!(&static_paint, ShadingPaint::RasterImage { .. }));
-        if let ShadingPaint::RasterImage {
-            pixels: static_pixels,
-            ..
-        } = static_paint
-        {
-            assert!(Arc::ptr_eq(&static_pixels, &pixels));
-        }
     }
 }

--- a/examples/skia.rs
+++ b/examples/skia.rs
@@ -263,7 +263,7 @@ fn draw_selection_rects(
     rects: &[pdf_graphics::rect::Rect],
 ) -> Result<(), AppError> {
     let color = Color::from_rgba(0.20, 0.48, 1.0, 0.28);
-    let shader: Option<Shader<'_>> = None;
+    let shader: Option<Shader> = None;
     for rect in rects {
         let path = PdfPath::from(rect);
         backend.fill_path(


### PR DESCRIPTION
Store sampled gradient colors and positions in Arc-backed slices so shading paints, recorded commands, and recording clones reuse the same allocations.

Remove ShadingPaint and Shader lifetimes and their to_static conversion helpers. Add regressions covering allocation sharing across paint construction and recording clones.