### PR TITLE
pdf-document: schedule object loading by dependency

### DIFF
--- a/crates/pdf-document/src/error.rs
+++ b/crates/pdf-document/src/error.rs
@@ -32,15 +32,8 @@ pub enum PdfReaderError {
     DecryptionSetup(String),
     #[error("missing document ID required for encryption")]
     MissingDocumentId,
-    #[error(
-        "failed to resolve {count} object(s) after {iterations} iteration(s); \
-         first unresolved at byte offset {first_offset}"
-    )]
-    UnresolvedObjects {
-        count: usize,
-        iterations: usize,
-        first_offset: usize,
-    },
+    #[error("failed to resolve {count} object(s); first unresolved at byte offset {first_offset}")]
+    UnresolvedObjects { count: usize, first_offset: usize },
 }
 
 impl PdfReaderError {
@@ -49,6 +42,24 @@ impl PdfReaderError {
         match error {
             DecryptionError::IncorrectPassword => Self::IncorrectPassword,
             error => Self::DecryptionSetup(error.to_string()),
+        }
+    }
+
+    pub(crate) fn is_recoverable_optional_object_error(&self) -> bool {
+        matches!(
+            self,
+            PdfReaderError::ParserError(_)
+                | PdfReaderError::ObjectError(ObjectError::DecompressionError(_))
+        )
+    }
+
+    /// Returns the missing object number when an object failure can be retried later.
+    pub(crate) fn unresolved_object_number(&self) -> Option<usize> {
+        match self {
+            PdfReaderError::ParserError(ParserError::ObjectError(
+                ObjectError::FailedResolveObjectReference { obj_num },
+            )) => Some(*obj_num),
+            _ => None,
         }
     }
 }

--- a/crates/pdf-document/src/lib.rs
+++ b/crates/pdf-document/src/lib.rs
@@ -3,6 +3,7 @@ pub mod diagnostic;
 pub mod document;
 mod encryption;
 pub mod error;
+pub mod object_loader;
 pub mod object_stream;
 pub mod page;
 pub mod pages;

--- a/crates/pdf-document/src/object_loader.rs
+++ b/crates/pdf-document/src/object_loader.rs
@@ -1,0 +1,516 @@
+//! Dependency-aware loading of objects referenced by a PDF cross-reference table.
+//!
+//! Loading is not always a single pass: a stream may use an indirect `/Length`,
+//! and that length may itself live in a compressed object stream. The loader
+//! therefore separates the process into three responsibilities:
+//!
+//! 1. [`LoadPlan`] partitions xref entries without parsing any objects.
+//! 2. [`ObjectLoadQueue`] schedules work and wakes objects whose dependencies load.
+//! 3. [`ObjectLoader`] parses, decrypts, and inserts the scheduled objects.
+//!
+//! This avoids rescanning the entire xref table after every successful load. A
+//! deferred object is retried only when the exact object number it needs becomes
+//! available.
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+
+use crate::diagnostic::{PdfReadDiagnostic, PdfReadDiagnosticKind};
+use crate::error::PdfReaderError;
+use crate::object_stream::read_object_stream;
+use crate::reader::{EncryptionContext, object_id};
+use pdf_object::{
+    cross_reference_table::{CrossReferenceEntry, CrossReferenceEntryType},
+    error::ObjectError,
+    object_variant::ObjectVariant,
+};
+use pdf_object_collection::object_collection::ObjectCollection;
+use pdf_parser::parser::PdfParser;
+
+/// Maps an index within one object stream to the xref object numbers using that index.
+///
+/// Multiple object numbers can target the same index in malformed PDFs. Keeping
+/// all of them preserves best-effort behavior while allowing the normal,
+/// one-to-one case to move the parsed value without cloning it.
+type CompressedStreamPlan = BTreeMap<usize, Vec<usize>>;
+
+/// Work derived from the cross-reference table before object parsing begins.
+struct LoadPlan {
+    /// Byte offsets of ordinary indirect objects, in initial parsing order.
+    normal_objects: VecDeque<usize>,
+    /// Compressed-object requests grouped by their containing object stream.
+    compressed_streams: BTreeMap<usize, CompressedStreamPlan>,
+    /// Number of live xref entries used to preallocate the object collection.
+    object_capacity: usize,
+}
+
+impl LoadPlan {
+    /// Partitions live xref entries into normal objects and compressed-stream batches.
+    fn from_entries(entries: &BTreeMap<usize, CrossReferenceEntry>) -> Self {
+        let mut normal_objects = entries
+            .values()
+            .filter_map(|entry| match entry.entry_type {
+                CrossReferenceEntryType::Normal { byte_offset, .. } if byte_offset != 0 => {
+                    Some(byte_offset)
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        // Higher-numbered objects commonly contain lengths or metadata needed by
+        // earlier objects, so retain the reader's established reverse-xref order.
+        normal_objects.reverse();
+
+        // BTreeMap keeps stream and index processing deterministic, including
+        // which unresolved stream is reported first.
+        let mut compressed_streams = BTreeMap::<usize, CompressedStreamPlan>::new();
+        for (&object_number, entry) in entries {
+            let CrossReferenceEntryType::Compressed {
+                object_stream_number,
+                index_within_stream,
+            } = entry.entry_type
+            else {
+                continue;
+            };
+            compressed_streams
+                .entry(object_stream_number)
+                .or_default()
+                .entry(index_within_stream)
+                .or_default()
+                .push(object_number);
+        }
+
+        let compressed_count = compressed_streams
+            .values()
+            .flat_map(BTreeMap::values)
+            .map(Vec::len)
+            .fold(0usize, usize::saturating_add);
+        let object_capacity = normal_objects.len().saturating_add(compressed_count);
+
+        Self {
+            normal_objects: normal_objects.into(),
+            compressed_streams,
+            object_capacity,
+        }
+    }
+}
+
+/// Normal objects parked until a referenced object number becomes available.
+#[derive(Default)]
+struct DeferredObjects {
+    /// Maps a missing object number to the offsets that failed while resolving it.
+    offsets_by_dependency: HashMap<usize, Vec<usize>>,
+}
+
+impl DeferredObjects {
+    /// Parks `byte_offset` until `object_number` is inserted.
+    fn wait_for(&mut self, object_number: usize, byte_offset: usize) {
+        self.offsets_by_dependency
+            .entry(object_number)
+            .or_default()
+            .push(byte_offset);
+    }
+
+    /// Removes and returns every offset unblocked by `object_number`.
+    fn resume(&mut self, object_number: usize) -> Option<Vec<usize>> {
+        self.offsets_by_dependency.remove(&object_number)
+    }
+
+    /// Builds the deterministic terminal error for dependencies that never loaded.
+    fn unresolved_error(&self) -> Option<PdfReaderError> {
+        let first_offset = self
+            .offsets_by_dependency
+            .values()
+            .flatten()
+            .copied()
+            .min()?;
+        let count = self
+            .offsets_by_dependency
+            .values()
+            .map(Vec::len)
+            .fold(0usize, usize::saturating_add);
+        Some(PdfReaderError::UnresolvedObjects {
+            count,
+            first_offset,
+        })
+    }
+}
+
+/// A unit of work whose prerequisites are currently available.
+enum ObjectLoadTask {
+    /// Parses an ordinary indirect object at an xref byte offset.
+    Normal {
+        /// Absolute byte offset within the PDF input.
+        byte_offset: usize,
+    },
+    /// Parses one object stream and materializes its requested members.
+    CompressedStream {
+        /// Indirect object number of the containing `/ObjStm`.
+        object_stream_number: usize,
+        /// Xref members requested from the stream, grouped by stream index.
+        plan: CompressedStreamPlan,
+    },
+}
+
+/// Schedules object work and wakes tasks when their dependencies become available.
+#[derive(Default)]
+struct ObjectLoadQueue {
+    /// Normal-object offsets ready to parse.
+    normal_objects: VecDeque<usize>,
+    /// Newly inserted object numbers whose dependents have not been woken yet.
+    available_objects: VecDeque<usize>,
+    /// Object streams whose containing stream object has been inserted.
+    ready_streams: VecDeque<(usize, CompressedStreamPlan)>,
+    /// Normal objects blocked on an unavailable indirect object.
+    deferred_objects: DeferredObjects,
+    /// Compressed-stream plans waiting for their containing stream object.
+    pending_streams: BTreeMap<usize, CompressedStreamPlan>,
+}
+
+impl ObjectLoadQueue {
+    /// Seeds the scheduler from the xref-derived load plan.
+    fn from_plan(plan: LoadPlan) -> Self {
+        Self {
+            normal_objects: plan.normal_objects,
+            pending_streams: plan.compressed_streams,
+            ..Self::default()
+        }
+    }
+
+    /// Returns the next parse task, applying dependency notifications along the way.
+    ///
+    /// Normal objects take priority so an object stream is not parsed before all
+    /// immediately available indirect values in its dictionary have been loaded.
+    fn next_task(&mut self) -> Option<ObjectLoadTask> {
+        loop {
+            if let Some(byte_offset) = self.normal_objects.pop_front() {
+                return Some(ObjectLoadTask::Normal { byte_offset });
+            }
+            if let Some(object_number) = self.available_objects.pop_front() {
+                self.wake_dependents(object_number);
+                continue;
+            }
+            if let Some((object_stream_number, plan)) = self.ready_streams.pop_front() {
+                return Some(ObjectLoadTask::CompressedStream {
+                    object_stream_number,
+                    plan,
+                });
+            }
+            return None;
+        }
+    }
+
+    /// Parks a normal object until its missing dependency is inserted.
+    fn defer(&mut self, byte_offset: usize, dependency: usize) {
+        self.deferred_objects.wait_for(dependency, byte_offset);
+    }
+
+    /// Announces one inserted object so dependent work can be scheduled.
+    fn mark_available(&mut self, object_number: usize) {
+        self.available_objects.push_back(object_number);
+    }
+
+    /// Announces a batch of objects extracted from the same object stream.
+    fn mark_all_available(&mut self, object_numbers: impl IntoIterator<Item = usize>) {
+        self.available_objects.extend(object_numbers);
+    }
+
+    /// Moves work unblocked by `object_number` into the appropriate ready queue.
+    fn wake_dependents(&mut self, object_number: usize) {
+        if let Some(offsets) = self.deferred_objects.resume(object_number) {
+            self.normal_objects.extend(offsets);
+        }
+        if let Some(plan) = self.pending_streams.remove(&object_number) {
+            self.ready_streams.push_back((object_number, plan));
+        }
+    }
+
+    /// Reports work that could not be scheduled after all ready queues were drained.
+    ///
+    /// Unresolved normal objects take precedence over missing object streams,
+    /// matching the loader's normal-before-compressed processing order.
+    fn terminal_error(&self) -> Option<PdfReaderError> {
+        self.deferred_objects.unresolved_error().or_else(|| {
+            self.pending_streams
+                .first_key_value()
+                .map(|(&object_stream_number, _)| {
+                    ObjectError::FailedResolveObjectReference {
+                        obj_num: object_stream_number,
+                    }
+                    .into()
+                })
+        })
+    }
+}
+
+/// Parses, decrypts, and stores every live object described by an xref table.
+///
+/// The loader owns parsing policy and object state, while [`ObjectLoadQueue`]
+/// owns scheduling state. Keeping those responsibilities separate makes
+/// [`Self::load`] a small orchestration loop and keeps dependency mechanics out
+/// of parsing code.
+pub(super) struct ObjectLoader<'input, 'loader> {
+    /// Random-access parser over the source PDF bytes.
+    parser: &'loader mut PdfParser<'input>,
+    /// Optional document decryptor and encryption-dictionary exclusion.
+    encryption: EncryptionContext,
+    /// Objects available for resolving references during subsequent parses.
+    objects: ObjectCollection,
+    /// Dependency-aware work scheduler.
+    queue: ObjectLoadQueue,
+    /// Recoverable failures collected for the final read report.
+    diagnostics: &'loader mut Vec<PdfReadDiagnostic>,
+}
+
+impl<'input, 'loader> ObjectLoader<'input, 'loader> {
+    /// Creates an object loader for one parsed cross-reference table.
+    pub(super) fn new(
+        entries: &BTreeMap<usize, CrossReferenceEntry>,
+        parser: &'loader mut PdfParser<'input>,
+        encryption: EncryptionContext,
+        diagnostics: &'loader mut Vec<PdfReadDiagnostic>,
+    ) -> Self {
+        let plan = LoadPlan::from_entries(entries);
+        Self {
+            parser,
+            encryption,
+            objects: ObjectCollection::with_capacity(plan.object_capacity),
+            queue: ObjectLoadQueue::from_plan(plan),
+            diagnostics,
+        }
+    }
+
+    /// Drains dependency-ready work and returns the completed object collection.
+    ///
+    /// Each task either inserts objects, defers a normal object on a precise
+    /// dependency, records a recoverable diagnostic, or returns a fatal error.
+    /// Once no task remains, unresolved dependencies become a terminal error.
+    pub(super) fn load(mut self) -> Result<ObjectCollection, PdfReaderError> {
+        let mut queue = std::mem::take(&mut self.queue);
+        while let Some(task) = queue.next_task() {
+            self.execute_task(task, &mut queue)?;
+        }
+
+        if let Some(error) = queue.terminal_error() {
+            return Err(error);
+        }
+        Ok(self.objects)
+    }
+
+    /// Dispatches one scheduler task to the corresponding parsing operation.
+    fn execute_task(
+        &mut self,
+        task: ObjectLoadTask,
+        queue: &mut ObjectLoadQueue,
+    ) -> Result<(), PdfReaderError> {
+        match task {
+            ObjectLoadTask::Normal { byte_offset } => self.load_normal_object(byte_offset, queue),
+            ObjectLoadTask::CompressedStream {
+                object_stream_number,
+                plan,
+            } => {
+                let loaded = self.load_compressed_stream(object_stream_number, plan)?;
+                queue.mark_all_available(loaded);
+                Ok(())
+            }
+        }
+    }
+
+    /// Loads a normal object or records why it cannot be loaded yet.
+    fn load_normal_object(
+        &mut self,
+        byte_offset: usize,
+        queue: &mut ObjectLoadQueue,
+    ) -> Result<(), PdfReaderError> {
+        match self.load_object(byte_offset) {
+            Ok(Some(object_number)) => {
+                queue.mark_available(object_number);
+                Ok(())
+            }
+            Ok(None) => Ok(()),
+            Err(error) => self.handle_normal_object_error(byte_offset, error, queue),
+        }
+    }
+
+    /// Applies retry, diagnostic, and fatal-error policy to a normal-object failure.
+    fn handle_normal_object_error(
+        &mut self,
+        byte_offset: usize,
+        error: PdfReaderError,
+        queue: &mut ObjectLoadQueue,
+    ) -> Result<(), PdfReaderError> {
+        if let Some(dependency) = error.unresolved_object_number() {
+            queue.defer(byte_offset, dependency);
+            return Ok(());
+        }
+        if !error.is_recoverable_optional_object_error() {
+            return Err(error);
+        }
+
+        self.diagnostics.push(PdfReadDiagnostic::new(
+            PdfReadDiagnosticKind::ObjectParse,
+            Some(byte_offset),
+            None,
+            error,
+        ));
+        Ok(())
+    }
+
+    /// Parses, decrypts, and inserts one normal indirect object.
+    ///
+    /// The returned object number is used to wake dependent work. `None` means
+    /// that parsing was intentionally skipped after a recoverable decryption
+    /// failure or that the parsed value did not insert an addressable object.
+    fn load_object(&mut self, byte_offset: usize) -> Result<Option<usize>, PdfReaderError> {
+        let object = self
+            .parser
+            .parse_object_at(byte_offset, &self.objects)
+            .map_err(PdfReaderError::ParserError)?;
+        if matches!(object, ObjectVariant::Reference(_)) {
+            return Err(PdfReaderError::UnexpectedReference {
+                offset: byte_offset,
+            });
+        }
+
+        let identifier = object.identifier();
+        let object = match self.encryption.decryptor_for(identifier) {
+            Some(decryptor) => match decryptor.decrypt_object(object) {
+                Ok(object) => object,
+                Err(error) => {
+                    self.diagnostics.push(PdfReadDiagnostic::new(
+                        PdfReadDiagnosticKind::ObjectDecryption,
+                        Some(byte_offset),
+                        None,
+                        error,
+                    ));
+                    return Ok(None);
+                }
+            },
+            None => object,
+        };
+        self.objects
+            .insert(object)
+            .map_err(PdfReaderError::ObjectError)?;
+
+        Ok(identifier
+            .map(|identifier| identifier.number)
+            .filter(|&object_number| self.objects.get(object_number).is_some()))
+    }
+
+    /// Parses one available object stream and inserts all xref-requested members.
+    ///
+    /// Parsed values are wrapped in `Option` so the normal case can take ownership
+    /// by index without cloning. A clone is required only when a malformed xref
+    /// maps more than one object number to the same object-stream index.
+    ///
+    /// Returns the inserted object numbers so the scheduler can wake their dependents.
+    fn load_compressed_stream(
+        &mut self,
+        object_stream_number: usize,
+        stream_plan: CompressedStreamPlan,
+    ) -> Result<Vec<usize>, PdfReaderError> {
+        let stream_object = self.objects.get(object_stream_number).ok_or(
+            ObjectError::FailedResolveObjectReference {
+                obj_num: object_stream_number,
+            },
+        )?;
+        let stream = stream_object.try_stream(&self.objects)?;
+        let mut objects = read_object_stream(stream, &self.objects)?
+            .into_iter()
+            .map(Some)
+            .collect::<Vec<_>>();
+        let loaded_capacity = stream_plan
+            .values()
+            .map(Vec::len)
+            .fold(0usize, usize::saturating_add);
+        let mut loaded = Vec::with_capacity(loaded_capacity);
+
+        for (index_within_stream, object_numbers) in stream_plan {
+            let Some(object) = objects.get_mut(index_within_stream).and_then(Option::take) else {
+                continue;
+            };
+            let Some((&last_object_number, duplicate_object_numbers)) = object_numbers.split_last()
+            else {
+                continue;
+            };
+
+            // Preserve duplicate-index recovery, but move the value for the final
+            // target so valid PDFs take the allocation-free path.
+            for &object_number in duplicate_object_numbers {
+                self.report_compressed_number_mismatch(object_number, object.number);
+                self.objects
+                    .insert_compressed(object_number, object.value.clone());
+                loaded.push(object_number);
+            }
+
+            self.report_compressed_number_mismatch(last_object_number, object.number);
+            self.objects
+                .insert_compressed(last_object_number, object.value);
+            loaded.push(last_object_number);
+        }
+
+        Ok(loaded)
+    }
+
+    /// Records a recoverable diagnostic when xref and object-stream numbers disagree.
+    fn report_compressed_number_mismatch(
+        &mut self,
+        expected_object_number: usize,
+        actual_object_number: usize,
+    ) {
+        if actual_object_number == expected_object_number {
+            return;
+        }
+        self.diagnostics.push(PdfReadDiagnostic::new(
+            PdfReadDiagnosticKind::CompressedObject,
+            None,
+            Some(object_id(expected_object_number)),
+            "xref compressed object number differed from its object stream entry",
+        ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_plan_partitions_entries_and_groups_compressed_indexes() {
+        let entries = BTreeMap::from([
+            (0, CrossReferenceEntry::new_free(0, 65_535)),
+            (1, CrossReferenceEntry::new_normal(10, 0)),
+            (2, CrossReferenceEntry::new_compressed(5, 1)),
+            (3, CrossReferenceEntry::new_compressed(5, 1)),
+            (4, CrossReferenceEntry::new_normal(0, 0)),
+            (5, CrossReferenceEntry::new_normal(50, 0)),
+        ]);
+
+        let plan = LoadPlan::from_entries(&entries);
+
+        assert_eq!(plan.normal_objects, VecDeque::from([50, 10]));
+        assert_eq!(plan.object_capacity, 4);
+        assert_eq!(
+            plan.compressed_streams
+                .get(&5)
+                .and_then(|stream| stream.get(&1)),
+            Some(&vec![2, 3])
+        );
+    }
+
+    #[test]
+    fn unresolved_error_is_deterministic_across_dependencies() {
+        let mut deferred = DeferredObjects::default();
+        deferred.wait_for(9, 80);
+        deferred.wait_for(9, 20);
+        deferred.wait_for(4, 50);
+
+        let error = deferred.unresolved_error();
+
+        assert!(matches!(
+            error,
+            Some(PdfReaderError::UnresolvedObjects {
+                count: 3,
+                first_offset: 20
+            })
+        ));
+    }
+}

--- a/crates/pdf-document/src/object_stream.rs
+++ b/crates/pdf-document/src/object_stream.rs
@@ -15,6 +15,14 @@ pub(crate) struct CompressedObject {
     pub(crate) value: ObjectVariant,
 }
 
+/// Locates one object within an object stream's decoded bytes.
+struct ObjectStreamEntry {
+    /// The object's indirect object number.
+    number: usize,
+    /// The object's byte offset relative to the stream's `/First` value.
+    relative_offset: usize,
+}
+
 /// Parses an object stream (PDF 1.5+) and extracts all objects stored within it.
 ///
 /// # Parameters
@@ -71,12 +79,4 @@ pub(crate) fn read_object_stream(
     }
 
     Ok(result)
-}
-
-/// Locates one object within an object stream's decoded bytes.
-struct ObjectStreamEntry {
-    /// The object's indirect object number.
-    number: usize,
-    /// The object's byte offset relative to the stream's `/First` value.
-    relative_offset: usize,
 }

--- a/crates/pdf-document/src/reader.rs
+++ b/crates/pdf-document/src/reader.rs
@@ -1,11 +1,11 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
-use crate::decryption::{DecryptionError, DocumentDecryptor};
+use crate::decryption::DocumentDecryptor;
 use crate::diagnostic::{PdfReadDiagnostic, PdfReadDiagnosticKind};
 use crate::document::PdfDocument;
 use crate::encryption::EncryptDictionary;
 use crate::error::PdfReaderError;
-use crate::object_stream::{CompressedObject, read_object_stream};
+use crate::object_loader::ObjectLoader;
 use crate::page::PdfPage;
 use crate::pages::PdfPages;
 use crate::report::PdfReadReport;
@@ -14,18 +14,15 @@ use pdf_object::object_id::PdfObjectId;
 use pdf_object::object_lookup::ObjectLookupExt;
 use pdf_object::object_resolver::{ObjectResolver, PassthroughResolver};
 use pdf_object::{
-    cross_reference_table::{CrossReferenceEntry, CrossReferenceEntryType, CrossReferenceTable},
+    cross_reference_table::{CrossReferenceEntry, CrossReferenceTable},
     error::ObjectError,
     object_variant::ObjectVariant,
     trailer::Trailer,
 };
-use pdf_object_collection::object_collection::ObjectCollection;
-use pdf_parser::error::ParserError;
 use pdf_parser::parser::PdfParser;
 use pdf_resources::object_reader::{ReadCycleTracker, ReadFromDictionary};
 use pdf_resources::resource_cache::DefaultResourceCache;
 
-const MAX_RESOLVE_ITERATIONS: usize = 16;
 const EMPTY_PASSWORD: &[u8] = b"";
 
 /// Reads PDF documents from byte slices.
@@ -54,10 +51,10 @@ impl PdfReader {
             password.unwrap_or(EMPTY_PASSWORD),
             &mut diagnostics,
         )?;
-        let objects =
+        let mut objects =
             ObjectLoader::new(&entries, &mut parser, encryption, &mut diagnostics).load()?;
         let document = PdfDocument {
-            pages: extract_page_tree(&trailer, &mut objects.into_resolver())?,
+            pages: extract_page_tree(&trailer, &mut objects)?,
         };
 
         Ok(PdfReadReport::new(document, diagnostics))
@@ -88,7 +85,7 @@ fn validate_header(parser: &mut PdfParser) -> Result<(), PdfReaderError> {
 }
 
 /// Holds decryption state needed while loading objects.
-struct EncryptionContext {
+pub(crate) struct EncryptionContext {
     decryptor: Option<DocumentDecryptor>,
     dictionary_object_number: Option<usize>,
 }
@@ -111,7 +108,7 @@ impl EncryptionContext {
         let dictionary_object_number = encrypt_reference.try_object_number().ok();
         let encryption = match load_encrypt_dictionary(encrypt_reference, entries, parser) {
             Ok(encryption) => encryption,
-            Err(error) if is_recoverable_optional_object_error(&error) => {
+            Err(error) if error.is_recoverable_optional_object_error() => {
                 diagnostics.push(PdfReadDiagnostic::new(
                     PdfReadDiagnosticKind::MalformedEncryption,
                     None,
@@ -126,7 +123,7 @@ impl EncryptionContext {
             Err(error) => return Err(error),
         };
         let document_id = extract_document_id(trailer)?;
-        let decryptor = DocumentDecryptor::new(&encryption, &document_id, password)
+        let decryptor = DocumentDecryptor::new(&encryption, document_id, password)
             .map_err(PdfReaderError::from_decryption_setup)?;
         Ok(Self {
             decryptor: Some(decryptor),
@@ -135,7 +132,7 @@ impl EncryptionContext {
     }
 
     /// Returns the decryptor unless the object is the encryption dictionary itself.
-    fn decryptor_for(&self, object: Option<PdfObjectId>) -> Option<&DocumentDecryptor> {
+    pub(crate) fn decryptor_for(&self, object: Option<PdfObjectId>) -> Option<&DocumentDecryptor> {
         let object_number = object.map(|identifier| identifier.number);
         (object_number != self.dictionary_object_number)
             .then_some(self.decryptor.as_ref())
@@ -143,280 +140,12 @@ impl EncryptionContext {
     }
 }
 
-/// Loads xref-addressable objects while retaining enough state for retries.
-struct ObjectLoader<'a> {
-    entries: &'a BTreeMap<usize, CrossReferenceEntry>,
-    parser: &'a mut PdfParser<'a>,
-    encryption: EncryptionContext,
-    objects: ObjectCollection,
-    object_streams: HashMap<usize, Vec<CompressedObject>>,
-    diagnostics: &'a mut Vec<PdfReadDiagnostic>,
-}
-
-impl<'a> ObjectLoader<'a> {
-    /// Creates an object loader for one parsed cross-reference table.
-    fn new(
-        entries: &'a BTreeMap<usize, CrossReferenceEntry>,
-        parser: &'a mut PdfParser<'a>,
-        encryption: EncryptionContext,
-        diagnostics: &'a mut Vec<PdfReadDiagnostic>,
-    ) -> Self {
-        Self {
-            entries,
-            parser,
-            encryption,
-            objects: ObjectCollection::default(),
-            object_streams: HashMap::new(),
-            diagnostics,
-        }
-    }
-
-    /// Loads normal and compressed objects, returning all successfully loaded objects.
-    fn load(mut self) -> Result<LoadedObjects, PdfReaderError> {
-        let mut pending = self.load_normal_objects()?;
-        self.load_available_compressed_objects(false)?;
-        let mut iterations = 0usize;
-
-        while !pending.is_empty() && iterations < MAX_RESOLVE_ITERATIONS {
-            iterations = iterations.saturating_add(1);
-            let previous_count = pending.len();
-            pending = self.retry_pending_objects(pending)?;
-            let loaded_compressed = self.load_available_compressed_objects(false)?;
-            if pending.len() == previous_count && !loaded_compressed {
-                break;
-            }
-        }
-
-        if let Some(offset) = pending.first().copied() {
-            return Err(PdfReaderError::UnresolvedObjects {
-                count: pending.len(),
-                iterations,
-                first_offset: offset,
-            });
-        }
-        self.load_available_compressed_objects(true)?;
-        Ok(LoadedObjects(self.objects))
-    }
-
-    /// Loads each normal xref entry once and returns references that need a later retry.
-    fn load_normal_objects(&mut self) -> Result<Vec<usize>, PdfReaderError> {
-        let mut pending = Vec::new();
-        for entry in self.entries.values().rev() {
-            let CrossReferenceEntryType::Normal { byte_offset, .. } = entry.entry_type else {
-                continue;
-            };
-            if byte_offset == 0 {
-                continue;
-            }
-            let result = self.load_object(byte_offset);
-            self.handle_load_result(byte_offset, &mut pending, result)?;
-        }
-        Ok(pending)
-    }
-
-    /// Retries object offsets that previously referred to unavailable objects.
-    fn retry_pending_objects(&mut self, pending: Vec<usize>) -> Result<Vec<usize>, PdfReaderError> {
-        let mut still_pending = Vec::new();
-        for byte_offset in pending {
-            let result = self.load_object(byte_offset);
-            self.handle_load_result(byte_offset, &mut still_pending, result)?;
-        }
-        Ok(still_pending)
-    }
-
-    /// Classifies a single object load result according to the best-effort policy.
-    fn handle_load_result(
-        &mut self,
-        byte_offset: usize,
-        pending: &mut Vec<usize>,
-        result: Result<(), ObjectLoadError>,
-    ) -> Result<(), PdfReaderError> {
-        match result {
-            Ok(()) => Ok(()),
-            Err(ObjectLoadError::Reader(error)) if is_unresolved_reference(&error) => {
-                pending.push(byte_offset);
-                Ok(())
-            }
-            Err(ObjectLoadError::Reader(error)) if is_recoverable_optional_object_error(&error) => {
-                self.diagnostics.push(PdfReadDiagnostic::new(
-                    PdfReadDiagnosticKind::ObjectParse,
-                    Some(byte_offset),
-                    None,
-                    error,
-                ));
-                Ok(())
-            }
-            Err(ObjectLoadError::Decryption(error)) => {
-                self.diagnostics.push(PdfReadDiagnostic::new(
-                    PdfReadDiagnosticKind::ObjectDecryption,
-                    Some(byte_offset),
-                    None,
-                    error,
-                ));
-                Ok(())
-            }
-            Err(ObjectLoadError::Reader(error)) => Err(error),
-        }
-    }
-
-    /// Parses, decrypts, and inserts one normal indirect object.
-    fn load_object(&mut self, byte_offset: usize) -> Result<(), ObjectLoadError> {
-        let object = self
-            .parser
-            .parse_object_at(byte_offset, &self.objects)
-            .map_err(PdfReaderError::ParserError)?;
-        if matches!(object, ObjectVariant::Reference(_)) {
-            return Err(PdfReaderError::UnexpectedReference {
-                offset: byte_offset,
-            }
-            .into());
-        }
-        let identifier = object_identifier(&object);
-        let object = match self.encryption.decryptor_for(identifier) {
-            Some(decryptor) => decryptor.decrypt_object(object)?,
-            None => object,
-        };
-        self.objects
-            .insert(object)
-            .map_err(PdfReaderError::ObjectError)?;
-        Ok(())
-    }
-
-    /// Loads compressed objects whose containing object streams are available.
-    fn load_available_compressed_objects(&mut self, strict: bool) -> Result<bool, PdfReaderError> {
-        let mut loaded_any = false;
-        for (&object_number, entry) in self.entries {
-            let CrossReferenceEntryType::Compressed {
-                object_stream_number,
-                index_within_stream,
-            } = entry.entry_type
-            else {
-                continue;
-            };
-            if self.objects.get(object_number).is_some() {
-                continue;
-            }
-            if !self.object_streams.contains_key(&object_stream_number) {
-                let Some(stream_object) = self.objects.get(object_stream_number) else {
-                    if strict {
-                        return Err(ObjectError::FailedResolveObjectReference {
-                            obj_num: object_stream_number,
-                        }
-                        .into());
-                    }
-                    continue;
-                };
-                let stream = stream_object.try_stream(&self.objects)?;
-                match read_object_stream(stream, &self.objects) {
-                    Ok(objects) => {
-                        self.object_streams.insert(object_stream_number, objects);
-                    }
-                    Err(error) if !strict && is_recoverable_optional_object_error(&error) => {
-                        self.diagnostics.push(PdfReadDiagnostic::new(
-                            PdfReadDiagnosticKind::CompressedObject,
-                            None,
-                            Some(object_id(object_stream_number)),
-                            error,
-                        ));
-                        continue;
-                    }
-                    Err(error) => return Err(error),
-                }
-            }
-            if let Some(object) = self
-                .object_streams
-                .get(&object_stream_number)
-                .and_then(|objects| objects.get(index_within_stream))
-            {
-                if object.number != object_number {
-                    self.diagnostics.push(PdfReadDiagnostic::new(
-                        PdfReadDiagnosticKind::CompressedObject,
-                        None,
-                        Some(object_id(object_number)),
-                        "xref compressed object number differed from its object stream entry",
-                    ));
-                }
-                self.objects
-                    .insert_compressed(object_number, object.value.clone());
-                loaded_any = true;
-            }
-        }
-        Ok(loaded_any)
-    }
-}
-
-/// Wraps the loaded collection so ownership can cross the reader boundary explicitly.
-struct LoadedObjects(ObjectCollection);
-
-impl LoadedObjects {
-    /// Returns the owned collection as an object resolver.
-    fn into_resolver(self) -> ObjectCollection {
-        self.0
-    }
-}
-
-/// Distinguishes reader failures from recoverable object decryption failures.
-enum ObjectLoadError {
-    /// An ordinary reader failure.
-    Reader(PdfReaderError),
-    /// A failure while decrypting one object.
-    Decryption(DecryptionError),
-}
-
-impl From<PdfReaderError> for ObjectLoadError {
-    /// Wraps a reader error produced while loading an object.
-    fn from(error: PdfReaderError) -> Self {
-        Self::Reader(error)
-    }
-}
-
-impl From<DecryptionError> for ObjectLoadError {
-    /// Wraps an object decryption error.
-    fn from(error: DecryptionError) -> Self {
-        Self::Decryption(error)
-    }
-}
-
-/// Extracts a named object identifier when an object carries one.
-fn object_identifier(object: &ObjectVariant) -> Option<PdfObjectId> {
-    match object {
-        ObjectVariant::IndirectObject(indirect) => Some(PdfObjectId {
-            number: indirect.object_number,
-            generation: indirect.generation_number,
-        }),
-        ObjectVariant::Stream(stream) => Some(PdfObjectId {
-            number: stream.object_number,
-            generation: stream.generation_number,
-        }),
-        _ => None,
-    }
-}
-
 /// Creates an identifier for an object whose generation is not available in xref context.
-fn object_id(number: usize) -> PdfObjectId {
+pub(crate) fn object_id(number: usize) -> PdfObjectId {
     PdfObjectId {
         number,
         generation: 0,
     }
-}
-
-/// Returns whether an object failure should be retried after more objects load.
-fn is_unresolved_reference(error: &PdfReaderError) -> bool {
-    matches!(
-        error,
-        PdfReaderError::ParserError(ParserError::ObjectError(
-            ObjectError::FailedResolveObjectReference { .. }
-        ))
-    )
-}
-
-/// Returns whether a bulk-loaded object may be skipped without preventing a usable document.
-fn is_recoverable_optional_object_error(error: &PdfReaderError) -> bool {
-    matches!(
-        error,
-        PdfReaderError::ParserError(_)
-            | PdfReaderError::ObjectError(ObjectError::DecompressionError(_))
-    )
 }
 
 /// Resolves the page tree rooted at the trailer catalog.
@@ -445,7 +174,7 @@ fn load_encrypt_dictionary(
     entries: &BTreeMap<usize, CrossReferenceEntry>,
     parser: &mut PdfParser,
 ) -> Result<EncryptDictionary, PdfReaderError> {
-    let dictionary = match encrypt_reference {
+    let object = match encrypt_reference {
         ObjectVariant::Reference(object_number) => {
             let entry =
                 entries
@@ -459,45 +188,20 @@ fn load_encrypt_dictionary(
                     .ok_or(ObjectError::FailedResolveObjectReference {
                         obj_num: object_number,
                     })?;
-            dictionary_from_object(parser.parse_object_at(byte_offset, &PassthroughResolver)?)?
+            parser.parse_object_at(byte_offset, &PassthroughResolver)?
         }
-        ObjectVariant::Dictionary(dictionary) => dictionary,
-        object => {
-            return Err(ObjectError::FailedResolveDictionaryObject {
-                resolved_type: object.name(),
-            }
-            .into());
-        }
+        object => object,
     };
-    EncryptDictionary::from_dictionary(&dictionary, &PassthroughResolver)
-}
-
-/// Extracts a dictionary from an object used as an encryption dictionary.
-fn dictionary_from_object(
-    object: ObjectVariant,
-) -> Result<Box<pdf_object::dictionary::Dictionary>, PdfReaderError> {
-    match object {
-        ObjectVariant::Dictionary(dictionary) => Ok(dictionary),
-        ObjectVariant::IndirectObject(indirect) => match indirect.object {
-            Some(ObjectVariant::Dictionary(dictionary)) => Ok(dictionary),
-            _ => Err(ObjectError::FailedResolveDictionaryObject {
-                resolved_type: "IndirectObject",
-            }
-            .into()),
-        },
-        object => Err(ObjectError::FailedResolveDictionaryObject {
-            resolved_type: object.name(),
-        }
-        .into()),
-    }
+    let dictionary = object.try_dictionary(&PassthroughResolver)?;
+    EncryptDictionary::from_dictionary(dictionary, &PassthroughResolver)
 }
 
 /// Extracts the first trailer document identifier used for encryption key derivation.
-fn extract_document_id(trailer: &Trailer) -> Result<Vec<u8>, PdfReaderError> {
+fn extract_document_id(trailer: &Trailer) -> Result<&[u8], PdfReaderError> {
     let identifier = trailer
         .dictionary
         .required_array("ID", &PassthroughResolver)?
         .first()
         .ok_or(PdfReaderError::MissingDocumentId)?;
-    Ok(identifier.try_bytes(&PassthroughResolver)?.to_vec())
+    Ok(identifier.try_bytes(&PassthroughResolver)?)
 }

--- a/crates/pdf-document/tests/reader.rs
+++ b/crates/pdf-document/tests/reader.rs
@@ -6,7 +6,8 @@
     clippy::as_conversions
 )]
 
-use pdf_document::{diagnostic::PdfReadDiagnosticKind, reader::PdfReader};
+use pdf_document::{diagnostic::PdfReadDiagnosticKind, error::PdfReaderError, reader::PdfReader};
+use pdf_object::error::ObjectError;
 
 fn format_xref_entry(offset: usize, generation: u16, used: bool) -> String {
     let kind = if used { 'n' } else { 'f' };
@@ -615,7 +616,12 @@ fn test_encrypted_document_detection() {
 
     let reader = PdfReader;
     let result = reader.read_from_bytes(&data, None);
-    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(PdfReaderError::ObjectError(
+            ObjectError::MissingRequiredKey { ref key }
+        )) if key == "ID"
+    ));
 }
 
 #[test]
@@ -1050,13 +1056,13 @@ fn test_unresolvable_reference_returns_error() {
 
     let reader = PdfReader;
     let result = reader.read_from_bytes(&data, None);
-    assert!(result.is_err(), "Should fail for unresolvable reference");
-
-    let err_msg = match result {
-        Err(err) => err.to_string(),
-        Ok(_) => unreachable!(),
-    };
-    assert!(err_msg.contains("failed to resolve"));
+    assert!(matches!(
+        result,
+        Err(PdfReaderError::UnresolvedObjects {
+            count: 1,
+            first_offset,
+        }) if first_offset == obj4_offset
+    ));
 }
 
 #[test]

--- a/crates/pdf-object-collection/src/object_collection.rs
+++ b/crates/pdf-object-collection/src/object_collection.rs
@@ -42,6 +42,13 @@ impl ObjectResolver for ObjectCollection {
 }
 
 impl ObjectCollection {
+    /// Creates an empty object collection with space for at least `capacity` objects.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            map: HashMap::with_capacity(capacity),
+        }
+    }
+
     /// Inserts a PDF object into the collection.
     ///
     /// This method handles different object variants and stores them using their
@@ -376,5 +383,13 @@ mod tests {
         });
 
         assert_eq!(decoded, Some(b"hello".as_slice()));
+    }
+
+    #[test]
+    fn with_capacity_preallocates_the_object_map() {
+        let collection = ObjectCollection::with_capacity(12);
+
+        assert!(collection.map.capacity() >= 12);
+        assert!(collection.map.is_empty());
     }
 }

--- a/crates/pdf-object/src/object_variant.rs
+++ b/crates/pdf-object/src/object_variant.rs
@@ -4,6 +4,7 @@ use crate::cross_reference_table::CrossReferenceTable;
 use crate::dictionary::Dictionary;
 use crate::error::ObjectError;
 use crate::indirect_object::IndirectObject;
+use crate::object_id::PdfObjectId;
 use crate::object_resolver::ObjectResolver;
 use crate::stream::StreamObject;
 use crate::trailer::Trailer;
@@ -50,7 +51,7 @@ impl ObjectVariant {
     /// Resolves an `ObjectVariant` into a `Dictionary`.
     ///
     /// This function takes a reference to an `ObjectVariant` and attempts to resolve it
-    /// into a `Dictionary`.
+    /// into a direct, stream, or indirect object's dictionary.
     ///
     /// # Parameters
     ///
@@ -73,6 +74,10 @@ impl ObjectVariant {
         match object {
             ObjectVariant::Dictionary(dict) => Ok(dict.as_ref()),
             ObjectVariant::Stream(stream) => Ok(stream.dictionary.as_ref()),
+            ObjectVariant::IndirectObject(indirect) => match indirect.object.as_ref() {
+                Some(ObjectVariant::Dictionary(dict)) => Ok(dict.as_ref()),
+                _ => Err(ObjectError::TypeMismatch("Dictionary", object.name())),
+            },
             _ => Err(ObjectError::TypeMismatch("Dictionary", object.name())),
         }
     }
@@ -394,12 +399,60 @@ impl ObjectVariant {
             ObjectVariant::Reference(_) => "Reference",
         }
     }
+
+    /// Extracts a named object identifier when an object carries one.
+    pub fn identifier(&self) -> Option<PdfObjectId> {
+        match self {
+            ObjectVariant::IndirectObject(indirect) => Some(PdfObjectId {
+                number: indirect.object_number,
+                generation: indirect.generation_number,
+            }),
+            ObjectVariant::Stream(stream) => Some(PdfObjectId {
+                number: stream.object_number,
+                generation: stream.generation_number,
+            }),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::object_resolver::PassthroughResolver;
+
+    #[test]
+    fn try_dictionary_returns_dictionary_from_indirect_object() {
+        let object = ObjectVariant::IndirectObject(Box::new(IndirectObject::new(
+            1,
+            0,
+            Some(ObjectVariant::Dictionary(Box::new(Dictionary::new(
+                std::collections::BTreeMap::new(),
+            )))),
+        )));
+
+        let dictionary = object
+            .try_dictionary(&PassthroughResolver)
+            .expect("indirect dictionary object should decode as a dictionary");
+
+        assert!(dictionary.dictionary.is_empty());
+    }
+
+    #[test]
+    fn try_dictionary_rejects_indirect_object_without_dictionary() {
+        for inner_object in [None, Some(ObjectVariant::Integer(7))] {
+            let object =
+                ObjectVariant::IndirectObject(Box::new(IndirectObject::new(1, 0, inner_object)));
+            let err = object
+                .try_dictionary(&PassthroughResolver)
+                .expect_err("indirect object without a dictionary should fail");
+
+            assert_eq!(
+                err,
+                ObjectError::TypeMismatch("Dictionary", "IndirectObject")
+            );
+        }
+    }
 
     #[test]
     fn try_str_returns_type_mismatch_for_non_string() {


### PR DESCRIPTION
Replace repeated full-table retries with a queue that parks normal objects on their exact missing references and wakes them as dependencies become available.

Group compressed entries by object stream and move parsed values into the collection where possible. Preserve recoverable diagnostics and deterministic terminal errors for unresolved work.

Extract the loader into its own module, preallocate object storage, and reuse object identifier and dictionary helpers. Add scheduler and reader regressions for the new behavior.