### PR TITLE
pdf-tokenizer: expose byte peeking

### DIFF
--- a/crates/pdf-cmap/src/cmap/parser.rs
+++ b/crates/pdf-cmap/src/cmap/parser.rs
@@ -58,7 +58,7 @@ impl<'a> CMapParser<'a> {
     ) -> Result<Option<CMapToken>, CMapError> {
         self.skip_cmap_whitespace_and_comments();
 
-        let Some(byte) = self.parser.tokenizer.data().first().copied() else {
+        let Some(byte) = self.parser.tokenizer.peek_byte() else {
             return Ok(None);
         };
 

--- a/crates/pdf-content-stream/src/operator_stream_parser.rs
+++ b/crates/pdf-content-stream/src/operator_stream_parser.rs
@@ -70,7 +70,7 @@ impl<'a, 'out> OperatorStreamParser<'a, 'out> {
 
     /// Returns the next raw byte without advancing the parser.
     fn peek_next_byte(&self) -> Option<u8> {
-        self.parser.tokenizer.data().first().copied()
+        self.parser.tokenizer.peek_byte()
     }
 
     /// Parses one operand object and appends it to the reusable operand buffer.

--- a/crates/pdf-parser/src/array.rs
+++ b/crates/pdf-parser/src/array.rs
@@ -71,7 +71,7 @@ mod tests {
         let mut parser = PdfParser::from(b"[]0".as_slice());
         let result = parser.parse_array(&PassthroughResolver).unwrap();
         assert!(result.is_empty());
-        assert_eq!(parser.tokenizer.data(), b"0");
+        assert_eq!(parser.tokenizer.peek_byte(), Some(b'0'));
     }
 
     #[test]

--- a/crates/pdf-parser/src/dictionary.rs
+++ b/crates/pdf-parser/src/dictionary.rs
@@ -162,7 +162,7 @@ impl PdfParser<'_> {
             return Ok(DictionaryEntryState::ExpectKeyOrTerminator);
         }
 
-        let Some(byte) = self.tokenizer.data().first().copied() else {
+        let Some(byte) = self.tokenizer.peek_byte() else {
             return Err(ParserError::UnexpectedEndOfFile);
         };
 

--- a/crates/pdf-parser/src/inline_image.rs
+++ b/crates/pdf-parser/src/inline_image.rs
@@ -27,7 +27,7 @@ impl PdfParser<'_> {
     /// Enforcing this avoids ambiguous parses where data bytes could be mistaken for
     /// dictionary or operator content.
     fn consume_inline_image_data_separator(&mut self) -> Result<(), ParserError> {
-        let Some(first) = self.tokenizer.data().first().copied() else {
+        let Some(first) = self.tokenizer.peek_byte() else {
             return Err(ParserError::InlineImageMissingDataEnd);
         };
 

--- a/crates/pdf-parser/src/parser.rs
+++ b/crates/pdf-parser/src/parser.rs
@@ -56,11 +56,11 @@ impl<'a> PdfParser<'a> {
     /// Valid EOL sequences are `\r\n` (CRLF), `\r` (CR), or `\n` (LF), consumed in that
     /// priority order. If no EOL marker is present at the current position, does nothing.
     pub fn try_read_end_of_line_marker(&mut self) {
-        match self.tokenizer.data().first().copied() {
+        match self.tokenizer.peek_byte() {
             Some(b'\r') => {
                 let _ = self.tokenizer.read();
                 // Consume a following LF to handle the CRLF sequence.
-                if matches!(self.tokenizer.data().first().copied(), Some(b'\n')) {
+                if matches!(self.tokenizer.peek_byte(), Some(b'\n')) {
                     let _ = self.tokenizer.read();
                 }
             }
@@ -139,8 +139,7 @@ impl<'a> PdfParser<'a> {
     }
 
     fn read_regular_character_token(&mut self) -> Result<&'a [u8], ParserError> {
-        let first = self.tokenizer.data().first().copied();
-        match first {
+        match self.tokenizer.peek_byte() {
             Some(b) if Self::is_pdf_regular_character(b) => {
                 Ok(self.tokenizer.read_while_u8(Self::is_pdf_regular_character))
             }

--- a/crates/pdf-tokenizer/src/lib.rs
+++ b/crates/pdf-tokenizer/src/lib.rs
@@ -75,7 +75,7 @@ impl<'a> Tokenizer<'a> {
 
     /// Peek the current byte without consuming it.
     #[inline]
-    fn peek_byte(&self) -> Option<u8> {
+    pub fn peek_byte(&self) -> Option<u8> {
         self.input.get(self.position).copied()
     }
 


### PR DESCRIPTION
Make Tokenizer::peek_byte public so parser consumers can inspect the next byte without accessing the remaining input slice.

Update CMap, content-stream, and object parsers to use the focused API, including the parser boundary regression.