### PR TITLE
pdf-shading: support mesh shading streams

### DIFF
--- a/crates/pdf-canvas/src/pdf_canvas.rs
+++ b/crates/pdf-canvas/src/pdf_canvas.rs
@@ -22,9 +22,8 @@ use pdf_graphics::{
 use pdf_resources::{
     pattern::{PaintType, Pattern},
     resources::Resources,
-    shading::Shading,
 };
-use pdf_shading::paint::build_shading_paint;
+use pdf_shading::{model::Shading, paint::build_shading_paint};
 use skrifa::{
     OutlineGlyph,
     outline::DrawSettings,

--- a/crates/pdf-graphics-skia/src/skia_canvas_backend.rs
+++ b/crates/pdf-graphics-skia/src/skia_canvas_backend.rs
@@ -343,7 +343,7 @@ fn to_skia_shader(shader: &Shader) -> Result<skia_safe::Shader, PdfCanvasError> 
 
             image
                 .to_shader(
-                    (skia_safe::TileMode::Clamp, skia_safe::TileMode::Clamp),
+                    (skia_safe::TileMode::Decal, skia_safe::TileMode::Decal),
                     skia_safe::SamplingOptions::default(),
                     Some(&matrix),
                 )

--- a/crates/pdf-resources/src/lib.rs
+++ b/crates/pdf-resources/src/lib.rs
@@ -6,7 +6,6 @@ pub mod matrix;
 pub mod media_box;
 pub mod pattern;
 pub mod resources;
-pub mod shading;
 pub mod xobject;
 
 mod lazy_cache_value;

--- a/crates/pdf-resources/src/pattern.rs
+++ b/crates/pdf-resources/src/pattern.rs
@@ -3,6 +3,7 @@ use pdf_graphics::{rect::Rect, transform::Transform};
 use pdf_object::{
     object_lookup::ObjectLookupExt, object_resolver::ObjectResolver, object_variant::ObjectVariant,
 };
+use pdf_shading::model::Shading;
 
 use crate::{
     error::PdfPagesError,
@@ -11,7 +12,6 @@ use crate::{
     object_reader::{ReadCycleTracker, ReadFromDictionary},
     resource_cache::ResourceCache,
     resources::Resources,
-    shading::Shading,
 };
 
 /// PaintType for tiling patterns.

--- a/crates/pdf-resources/src/resource.rs
+++ b/crates/pdf-resources/src/resource.rs
@@ -1,9 +1,10 @@
 use crate::{
     external_graphics_state::ExternalGraphicsState, pattern::Pattern, resources::Resources,
-    shading::Shading, xobject::XObject,
+    xobject::XObject,
 };
 use pdf_color_space::color_space::ColorSpace;
 use pdf_font::font::Font;
+use pdf_shading::model::Shading;
 use std::{cell::OnceCell, rc::Rc};
 
 /// Lazily-resolved handle to a resource that is still being constructed.

--- a/crates/pdf-resources/src/resources.rs
+++ b/crates/pdf-resources/src/resources.rs
@@ -13,6 +13,7 @@ use pdf_object::{
     dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
     object_variant::ObjectVariant,
 };
+use pdf_shading::model::Shading;
 
 use crate::{
     error::PdfPagesError,
@@ -22,7 +23,6 @@ use crate::{
     resource::Resource,
     resource_cache::{ResourceCache, read_resource_lazy},
     resources_reference::ResourcesReference,
-    shading::Shading,
     xobject::XObject,
 };
 use pdf_color_space::color_space::ColorSpace;
@@ -579,8 +579,9 @@ mod tests {
 
     use crate::{
         object_reader::ReadCycleTracker, pattern::Pattern, resource::Resource,
-        resource_cache::DefaultResourceCache, shading::Shading, xobject::XObject,
+        resource_cache::DefaultResourceCache, xobject::XObject,
     };
+    use pdf_shading::model::Shading;
 
     use super::{Resources, read_xobjects};
 

--- a/crates/pdf-resources/src/shading.rs
+++ b/crates/pdf-resources/src/shading.rs
@@ -1,3 +1,0 @@
-//! Compatibility re-exports for the shared shading crate.
-
-pub use pdf_shading::model::{MeshPatch, Shading, ShadingType};

--- a/crates/pdf-shading/Cargo.toml
+++ b/crates/pdf-shading/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pdf-shading"
 version = "0.1.0"
 edition = "2024"
+autotests = false
 
 [lints]
 workspace = true
@@ -14,3 +15,15 @@ pdf-function = { path = "../pdf-function" }
 pdf-graphics = { path = "../pdf-graphics" }
 pdf-object = { path = "../pdf-object" }
 thiserror = "2.0.12"
+
+[[test]]
+name = "mesh"
+path = "tests/mesh.rs"
+
+[[test]]
+name = "paint"
+path = "tests/paint.rs"
+
+[[test]]
+name = "parse"
+path = "tests/parse.rs"

--- a/crates/pdf-shading/src/free_form_mesh.rs
+++ b/crates/pdf-shading/src/free_form_mesh.rs
@@ -1,0 +1,195 @@
+//! Parsing for Type 4 free-form Gouraud triangle meshes.
+
+use pdf_color_space::color_space::ColorSpace;
+use pdf_function::function::Function;
+use pdf_graphics::rect::Rect;
+use pdf_object::{
+    dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
+    object_variant::ObjectVariant,
+};
+
+use crate::{
+    error::PdfShadingError,
+    mesh_decoder::{MeshBitWidths, MeshDecoder},
+    mesh_sample_reader::MeshSampleReader,
+    model::{MeshTriangle, MeshVertex, Shading},
+    parse::{optional_bbox, parse_functions, required_color_space},
+};
+
+/// Parses a Type 4 shading stream into independent mesh triangles.
+pub(crate) fn parse_free_form_triangle_mesh(
+    object: &ObjectVariant,
+    objects: &dyn ObjectResolver,
+) -> Result<Shading, PdfShadingError> {
+    let stream = object.try_stream(objects)?;
+    let config = FreeFormMeshConfig::parse(stream.dictionary.as_ref(), objects)?;
+    let triangles = FreeFormMeshParser::new(stream.raw_data(), &config)?.parse()?;
+
+    Ok(Shading::FreeFormTriangleMesh {
+        color_space: config.color_space,
+        bbox: config.bbox,
+        anti_alias: config.anti_alias,
+        triangles,
+    })
+}
+
+/// Owned dictionary values needed while parsing a Type 4 stream.
+struct FreeFormMeshConfig {
+    color_space: ColorSpace,
+    bbox: Option<Rect>,
+    anti_alias: Option<bool>,
+    widths: MeshBitWidths,
+    decode: Vec<f32>,
+    functions: Vec<Function>,
+}
+
+impl FreeFormMeshConfig {
+    /// Reads and validates the mesh-specific shading dictionary entries.
+    fn parse(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+    ) -> Result<Self, PdfShadingError> {
+        let color_space = required_color_space(dictionary, objects)?;
+        let widths = MeshBitWidths::new(
+            dictionary.required_number::<usize>("BitsPerCoordinate", objects)?,
+            dictionary.required_number::<usize>("BitsPerComponent", objects)?,
+            dictionary.required_number::<usize>("BitsPerFlag", objects)?,
+        )?;
+        let decode = dictionary.required_vec_of::<f32>("Decode", objects)?;
+        let bbox = optional_bbox(dictionary, objects)?;
+        let anti_alias = dictionary.optional_boolean("AntiAlias", objects)?;
+        let functions = optional_functions(dictionary, objects)?;
+
+        Ok(Self {
+            color_space,
+            bbox,
+            anti_alias,
+            widths,
+            decode,
+            functions,
+        })
+    }
+}
+
+/// Stateful reconstruction of triangles from Type 4 vertex records.
+struct FreeFormMeshParser<'a> {
+    reader: MeshSampleReader<'a>,
+    decoder: MeshDecoder<'a>,
+    flag_width: usize,
+}
+
+impl<'a> FreeFormMeshParser<'a> {
+    /// Creates a parser borrowing the stream and its validated configuration.
+    fn new(data: &'a [u8], config: &'a FreeFormMeshConfig) -> Result<Self, PdfShadingError> {
+        Ok(Self {
+            reader: MeshSampleReader::new(data),
+            decoder: MeshDecoder::new(
+                config.widths,
+                &config.decode,
+                &config.functions,
+                &config.color_space,
+                "Free-form triangle mesh",
+            )?,
+            flag_width: config.widths.flag(),
+        })
+    }
+
+    /// Consumes all complete vertex records and reconstructs their triangles.
+    fn parse(mut self) -> Result<Vec<MeshTriangle>, PdfShadingError> {
+        let mut triangles = Vec::new();
+
+        while let Some((flag, vertex)) = self.read_vertex()? {
+            let triangle = match flag {
+                0 => self.read_new_triangle(vertex)?,
+                1 | 2 => {
+                    let previous = triangles.last().ok_or_else(|| {
+                        invalid_mesh_data(format!(
+                            "Free-form triangle continuation flag {flag} used without a previous triangle"
+                        ))
+                    })?;
+                    continue_triangle(flag, previous, vertex)?
+                }
+                _ => {
+                    return Err(invalid_mesh_data(format!(
+                        "Invalid free-form triangle edge flag {flag}"
+                    )));
+                }
+            };
+            triangles.push(triangle);
+        }
+
+        if triangles.is_empty() {
+            return Err(invalid_mesh_data(
+                "Free-form triangle mesh stream did not contain any triangles",
+            ));
+        }
+
+        Ok(triangles)
+    }
+
+    /// Reads the two remaining vertices of a newly started triangle.
+    fn read_new_triangle(&mut self, first: MeshVertex) -> Result<MeshTriangle, PdfShadingError> {
+        let (_, second) = self.read_required_vertex()?;
+        let (_, third) = self.read_required_vertex()?;
+        Ok(MeshTriangle {
+            vertices: [first, second, third],
+        })
+    }
+
+    /// Reads a vertex that must exist to complete the current triangle.
+    fn read_required_vertex(&mut self) -> Result<(u8, MeshVertex), PdfShadingError> {
+        self.read_vertex()?.ok_or_else(|| {
+            invalid_mesh_data("Free-form triangle mesh stream ended before completing a triangle")
+        })
+    }
+
+    /// Reads one byte-aligned Type 4 vertex record.
+    fn read_vertex(&mut self) -> Result<Option<(u8, MeshVertex)>, PdfShadingError> {
+        let Some(flag) = self.reader.read_bits(self.flag_width)? else {
+            return Ok(None);
+        };
+        let flag = u8::try_from(flag & 0b11)
+            .map_err(|_| invalid_mesh_data("Free-form triangle flag does not fit into u8"))?;
+        let point = self.decoder.read_point(&mut self.reader)?;
+        let color = self.decoder.read_color(&mut self.reader)?;
+        self.reader.align_to_byte();
+
+        Ok(Some((flag, MeshVertex { point, color })))
+    }
+}
+
+/// Reuses the appropriate edge of the preceding triangle.
+fn continue_triangle(
+    flag: u8,
+    previous: &MeshTriangle,
+    vertex: MeshVertex,
+) -> Result<MeshTriangle, PdfShadingError> {
+    let [first, second, third] = previous.vertices;
+    let vertices = match flag {
+        1 => [second, third, vertex],
+        2 => [first, third, vertex],
+        _ => {
+            return Err(invalid_mesh_data(format!(
+                "Invalid free-form triangle continuation flag {flag}"
+            )));
+        }
+    };
+    Ok(MeshTriangle { vertices })
+}
+
+fn optional_functions(
+    dictionary: &Dictionary,
+    objects: &dyn ObjectResolver,
+) -> Result<Vec<Function>, PdfShadingError> {
+    if dictionary.get("Function").is_some() {
+        parse_functions(dictionary, objects)
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+fn invalid_mesh_data(reason: impl Into<String>) -> PdfShadingError {
+    PdfShadingError::InvalidShadingMeshData {
+        reason: reason.into(),
+    }
+}

--- a/crates/pdf-shading/src/lib.rs
+++ b/crates/pdf-shading/src/lib.rs
@@ -2,7 +2,11 @@
 
 pub mod color_stops;
 pub mod error;
+mod free_form_mesh;
 pub mod mesh;
+mod mesh_decoder;
+mod mesh_sample_reader;
 pub mod model;
 pub mod paint;
 mod parse;
+mod patch_mesh;

--- a/crates/pdf-shading/src/mesh.rs
+++ b/crates/pdf-shading/src/mesh.rs
@@ -10,7 +10,9 @@ use pdf_graphics::{
     transform::Transform,
 };
 
-use crate::model::MeshPatch;
+use crate::model::{MeshPatch, MeshTriangle};
+
+pub use crate::model::MeshVertex;
 
 const DEFAULT_SUBDIVISION: usize = 8;
 const MAX_SUBDIVISION: f32 = 32.0;
@@ -35,16 +37,7 @@ pub enum MeshPatchRef<'a> {
     },
 }
 
-/// A tessellated mesh vertex with a device-space position and interpolated color.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct MeshVertex {
-    /// The device-space point.
-    pub point: Point,
-    /// The interpolated vertex color.
-    pub color: Color,
-}
-
-/// A rasterized patch mesh in device space.
+/// A rasterized mesh in device space.
 #[derive(Debug, Clone, PartialEq)]
 pub struct RasterizedPatchMesh {
     /// Packed RGBA8 pixels in row-major order.
@@ -165,6 +158,22 @@ where
     bounds.finish()
 }
 
+/// Computes device-space bounds for parsed triangles after applying `transform`.
+pub fn triangle_mesh_bounds<'a, I>(triangles: I, transform: &Transform) -> Option<Rect>
+where
+    I: IntoIterator<Item = &'a MeshTriangle>,
+{
+    let mut bounds = BoundsAccumulator::new();
+
+    for triangle in triangles {
+        for vertex in triangle.vertices {
+            bounds.include(transformed_point(vertex.point, transform));
+        }
+    }
+
+    bounds.finish()
+}
+
 /// Chooses a tessellation subdivision count for one patch in device space.
 pub fn patch_subdivision(patch: MeshPatchRef<'_>, transform: &Transform) -> usize {
     let Some(bounds) = patch_mesh_bounds(std::iter::once(patch), transform) else {
@@ -228,7 +237,7 @@ where
     let bounds = bounds.normalized();
     let width = bounded_raster_dimension(bounds.width(), max_dimension);
     let height = bounded_raster_dimension(bounds.height(), max_dimension);
-    let mut pixels = vec![255_u8; width.saturating_mul(height).saturating_mul(4)];
+    let mut pixels = vec![0_u8; width.saturating_mul(height).saturating_mul(4)];
 
     for patch in patches {
         let subdivision = patch_subdivision(patch, transform);
@@ -236,6 +245,36 @@ where
         for triangle in triangles {
             rasterize_triangle(&mut pixels, width, height, &bounds, triangle);
         }
+    }
+
+    RasterizedPatchMesh {
+        pixels,
+        bounds,
+        width,
+        height,
+    }
+}
+
+/// Rasterizes parsed Gouraud-shaded triangles into an RGBA8 image.
+pub fn rasterize_triangle_mesh<'a, I>(
+    triangles: I,
+    bounds: Rect,
+    transform: &Transform,
+    max_dimension: usize,
+) -> RasterizedPatchMesh
+where
+    I: IntoIterator<Item = &'a MeshTriangle>,
+{
+    let bounds = bounds.normalized();
+    let width = bounded_raster_dimension(bounds.width(), max_dimension);
+    let height = bounded_raster_dimension(bounds.height(), max_dimension);
+    let mut pixels = vec![0_u8; width.saturating_mul(height).saturating_mul(4)];
+
+    for triangle in triangles {
+        let vertices = triangle
+            .vertices
+            .map(|vertex| transform_mesh_vertex(vertex, transform));
+        rasterize_triangle(&mut pixels, width, height, &bounds, vertices);
     }
 
     RasterizedPatchMesh {
@@ -291,6 +330,18 @@ where
     I: IntoIterator<Item = MeshPatchRef<'a>>,
 {
     rasterize_patch_mesh(patches, bounds, transform, MAX_RASTER_DIMENSION)
+}
+
+/// Builds a raster image for triangle mesh shading paint with the default size cap.
+pub fn rasterize_mesh_triangles<'a, I>(
+    triangles: I,
+    bounds: Rect,
+    transform: &Transform,
+) -> RasterizedPatchMesh
+where
+    I: IntoIterator<Item = &'a MeshTriangle>,
+{
+    rasterize_triangle_mesh(triangles, bounds, transform, MAX_RASTER_DIMENSION)
 }
 
 fn transformed_point(point: Point, transform: &Transform) -> Point {
@@ -519,6 +570,3 @@ fn triangle_scan_bounds(
         bottom: (max_y - bounds.top).max(0.0).min(max_height),
     })
 }
-
-#[cfg(test)]
-mod tests;

--- a/crates/pdf-shading/src/mesh_decoder.rs
+++ b/crates/pdf-shading/src/mesh_decoder.rs
@@ -1,0 +1,216 @@
+//! Decoding of coordinates and colors from packed mesh samples.
+
+use num_traits::ToPrimitive;
+use pdf_color_space::color_space::ColorSpace;
+use pdf_function::function::Function;
+use pdf_graphics::{color::Color, point::Point};
+
+use crate::{error::PdfShadingError, mesh_sample_reader::MeshSampleReader};
+
+const VALID_COORDINATE_WIDTHS: [usize; 8] = [1, 2, 4, 8, 12, 16, 24, 32];
+const VALID_COMPONENT_WIDTHS: [usize; 6] = [1, 2, 4, 8, 12, 16];
+const VALID_FLAG_WIDTHS: [usize; 3] = [2, 4, 8];
+
+/// Validated bit widths from a Type 4, 6, or 7 mesh dictionary.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MeshBitWidths {
+    coordinate: usize,
+    component: usize,
+    flag: usize,
+}
+
+impl MeshBitWidths {
+    /// Validates the three PDF mesh bit-width entries.
+    pub(crate) fn new(
+        coordinate: usize,
+        component: usize,
+        flag: usize,
+    ) -> Result<Self, PdfShadingError> {
+        validate_allowed_width(
+            coordinate,
+            &VALID_COORDINATE_WIDTHS,
+            "BitsPerCoordinate must be 1, 2, 4, 8, 12, 16, 24, or 32",
+        )?;
+        validate_allowed_width(
+            component,
+            &VALID_COMPONENT_WIDTHS,
+            "BitsPerComponent must be 1, 2, 4, 8, 12, or 16",
+        )?;
+        validate_allowed_width(flag, &VALID_FLAG_WIDTHS, "BitsPerFlag must be 2, 4, or 8")?;
+
+        Ok(Self {
+            coordinate,
+            component,
+            flag,
+        })
+    }
+
+    /// Returns the width of each edge-flag field.
+    pub(crate) fn flag(self) -> usize {
+        self.flag
+    }
+}
+
+/// Decodes mesh coordinates and color inputs according to a `/Decode` array.
+///
+/// A decoder borrows the parsed dictionary data while a mesh parser owns the
+/// stream cursor. Keeping these responsibilities separate makes record
+/// reconstruction independent from bit and color decoding.
+pub(crate) struct MeshDecoder<'a> {
+    widths: MeshBitWidths,
+    decode: &'a [f32],
+    color_input_count: usize,
+    functions: &'a [Function],
+    color_space: &'a ColorSpace,
+}
+
+impl<'a> MeshDecoder<'a> {
+    /// Creates a decoder after validating `/Decode` against the color inputs.
+    pub(crate) fn new(
+        widths: MeshBitWidths,
+        decode: &'a [f32],
+        functions: &'a [Function],
+        color_space: &'a ColorSpace,
+        mesh_name: &str,
+    ) -> Result<Self, PdfShadingError> {
+        let color_input_count = if functions.is_empty() {
+            color_space.num_color_components()
+        } else {
+            1
+        };
+        if color_input_count == 0 {
+            return Err(invalid_mesh_data(format!(
+                "{mesh_name} color space requires at least one component"
+            )));
+        }
+
+        let expected_values = color_input_count.saturating_add(2).saturating_mul(2);
+        if decode.len() != expected_values {
+            return Err(invalid_mesh_data(format!(
+                "{mesh_name} Decode array must contain {expected_values} values"
+            )));
+        }
+
+        Ok(Self {
+            widths,
+            decode,
+            color_input_count,
+            functions,
+            color_space,
+        })
+    }
+
+    /// Reads and decodes one `(x, y)` coordinate pair.
+    pub(crate) fn read_point(
+        &self,
+        reader: &mut MeshSampleReader<'_>,
+    ) -> Result<Point, PdfShadingError> {
+        let (x_min, x_max) = decode_pair(self.decode, 0, "X")?;
+        let (y_min, y_max) = decode_pair(self.decode, 1, "Y")?;
+        let x = self.read_sample(reader, self.widths.coordinate, x_min, x_max)?;
+        let y = self.read_sample(reader, self.widths.coordinate, y_min, y_max)?;
+        Ok(Point::new(x, y))
+    }
+
+    /// Reads mesh color inputs, applies optional functions, and converts them
+    /// into the shading color space.
+    pub(crate) fn read_color(
+        &self,
+        reader: &mut MeshSampleReader<'_>,
+    ) -> Result<Color, PdfShadingError> {
+        let inputs = (0..self.color_input_count)
+            .map(|component| {
+                let (min, max) =
+                    decode_pair(self.decode, component.saturating_add(2), "component")?;
+                self.read_sample(reader, self.widths.component, min, max)
+            })
+            .collect::<Result<Vec<_>, PdfShadingError>>()?;
+
+        let components = self.apply_functions(&inputs)?;
+        Ok(self.color_space.apply(&components)?)
+    }
+
+    fn read_sample(
+        &self,
+        reader: &mut MeshSampleReader<'_>,
+        width: usize,
+        min: f32,
+        max: f32,
+    ) -> Result<f32, PdfShadingError> {
+        decode_sample(reader.read_required_bits(width)?.into(), width, min, max)
+    }
+
+    fn apply_functions(&self, inputs: &[f32]) -> Result<Vec<f32>, PdfShadingError> {
+        match self.functions {
+            [] => Ok(inputs.to_vec()),
+            [function] => Ok(function.apply(inputs)?),
+            functions => functions
+                .iter()
+                .map(|function| {
+                    function.apply(inputs)?.first().copied().ok_or_else(|| {
+                        invalid_mesh_data(
+                            "Mesh shading function did not return a color component".to_string(),
+                        )
+                    })
+                })
+                .collect(),
+        }
+    }
+}
+
+fn validate_allowed_width(
+    width: usize,
+    allowed: &[usize],
+    reason: &str,
+) -> Result<(), PdfShadingError> {
+    if allowed.contains(&width) {
+        Ok(())
+    } else {
+        Err(invalid_mesh_data(reason.to_string()))
+    }
+}
+
+fn decode_pair(
+    decode: &[f32],
+    pair_index: usize,
+    label: &str,
+) -> Result<(f32, f32), PdfShadingError> {
+    let first_index = pair_index.saturating_mul(2);
+    let second_index = first_index.saturating_add(1);
+    let min = decode
+        .get(first_index)
+        .copied()
+        .ok_or_else(|| invalid_mesh_data(format!("Decode array is missing {label} minimum")))?;
+    let max = decode
+        .get(second_index)
+        .copied()
+        .ok_or_else(|| invalid_mesh_data(format!("Decode array is missing {label} maximum")))?;
+    Ok((min, max))
+}
+
+fn decode_sample(code: u64, width: usize, min: f32, max: f32) -> Result<f32, PdfShadingError> {
+    let shift = u32::try_from(width)
+        .map_err(|_| invalid_mesh_data("Mesh sample width is too large".to_string()))?;
+    let code_max = 1_u64
+        .checked_shl(shift)
+        .ok_or_else(|| invalid_mesh_data("Mesh sample width overflowed".to_string()))?
+        .saturating_sub(1);
+    let code = code
+        .to_f32()
+        .ok_or_else(|| invalid_mesh_data("Mesh sample is not representable as f32".to_string()))?;
+    let code_max = code_max.to_f32().ok_or_else(|| {
+        invalid_mesh_data("Mesh sample range is not representable as f32".to_string())
+    })?;
+
+    Ok(min + (code / code_max) * (max - min))
+}
+
+fn invalid_mesh_data(reason: impl Into<String>) -> PdfShadingError {
+    PdfShadingError::InvalidShadingMeshData {
+        reason: reason.into(),
+    }
+}
+
+#[cfg(test)]
+#[path = "../tests/mesh_decoder.rs"]
+mod tests;

--- a/crates/pdf-shading/src/mesh_sample_reader.rs
+++ b/crates/pdf-shading/src/mesh_sample_reader.rs
@@ -1,0 +1,82 @@
+//! Bit-level reading for packed PDF mesh samples.
+
+use crate::error::PdfShadingError;
+
+/// Reads unsigned, big-endian bit fields from a mesh shading stream.
+///
+/// The reader deliberately does not know the meaning of individual fields.
+/// Mesh-specific parsers decide when record padding requires byte alignment.
+pub(crate) struct MeshSampleReader<'a> {
+    data: &'a [u8],
+    bit_offset: usize,
+}
+
+impl<'a> MeshSampleReader<'a> {
+    /// Creates a reader positioned at the first bit of `data`.
+    pub(crate) fn new(data: &'a [u8]) -> Self {
+        Self {
+            data,
+            bit_offset: 0,
+        }
+    }
+
+    /// Reads a field, returning `None` only when already at end-of-stream.
+    pub(crate) fn read_bits(&mut self, width: usize) -> Result<Option<u32>, PdfShadingError> {
+        validate_width(width)?;
+
+        let available_bits = self.data.len().saturating_mul(8);
+        if self.bit_offset >= available_bits {
+            return Ok(None);
+        }
+
+        let end_offset = self.bit_offset.saturating_add(width);
+        if end_offset > available_bits {
+            return Err(invalid_mesh_data(
+                "Mesh stream ended in the middle of a sample",
+            ));
+        }
+
+        let mut value = 0_u32;
+        for absolute_bit in self.bit_offset..end_offset {
+            let byte_index = absolute_bit / 8;
+            let bit_in_byte = absolute_bit % 8;
+            let byte = self.data.get(byte_index).copied().ok_or_else(|| {
+                invalid_mesh_data("Mesh stream byte access exceeded the available data")
+            })?;
+            let shift = 7_usize.saturating_sub(bit_in_byte);
+            value = (value << 1) | u32::from((byte >> shift) & 1);
+        }
+
+        self.bit_offset = end_offset;
+        Ok(Some(value))
+    }
+
+    /// Reads a required field and reports a truncated mesh stream at EOF.
+    pub(crate) fn read_required_bits(&mut self, width: usize) -> Result<u32, PdfShadingError> {
+        self.read_bits(width)?
+            .ok_or_else(|| invalid_mesh_data("Mesh stream ended unexpectedly"))
+    }
+
+    /// Skips padding at the end of a byte-aligned mesh record.
+    pub(crate) fn align_to_byte(&mut self) {
+        self.bit_offset = self.bit_offset.div_ceil(8).saturating_mul(8);
+    }
+}
+
+fn validate_width(width: usize) -> Result<(), PdfShadingError> {
+    if (1..=32).contains(&width) {
+        Ok(())
+    } else {
+        Err(invalid_mesh_data("Mesh bit-field widths must be in 1..=32"))
+    }
+}
+
+fn invalid_mesh_data(reason: &str) -> PdfShadingError {
+    PdfShadingError::InvalidShadingMeshData {
+        reason: reason.to_string(),
+    }
+}
+
+#[cfg(test)]
+#[path = "../tests/mesh_sample_reader.rs"]
+mod tests;

--- a/crates/pdf-shading/src/model.rs
+++ b/crates/pdf-shading/src/model.rs
@@ -97,6 +97,17 @@ pub enum Shading {
         /// Optional bounding box in shading space.
         bbox: Option<Rect>,
     },
+    /// Type 4 free-form Gouraud-shaded triangle mesh.
+    FreeFormTriangleMesh {
+        /// The shading color space.
+        color_space: ColorSpace,
+        /// Optional mesh bounding box in shading space.
+        bbox: Option<Rect>,
+        /// Optional anti-aliasing preference.
+        anti_alias: Option<bool>,
+        /// Parsed vertex-colored triangles.
+        triangles: Vec<MeshTriangle>,
+    },
     /// Type 6 or 7 patch mesh shading.
     PatchMesh {
         /// The original mesh shading subtype.
@@ -115,6 +126,22 @@ pub enum Shading {
         /// The unsupported shading type name.
         name: String,
     },
+}
+
+/// A vertex in a PDF triangle mesh.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MeshVertex {
+    /// The vertex position in shading space.
+    pub point: Point,
+    /// The decoded vertex color.
+    pub color: Color,
+}
+
+/// A Gouraud-shaded triangle from a PDF triangle mesh.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MeshTriangle {
+    /// The triangle vertices in stream order.
+    pub vertices: [MeshVertex; 3],
 }
 
 /// A parsed patch from a PDF mesh shading.
@@ -143,6 +170,7 @@ impl Shading {
             Self::FunctionBased { color_space, .. } => color_space.as_ref(),
             Self::Axial { color_space, .. }
             | Self::Radial { color_space, .. }
+            | Self::FreeFormTriangleMesh { color_space, .. }
             | Self::PatchMesh { color_space, .. } => Some(color_space),
             Self::Unsupported { .. } => None,
         }
@@ -153,6 +181,7 @@ impl Shading {
         match self {
             Self::FunctionBased { bbox, .. }
             | Self::Radial { bbox, .. }
+            | Self::FreeFormTriangleMesh { bbox, .. }
             | Self::PatchMesh { bbox, .. } => bbox.as_ref(),
             Self::Axial { .. } | Self::Unsupported { .. } => None,
         }

--- a/crates/pdf-shading/src/paint.rs
+++ b/crates/pdf-shading/src/paint.rs
@@ -6,7 +6,10 @@ use pdf_graphics::{color::Color, rect::Rect, transform::Transform};
 
 use crate::{
     error::PdfShadingError,
-    mesh::{MeshPatchRef, patch_mesh_bounds, rasterize_mesh_patches},
+    mesh::{
+        MeshPatchRef, patch_mesh_bounds, rasterize_mesh_patches, rasterize_mesh_triangles,
+        triangle_mesh_bounds,
+    },
     model::Shading,
 };
 
@@ -103,6 +106,32 @@ pub fn build_shading_paint(
         Shading::FunctionBased { .. } => Err(PdfShadingError::UnsupportedFeature(
             "FunctionBased shading not implemented".to_string(),
         )),
+        Shading::FreeFormTriangleMesh {
+            bbox, triangles, ..
+        } => {
+            let mesh_transform = match transform {
+                Some(value) => value,
+                None => Transform::identity(),
+            };
+            let bounds = bbox
+                .map(|rect| mesh_transform.map_rect(&rect))
+                .filter(has_paintable_bounds)
+                .or_else(|| triangle_mesh_bounds(triangles, &mesh_transform))
+                .filter(has_paintable_bounds);
+            let Some(bounds) = bounds.map(|value| value.normalized()) else {
+                return Ok(transparent_raster_paint());
+            };
+
+            let raster = rasterize_mesh_triangles(triangles, bounds, &mesh_transform);
+
+            Ok(ShadingPaint::RasterImage {
+                pixels: raster.pixels.into(),
+                width: raster.width,
+                height: raster.height,
+                dest_rect: raster.bounds,
+                transform: None,
+            })
+        }
         Shading::PatchMesh { bbox, patches, .. } => {
             let mesh_transform = match transform {
                 Some(value) => value,
@@ -142,5 +171,30 @@ pub fn build_shading_paint(
         Shading::Unsupported { name } => Err(PdfShadingError::UnsupportedFeature(format!(
             "Shading type '{name}' not implemented"
         ))),
+    }
+}
+
+fn has_paintable_bounds(bounds: &Rect) -> bool {
+    let normalized = bounds.normalized();
+    normalized.left.is_finite()
+        && normalized.top.is_finite()
+        && normalized.right.is_finite()
+        && normalized.bottom.is_finite()
+        && normalized.width() > 0.0
+        && normalized.height() > 0.0
+}
+
+fn transparent_raster_paint() -> ShadingPaint {
+    ShadingPaint::RasterImage {
+        pixels: Arc::from([0_u8, 0, 0, 0]),
+        width: 1,
+        height: 1,
+        dest_rect: Rect {
+            left: 0.0,
+            top: 0.0,
+            right: 1.0,
+            bottom: 1.0,
+        },
+        transform: None,
     }
 }

--- a/crates/pdf-shading/src/parse.rs
+++ b/crates/pdf-shading/src/parse.rs
@@ -1,9 +1,12 @@
-//! Parsing helpers for PDF shading dictionaries and streams.
+//! Top-level parsing for PDF shading dictionaries and streams.
+//!
+//! Mesh stream parsing lives in the dedicated free-form and patch-mesh
+//! modules. This module is responsible only for dispatching by shading type
+//! and parsing the non-mesh shading dictionaries.
 
-use num_traits::ToPrimitive;
 use pdf_color_space::color_space::ColorSpace;
 use pdf_function::function::{Function, FunctionImpl};
-use pdf_graphics::{color::Color, point::Point, rect::Rect};
+use pdf_graphics::rect::Rect;
 use pdf_object::{
     dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
     object_variant::ObjectVariant,
@@ -12,7 +15,9 @@ use pdf_object::{
 use crate::{
     color_stops::ColorStops,
     error::PdfShadingError,
-    model::{MeshPatch, Shading, ShadingType},
+    free_form_mesh::parse_free_form_triangle_mesh,
+    model::{Shading, ShadingType},
+    patch_mesh::parse_patch_mesh,
 };
 
 /// Parses a PDF shading object from a dictionary or stream object.
@@ -21,13 +26,15 @@ pub fn shading_from_dictionary(
     objects: &dyn ObjectResolver,
 ) -> Result<Shading, PdfShadingError> {
     let dictionary = object.try_dictionary(objects)?;
-    let shading_type_value = dictionary.required_number::<i32>("ShadingType", objects)?;
-    let shading_type = ShadingType::try_from(shading_type_value)?;
+    let shading_type = dictionary
+        .required_number::<i32>("ShadingType", objects)?
+        .try_into()?;
 
     match shading_type {
         ShadingType::FunctionBased => parse_function_based(dictionary, objects),
-        ShadingType::Axial => parse_axial(object, objects),
-        ShadingType::Radial => parse_radial(object, objects),
+        ShadingType::Axial => parse_axial(dictionary, objects),
+        ShadingType::Radial => parse_radial(dictionary, objects),
+        ShadingType::FreeFormTriangleMesh => parse_free_form_triangle_mesh(object, objects),
         ShadingType::CoonsPatchMesh | ShadingType::TensorProductPatchMesh => {
             parse_patch_mesh(object, objects, shading_type)
         }
@@ -37,15 +44,30 @@ pub fn shading_from_dictionary(
     }
 }
 
+/// Parses a single function or function array from a shading dictionary.
+pub(crate) fn parse_functions(
+    dictionary: &Dictionary,
+    objects: &dyn ObjectResolver,
+) -> Result<Vec<Function>, PdfShadingError> {
+    let function = objects.resolve_object(dictionary.get_or_err("Function")?)?;
+
+    match function {
+        ObjectVariant::Array(functions) => functions
+            .iter()
+            .map(|value| Function::parse(value, objects).map_err(PdfShadingError::from))
+            .collect(),
+        value => Ok(vec![Function::parse(value, objects)?]),
+    }
+}
+
+/// Parses a Type 1 function-based shading dictionary.
 fn parse_function_based(
     dictionary: &Dictionary,
     objects: &dyn ObjectResolver,
 ) -> Result<Shading, PdfShadingError> {
     let color_space = ColorSpace::from_dictionary(dictionary, objects)?;
     let background = dictionary.optional_vec_of::<f32>("Background", objects)?;
-    let bbox = dictionary
-        .optional_array_of::<f32, 4>("BBox", objects)?
-        .map(Rect::from);
+    let bbox = optional_bbox(dictionary, objects)?;
     let domain = dictionary.optional_vec_of::<f32>("Domain", objects)?;
     let anti_alias = dictionary.optional_boolean("AntiAlias", objects)?;
     let functions = parse_functions(dictionary, objects)?;
@@ -60,19 +82,14 @@ fn parse_function_based(
     })
 }
 
+/// Parses a Type 2 axial shading dictionary.
 fn parse_axial(
-    object: &ObjectVariant,
+    dictionary: &Dictionary,
     objects: &dyn ObjectResolver,
 ) -> Result<Shading, PdfShadingError> {
-    let dictionary = object.try_dictionary(objects)?;
     let coords = dictionary.required_array_of::<f32, 4>("Coords", objects)?;
-    let color_space = ColorSpace::from_dictionary(dictionary, objects)?.ok_or(
-        PdfShadingError::MissingRequiredEntry {
-            entry: "ColorSpace",
-        },
-    )?;
-    let function_object = dictionary.get_or_err("Function")?;
-    let function = Function::parse(function_object, objects)?;
+    let color_space = required_color_space(dictionary, objects)?;
+    let function = Function::parse(dictionary.get_or_err("Function")?, objects)?;
     let color_stops = ColorStops::from_function(&function, &color_space)?;
 
     Ok(Shading::Axial {
@@ -82,22 +99,15 @@ fn parse_axial(
     })
 }
 
+/// Parses a Type 3 radial shading dictionary.
 fn parse_radial(
-    object: &ObjectVariant,
+    dictionary: &Dictionary,
     objects: &dyn ObjectResolver,
 ) -> Result<Shading, PdfShadingError> {
-    let dictionary = object.try_dictionary(objects)?;
     let coords = dictionary.required_array_of::<f32, 6>("Coords", objects)?;
-    let color_space = ColorSpace::from_dictionary(dictionary, objects)?.ok_or(
-        PdfShadingError::MissingRequiredEntry {
-            entry: "ColorSpace",
-        },
-    )?;
-    let bbox = dictionary
-        .optional_array_of::<f32, 4>("BBox", objects)?
-        .map(Rect::from);
-    let function_object = dictionary.get_or_err("Function")?;
-    let function = Function::parse(function_object, objects)?;
+    let color_space = required_color_space(dictionary, objects)?;
+    let bbox = optional_bbox(dictionary, objects)?;
+    let function = Function::parse(dictionary.get_or_err("Function")?, objects)?;
     let color_stops = ColorStops::from_function(&function, &color_space)?;
 
     Ok(Shading::Radial {
@@ -108,534 +118,22 @@ fn parse_radial(
     })
 }
 
-fn parse_patch_mesh(
-    object: &ObjectVariant,
-    objects: &dyn ObjectResolver,
-    shading_type: ShadingType,
-) -> Result<Shading, PdfShadingError> {
-    let stream = object.try_stream(objects)?;
-    let dictionary = stream.dictionary.as_ref();
-    let color_space = ColorSpace::from_dictionary(dictionary, objects)?.ok_or(
-        PdfShadingError::MissingRequiredEntry {
-            entry: "ColorSpace",
-        },
-    )?;
-    let bits_per_coordinate = dictionary.required_number::<usize>("BitsPerCoordinate", objects)?;
-    let bits_per_component = dictionary.required_number::<usize>("BitsPerComponent", objects)?;
-    let bits_per_flag = dictionary.required_number::<usize>("BitsPerFlag", objects)?;
-    let decode_values = dictionary.required_vec_of::<f32>("Decode", objects)?;
-
-    if decode_values.len() < 6 || decode_values.len() % 2 != 0 {
-        return Err(PdfShadingError::InvalidShadingMeshData {
-            reason: "Decode array must contain coordinate and color ranges".to_string(),
-        });
-    }
-
-    let bbox = dictionary
-        .optional_array_of::<f32, 4>("BBox", objects)?
-        .map(Rect::from);
-    let anti_alias = dictionary.optional_boolean("AntiAlias", objects)?;
-    let functions = if dictionary.get("Function").is_some() {
-        parse_functions(dictionary, objects)?
-    } else {
-        Vec::new()
-    };
-
-    let component_inputs = decode_values
-        .len()
-        .checked_div(2)
-        .and_then(|pairs| pairs.checked_sub(2))
-        .ok_or_else(|| PdfShadingError::InvalidShadingMeshData {
-            reason: "Decode array does not include component ranges".to_string(),
-        })?;
-    let color_input_count = if functions.is_empty() {
-        color_space.num_color_components()
-    } else {
-        component_inputs
-    };
-
-    if color_input_count == 0 {
-        return Err(PdfShadingError::InvalidShadingMeshData {
-            reason: "Patch mesh color space requires at least one component".to_string(),
-        });
-    }
-
-    let params = MeshDecodeParams {
-        bits_per_coordinate,
-        bits_per_component,
-        decode_values: &decode_values,
-        color_input_count,
-        functions: &functions,
-        color_space: &color_space,
-    };
-
-    let mut reader = MeshSampleReader::new(stream.raw_data());
-    let mut patches = Vec::new();
-
-    while let Some(flag_bits) = reader.read_bits(bits_per_flag)? {
-        let flag =
-            u8::try_from(flag_bits).map_err(|_| PdfShadingError::InvalidShadingMeshData {
-                reason: "Patch flag does not fit into u8".to_string(),
-            })?;
-
-        let patch = match shading_type {
-            ShadingType::CoonsPatchMesh => {
-                let previous = match patches.last() {
-                    Some(MeshPatch::Coons {
-                        control_points,
-                        corner_colors,
-                    }) => Some(PreviousCoonsPatch {
-                        control_points,
-                        corner_colors,
-                    }),
-                    _ => None,
-                };
-                read_coons_patch(&mut reader, &params, flag, previous)?
-            }
-            ShadingType::TensorProductPatchMesh => {
-                let previous = match patches.last() {
-                    Some(MeshPatch::Tensor {
-                        control_points,
-                        corner_colors,
-                    }) => Some(PreviousTensorPatch {
-                        control_points,
-                        corner_colors,
-                    }),
-                    _ => None,
-                };
-                read_tensor_patch(&mut reader, &params, flag, previous)?
-            }
-            _ => break,
-        };
-        patches.push(patch);
-    }
-
-    if patches.is_empty() {
-        return Err(PdfShadingError::InvalidShadingMeshData {
-            reason: "Patch mesh stream did not contain any patches".to_string(),
-        });
-    }
-
-    Ok(Shading::PatchMesh {
-        shading_type,
-        color_space,
-        bbox,
-        anti_alias,
-        patches,
-    })
-}
-
-fn read_coons_patch(
-    reader: &mut MeshSampleReader<'_>,
-    params: &MeshDecodeParams<'_>,
-    flag: u8,
-    previous: Option<PreviousCoonsPatch<'_>>,
-) -> Result<MeshPatch, PdfShadingError> {
-    let mut control_points = if flag == 0 {
-        Vec::with_capacity(12)
-    } else {
-        Vec::from(coons_shared_edge_points(flag, previous)?)
-    };
-
-    while control_points.len() < 12 {
-        control_points.push(read_mesh_point(
-            reader,
-            params.bits_per_coordinate,
-            params.decode_values,
-        )?);
-    }
-
-    let mut corner_colors = if flag == 0 {
-        Vec::with_capacity(4)
-    } else {
-        Vec::from(coons_shared_edge_colors(flag, previous)?)
-    };
-
-    while corner_colors.len() < 4 {
-        corner_colors.push(read_mesh_color(reader, params)?);
-    }
-
-    let control_points: [Point; 12] =
-        control_points
-            .try_into()
-            .map_err(|_| PdfShadingError::InvalidShadingMeshData {
-                reason: "Coons patch did not contain 12 control points".to_string(),
-            })?;
-    let corner_colors: [Color; 4] =
-        corner_colors
-            .try_into()
-            .map_err(|_| PdfShadingError::InvalidShadingMeshData {
-                reason: "Coons patch did not contain 4 corner colors".to_string(),
-            })?;
-
-    Ok(MeshPatch::Coons {
-        control_points,
-        corner_colors,
-    })
-}
-
-fn read_tensor_patch(
-    reader: &mut MeshSampleReader<'_>,
-    params: &MeshDecodeParams<'_>,
-    flag: u8,
-    previous: Option<PreviousTensorPatch<'_>>,
-) -> Result<MeshPatch, PdfShadingError> {
-    let mut control_points = if flag == 0 {
-        Vec::with_capacity(16)
-    } else {
-        Vec::from(tensor_shared_edge_points(flag, previous)?)
-    };
-
-    while control_points.len() < 16 {
-        control_points.push(read_mesh_point(
-            reader,
-            params.bits_per_coordinate,
-            params.decode_values,
-        )?);
-    }
-
-    let mut corner_colors = if flag == 0 {
-        Vec::with_capacity(4)
-    } else {
-        Vec::from(tensor_shared_edge_colors(flag, previous)?)
-    };
-
-    while corner_colors.len() < 4 {
-        corner_colors.push(read_mesh_color(reader, params)?);
-    }
-
-    let control_points: [Point; 16] =
-        control_points
-            .try_into()
-            .map_err(|_| PdfShadingError::InvalidShadingMeshData {
-                reason: "Tensor patch did not contain 16 control points".to_string(),
-            })?;
-    let corner_colors: [Color; 4] =
-        corner_colors
-            .try_into()
-            .map_err(|_| PdfShadingError::InvalidShadingMeshData {
-                reason: "Tensor patch did not contain 4 corner colors".to_string(),
-            })?;
-
-    Ok(MeshPatch::Tensor {
-        control_points,
-        corner_colors,
-    })
-}
-
-fn read_mesh_point(
-    reader: &mut MeshSampleReader<'_>,
-    bits_per_coordinate: usize,
-    decode_values: &[f32],
-) -> Result<Point, PdfShadingError> {
-    let (x_min, x_max) = decode_pair(decode_values, 0, "X")?;
-    let (y_min, y_max) = decode_pair(decode_values, 1, "Y")?;
-    let x = decode_mesh_sample(
-        reader.read_required_bits(bits_per_coordinate)?.into(),
-        bits_per_coordinate,
-        x_min,
-        x_max,
-    )?;
-    let y = decode_mesh_sample(
-        reader.read_required_bits(bits_per_coordinate)?.into(),
-        bits_per_coordinate,
-        y_min,
-        y_max,
-    )?;
-    Ok(Point::new(x, y))
-}
-
-fn read_mesh_color(
-    reader: &mut MeshSampleReader<'_>,
-    params: &MeshDecodeParams<'_>,
-) -> Result<Color, PdfShadingError> {
-    let mut inputs = Vec::with_capacity(params.color_input_count);
-    for component_index in 0..params.color_input_count {
-        let (min, max) = decode_pair(
-            params.decode_values,
-            component_index.saturating_add(2),
-            "component",
-        )?;
-        let value = decode_mesh_sample(
-            reader.read_required_bits(params.bits_per_component)?.into(),
-            params.bits_per_component,
-            min,
-            max,
-        )?;
-        inputs.push(value);
-    }
-
-    let components =
-        if params.functions.is_empty() {
-            inputs
-        } else if params.functions.len() == 1 {
-            let function = params.functions.first().ok_or_else(|| {
-                PdfShadingError::InvalidShadingMeshData {
-                    reason: "Mesh shading function vector was unexpectedly empty".to_string(),
-                }
-            })?;
-            function.apply(&inputs)?
-        } else {
-            let mut outputs = Vec::with_capacity(params.functions.len());
-            for function in params.functions {
-                let mut values = function.apply(&inputs)?;
-                let value = values.drain(..1).next().ok_or_else(|| {
-                    PdfShadingError::InvalidShadingMeshData {
-                        reason: "Mesh shading function did not return any values".to_string(),
-                    }
-                })?;
-                outputs.push(value);
-            }
-            outputs
-        };
-
-    Ok(params.color_space.apply(&components)?)
-}
-
-fn decode_pair(
-    decode_values: &[f32],
-    pair_index: usize,
-    label: &str,
-) -> Result<(f32, f32), PdfShadingError> {
-    let first_index = pair_index.saturating_mul(2);
-    let second_index = first_index.saturating_add(1);
-    let min =
-        *decode_values
-            .get(first_index)
-            .ok_or_else(|| PdfShadingError::InvalidShadingMeshData {
-                reason: format!("Decode array is missing {label} minimum"),
-            })?;
-    let max = *decode_values.get(second_index).ok_or_else(|| {
-        PdfShadingError::InvalidShadingMeshData {
-            reason: format!("Decode array is missing {label} maximum"),
-        }
-    })?;
-    Ok((min, max))
-}
-
-fn decode_mesh_sample(
-    code: u64,
-    bits_per_sample: usize,
-    min: f32,
-    max: f32,
-) -> Result<f32, PdfShadingError> {
-    if bits_per_sample == 0 || bits_per_sample > 32 {
-        return Err(PdfShadingError::InvalidShadingMeshData {
-            reason: "BitsPerCoordinate/BitsPerComponent must be in 1..=32".to_string(),
-        });
-    }
-    let shift =
-        u32::try_from(bits_per_sample).map_err(|_| PdfShadingError::InvalidShadingMeshData {
-            reason: "Bits per sample value is too large".to_string(),
-        })?;
-    let max_value = 1_u64
-        .checked_shl(shift)
-        .ok_or_else(|| PdfShadingError::InvalidShadingMeshData {
-            reason: "Bits per sample shift overflowed".to_string(),
-        })?
-        .saturating_sub(1);
-    if max_value == 0 {
-        return Ok(min);
-    }
-    let code_f32 = code
-        .to_f32()
-        .ok_or_else(|| PdfShadingError::InvalidShadingMeshData {
-            reason: "Mesh sample code could not be represented as f32".to_string(),
-        })?;
-    let max_value_f32 =
-        max_value
-            .to_f32()
-            .ok_or_else(|| PdfShadingError::InvalidShadingMeshData {
-                reason: "Mesh sample range could not be represented as f32".to_string(),
-            })?;
-    let normalized = code_f32 / max_value_f32;
-    Ok(min + normalized * (max - min))
-}
-
-fn coons_shared_edge_points(
-    flag: u8,
-    previous: Option<PreviousCoonsPatch<'_>>,
-) -> Result<[Point; 4], PdfShadingError> {
-    let previous = previous.ok_or_else(|| PdfShadingError::InvalidShadingMeshData {
-        reason: format!("Coons continuation flag {flag} used without a previous patch"),
-    })?;
-    let &[p0, _p1, _p2, p3, p4, p5, p6, p7, p8, p9, p10, p11] = previous.control_points;
-
-    match flag {
-        1 => Ok([p3, p4, p5, p6]),
-        2 => Ok([p6, p7, p8, p9]),
-        3 => Ok([p9, p10, p11, p0]),
-        _ => Err(PdfShadingError::InvalidShadingMeshData {
-            reason: format!("Unsupported Coons continuation flag {flag}"),
-        }),
-    }
-}
-
-fn coons_shared_edge_colors(
-    flag: u8,
-    previous: Option<PreviousCoonsPatch<'_>>,
-) -> Result<[Color; 2], PdfShadingError> {
-    let previous = previous.ok_or_else(|| PdfShadingError::InvalidShadingMeshData {
-        reason: format!("Coons continuation flag {flag} used without a previous patch"),
-    })?;
-    let [c0, c1, c2, c3] = *previous.corner_colors;
-
-    match flag {
-        1 => Ok([c1, c2]),
-        2 => Ok([c2, c3]),
-        3 => Ok([c3, c0]),
-        _ => Err(PdfShadingError::InvalidShadingMeshData {
-            reason: format!("Unsupported Coons continuation flag {flag}"),
-        }),
-    }
-}
-
-fn tensor_shared_edge_points(
-    flag: u8,
-    previous: Option<PreviousTensorPatch<'_>>,
-) -> Result<[Point; 4], PdfShadingError> {
-    let previous = previous.ok_or_else(|| PdfShadingError::InvalidShadingMeshData {
-        reason: format!("Tensor continuation flag {flag} used without a previous patch"),
-    })?;
-    let &[
-        p0,
-        _p1,
-        _p2,
-        p3,
-        p4,
-        _p5,
-        _p6,
-        p7,
-        p8,
-        _p9,
-        _p10,
-        p11,
-        p12,
-        p13,
-        p14,
-        p15,
-    ] = previous.control_points;
-
-    match flag {
-        1 => Ok([p3, p7, p11, p15]),
-        2 => Ok([p15, p14, p13, p12]),
-        3 => Ok([p12, p8, p4, p0]),
-        _ => Err(PdfShadingError::InvalidShadingMeshData {
-            reason: format!("Unsupported tensor continuation flag {flag}"),
-        }),
-    }
-}
-
-fn tensor_shared_edge_colors(
-    flag: u8,
-    previous: Option<PreviousTensorPatch<'_>>,
-) -> Result<[Color; 2], PdfShadingError> {
-    let previous = previous.ok_or_else(|| PdfShadingError::InvalidShadingMeshData {
-        reason: format!("Tensor continuation flag {flag} used without a previous patch"),
-    })?;
-    let [c0, c1, c2, c3] = *previous.corner_colors;
-
-    match flag {
-        1 => Ok([c1, c2]),
-        2 => Ok([c2, c3]),
-        3 => Ok([c3, c0]),
-        _ => Err(PdfShadingError::InvalidShadingMeshData {
-            reason: format!("Unsupported tensor continuation flag {flag}"),
-        }),
-    }
-}
-
-fn parse_functions(
+/// Reads the required color space shared by shading types 2 through 7.
+pub(crate) fn required_color_space(
     dictionary: &Dictionary,
     objects: &dyn ObjectResolver,
-) -> Result<Vec<Function>, PdfShadingError> {
-    let function_obj = objects.resolve_object(dictionary.get_or_err("Function")?)?;
-
-    if let ObjectVariant::Array(array) = function_obj {
-        array
-            .iter()
-            .map(|value| Function::parse(value, objects).map_err(PdfShadingError::from))
-            .collect()
-    } else {
-        let function = Function::parse(function_obj, objects)?;
-        Ok(vec![function])
-    }
+) -> Result<ColorSpace, PdfShadingError> {
+    ColorSpace::from_dictionary(dictionary, objects)?.ok_or(PdfShadingError::MissingRequiredEntry {
+        entry: "ColorSpace",
+    })
 }
 
-struct MeshDecodeParams<'a> {
-    bits_per_coordinate: usize,
-    bits_per_component: usize,
-    decode_values: &'a [f32],
-    color_input_count: usize,
-    functions: &'a [Function],
-    color_space: &'a ColorSpace,
-}
-
-#[derive(Clone, Copy)]
-struct PreviousCoonsPatch<'a> {
-    control_points: &'a [Point; 12],
-    corner_colors: &'a [Color; 4],
-}
-
-#[derive(Clone, Copy)]
-struct PreviousTensorPatch<'a> {
-    control_points: &'a [Point; 16],
-    corner_colors: &'a [Color; 4],
-}
-
-struct MeshSampleReader<'a> {
-    data: &'a [u8],
-    bit_offset: usize,
-}
-
-impl<'a> MeshSampleReader<'a> {
-    fn new(data: &'a [u8]) -> Self {
-        Self {
-            data,
-            bit_offset: 0,
-        }
-    }
-
-    fn read_required_bits(&mut self, bits: usize) -> Result<u32, PdfShadingError> {
-        self.read_bits(bits)?
-            .ok_or_else(|| PdfShadingError::InvalidShadingMeshData {
-                reason: "Patch mesh stream ended unexpectedly".to_string(),
-            })
-    }
-
-    fn read_bits(&mut self, bits: usize) -> Result<Option<u32>, PdfShadingError> {
-        if bits == 0 || bits > 32 {
-            return Err(PdfShadingError::InvalidShadingMeshData {
-                reason: "Mesh bit widths must be in 1..=32".to_string(),
-            });
-        }
-
-        let required_bits = self.bit_offset.saturating_add(bits);
-        let required_bytes = required_bits.div_ceil(8);
-        if self.bit_offset >= self.data.len().saturating_mul(8) {
-            return Ok(None);
-        }
-        if required_bytes > self.data.len() {
-            return Err(PdfShadingError::InvalidShadingMeshData {
-                reason: "Patch mesh stream ended in the middle of a sample".to_string(),
-            });
-        }
-
-        let mut value = 0_u32;
-        for bit_index in 0..bits {
-            let absolute_bit = self.bit_offset.saturating_add(bit_index);
-            let byte_index = absolute_bit / 8;
-            let bit_in_byte = absolute_bit % 8;
-            let byte = self.data.get(byte_index).copied().ok_or_else(|| {
-                PdfShadingError::InvalidShadingMeshData {
-                    reason: "Patch mesh stream byte access overflowed".to_string(),
-                }
-            })?;
-            let bit = (byte >> (7_usize.saturating_sub(bit_in_byte))) & 1;
-            value <<= 1;
-            value |= u32::from(bit);
-        }
-        self.bit_offset = self.bit_offset.saturating_add(bits);
-        Ok(Some(value))
-    }
+/// Reads the optional shading bounding box.
+pub(crate) fn optional_bbox(
+    dictionary: &Dictionary,
+    objects: &dyn ObjectResolver,
+) -> Result<Option<Rect>, PdfShadingError> {
+    Ok(dictionary
+        .optional_array_of::<f32, 4>("BBox", objects)?
+        .map(Rect::from))
 }

--- a/crates/pdf-shading/src/patch_mesh.rs
+++ b/crates/pdf-shading/src/patch_mesh.rs
@@ -1,0 +1,364 @@
+//! Parsing for Type 6 Coons and Type 7 tensor-product patch meshes.
+
+use pdf_color_space::color_space::ColorSpace;
+use pdf_function::function::Function;
+use pdf_graphics::{color::Color, point::Point, rect::Rect};
+use pdf_object::{
+    dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
+    object_variant::ObjectVariant,
+};
+
+use crate::{
+    error::PdfShadingError,
+    mesh_decoder::{MeshBitWidths, MeshDecoder},
+    mesh_sample_reader::MeshSampleReader,
+    model::{MeshPatch, Shading, ShadingType},
+    parse::{optional_bbox, parse_functions, required_color_space},
+};
+
+const COONS_CONTROL_POINTS: usize = 12;
+const TENSOR_CONTROL_POINTS: usize = 16;
+const CORNER_COLORS: usize = 4;
+
+/// Parses a Type 6 or Type 7 patch-mesh shading stream.
+pub(crate) fn parse_patch_mesh(
+    object: &ObjectVariant,
+    objects: &dyn ObjectResolver,
+    shading_type: ShadingType,
+) -> Result<Shading, PdfShadingError> {
+    let kind = PatchKind::from_shading_type(shading_type)?;
+    let stream = object.try_stream(objects)?;
+    let config = PatchMeshConfig::parse(stream.dictionary.as_ref(), objects)?;
+    let patches = PatchMeshParser::new(stream.raw_data(), &config, kind)?.parse()?;
+
+    Ok(Shading::PatchMesh {
+        shading_type,
+        color_space: config.color_space,
+        bbox: config.bbox,
+        anti_alias: config.anti_alias,
+        patches,
+    })
+}
+
+/// The geometry layout selected by `/ShadingType`.
+#[derive(Debug, Clone, Copy)]
+enum PatchKind {
+    Coons,
+    Tensor,
+}
+
+impl PatchKind {
+    fn from_shading_type(shading_type: ShadingType) -> Result<Self, PdfShadingError> {
+        match shading_type {
+            ShadingType::CoonsPatchMesh => Ok(Self::Coons),
+            ShadingType::TensorProductPatchMesh => Ok(Self::Tensor),
+            _ => Err(invalid_mesh_data(format!(
+                "{shading_type} is not a patch-mesh shading type"
+            ))),
+        }
+    }
+}
+
+/// Owned dictionary values needed while parsing a patch stream.
+struct PatchMeshConfig {
+    color_space: ColorSpace,
+    bbox: Option<Rect>,
+    anti_alias: Option<bool>,
+    widths: MeshBitWidths,
+    decode: Vec<f32>,
+    functions: Vec<Function>,
+}
+
+impl PatchMeshConfig {
+    /// Reads and validates entries shared by Type 6 and Type 7 dictionaries.
+    fn parse(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+    ) -> Result<Self, PdfShadingError> {
+        let color_space = required_color_space(dictionary, objects)?;
+        let widths = MeshBitWidths::new(
+            dictionary.required_number::<usize>("BitsPerCoordinate", objects)?,
+            dictionary.required_number::<usize>("BitsPerComponent", objects)?,
+            dictionary.required_number::<usize>("BitsPerFlag", objects)?,
+        )?;
+        let decode = dictionary.required_vec_of::<f32>("Decode", objects)?;
+        let bbox = optional_bbox(dictionary, objects)?;
+        let anti_alias = dictionary.optional_boolean("AntiAlias", objects)?;
+        let functions = optional_functions(dictionary, objects)?;
+
+        Ok(Self {
+            color_space,
+            bbox,
+            anti_alias,
+            widths,
+            decode,
+            functions,
+        })
+    }
+}
+
+/// Stateful reconstruction of patches and their implicit shared edges.
+struct PatchMeshParser<'a> {
+    reader: MeshSampleReader<'a>,
+    decoder: MeshDecoder<'a>,
+    flag_width: usize,
+    kind: PatchKind,
+}
+
+impl<'a> PatchMeshParser<'a> {
+    /// Creates a parser borrowing the stream and its validated configuration.
+    fn new(
+        data: &'a [u8],
+        config: &'a PatchMeshConfig,
+        kind: PatchKind,
+    ) -> Result<Self, PdfShadingError> {
+        Ok(Self {
+            reader: MeshSampleReader::new(data),
+            decoder: MeshDecoder::new(
+                config.widths,
+                &config.decode,
+                &config.functions,
+                &config.color_space,
+                "Patch mesh",
+            )?,
+            flag_width: config.widths.flag(),
+            kind,
+        })
+    }
+
+    /// Consumes the packed stream and reconstructs all patches.
+    fn parse(mut self) -> Result<Vec<MeshPatch>, PdfShadingError> {
+        let mut patches = Vec::new();
+
+        while let Some(flag) = self.reader.read_bits(self.flag_width)? {
+            let flag = u8::try_from(flag & 0b11)
+                .map_err(|_| invalid_mesh_data("Patch flag does not fit into u8"))?;
+            let patch = self.read_patch(flag, patches.last())?;
+            patches.push(patch);
+        }
+
+        if patches.is_empty() {
+            return Err(invalid_mesh_data(
+                "Patch mesh stream did not contain any patches",
+            ));
+        }
+
+        Ok(patches)
+    }
+
+    fn read_patch(
+        &mut self,
+        flag: u8,
+        previous: Option<&MeshPatch>,
+    ) -> Result<MeshPatch, PdfShadingError> {
+        match self.kind {
+            PatchKind::Coons => self.read_coons_patch(flag, previous),
+            PatchKind::Tensor => self.read_tensor_patch(flag, previous),
+        }
+    }
+
+    /// Reads the explicit values of a Coons patch and prepends any shared edge.
+    fn read_coons_patch(
+        &mut self,
+        flag: u8,
+        previous: Option<&MeshPatch>,
+    ) -> Result<MeshPatch, PdfShadingError> {
+        let mut control_points = initial_coons_points(flag, previous)?;
+        self.read_points(&mut control_points, COONS_CONTROL_POINTS)?;
+
+        let mut corner_colors = initial_coons_colors(flag, previous)?;
+        self.read_colors(&mut corner_colors, CORNER_COLORS)?;
+
+        Ok(MeshPatch::Coons {
+            control_points: try_array(control_points, "12 Coons control points")?,
+            corner_colors: try_array(corner_colors, "4 Coons corner colors")?,
+        })
+    }
+
+    /// Reads the explicit values of a tensor patch and prepends any shared edge.
+    fn read_tensor_patch(
+        &mut self,
+        flag: u8,
+        previous: Option<&MeshPatch>,
+    ) -> Result<MeshPatch, PdfShadingError> {
+        let mut control_points = initial_tensor_points(flag, previous)?;
+        self.read_points(&mut control_points, TENSOR_CONTROL_POINTS)?;
+
+        let mut corner_colors = initial_tensor_colors(flag, previous)?;
+        self.read_colors(&mut corner_colors, CORNER_COLORS)?;
+
+        Ok(MeshPatch::Tensor {
+            control_points: try_array(control_points, "16 tensor control points")?,
+            corner_colors: try_array(corner_colors, "4 tensor corner colors")?,
+        })
+    }
+
+    fn read_points(
+        &mut self,
+        points: &mut Vec<Point>,
+        required: usize,
+    ) -> Result<(), PdfShadingError> {
+        while points.len() < required {
+            points.push(self.decoder.read_point(&mut self.reader)?);
+        }
+        Ok(())
+    }
+
+    fn read_colors(
+        &mut self,
+        colors: &mut Vec<Color>,
+        required: usize,
+    ) -> Result<(), PdfShadingError> {
+        while colors.len() < required {
+            colors.push(self.decoder.read_color(&mut self.reader)?);
+        }
+        Ok(())
+    }
+}
+
+fn initial_coons_points(
+    flag: u8,
+    previous: Option<&MeshPatch>,
+) -> Result<Vec<Point>, PdfShadingError> {
+    if flag == 0 {
+        return Ok(Vec::with_capacity(COONS_CONTROL_POINTS));
+    }
+    let (points, _) = previous_coons_patch(flag, previous)?;
+    let &[p0, _p1, _p2, p3, p4, p5, p6, p7, p8, p9, p10, p11] = points;
+    let shared = match flag {
+        1 => [p3, p4, p5, p6],
+        2 => [p6, p7, p8, p9],
+        3 => [p9, p10, p11, p0],
+        _ => return Err(invalid_continuation("Coons", flag)),
+    };
+    Ok(Vec::from(shared))
+}
+
+fn initial_coons_colors(
+    flag: u8,
+    previous: Option<&MeshPatch>,
+) -> Result<Vec<Color>, PdfShadingError> {
+    if flag == 0 {
+        return Ok(Vec::with_capacity(CORNER_COLORS));
+    }
+    let (_, colors) = previous_coons_patch(flag, previous)?;
+    Ok(Vec::from(shared_colors(flag, *colors, "Coons")?))
+}
+
+fn initial_tensor_points(
+    flag: u8,
+    previous: Option<&MeshPatch>,
+) -> Result<Vec<Point>, PdfShadingError> {
+    if flag == 0 {
+        return Ok(Vec::with_capacity(TENSOR_CONTROL_POINTS));
+    }
+    let (points, _) = previous_tensor_patch(flag, previous)?;
+    let &[
+        p0,
+        _p1,
+        _p2,
+        p3,
+        p4,
+        _p5,
+        _p6,
+        p7,
+        p8,
+        _p9,
+        _p10,
+        p11,
+        p12,
+        p13,
+        p14,
+        p15,
+    ] = points;
+    let shared = match flag {
+        1 => [p3, p7, p11, p15],
+        2 => [p15, p14, p13, p12],
+        3 => [p12, p8, p4, p0],
+        _ => return Err(invalid_continuation("Tensor", flag)),
+    };
+    Ok(Vec::from(shared))
+}
+
+fn initial_tensor_colors(
+    flag: u8,
+    previous: Option<&MeshPatch>,
+) -> Result<Vec<Color>, PdfShadingError> {
+    if flag == 0 {
+        return Ok(Vec::with_capacity(CORNER_COLORS));
+    }
+    let (_, colors) = previous_tensor_patch(flag, previous)?;
+    Ok(Vec::from(shared_colors(flag, *colors, "tensor")?))
+}
+
+fn shared_colors(
+    flag: u8,
+    [c0, c1, c2, c3]: [Color; 4],
+    kind: &str,
+) -> Result<[Color; 2], PdfShadingError> {
+    match flag {
+        1 => Ok([c1, c2]),
+        2 => Ok([c2, c3]),
+        3 => Ok([c3, c0]),
+        _ => Err(invalid_continuation(kind, flag)),
+    }
+}
+
+fn previous_coons_patch(
+    flag: u8,
+    previous: Option<&MeshPatch>,
+) -> Result<(&[Point; 12], &[Color; 4]), PdfShadingError> {
+    match previous {
+        Some(MeshPatch::Coons {
+            control_points,
+            corner_colors,
+        }) => Ok((control_points, corner_colors)),
+        _ => Err(missing_previous_patch("Coons", flag)),
+    }
+}
+
+fn previous_tensor_patch(
+    flag: u8,
+    previous: Option<&MeshPatch>,
+) -> Result<(&[Point; 16], &[Color; 4]), PdfShadingError> {
+    match previous {
+        Some(MeshPatch::Tensor {
+            control_points,
+            corner_colors,
+        }) => Ok((control_points, corner_colors)),
+        _ => Err(missing_previous_patch("Tensor", flag)),
+    }
+}
+
+fn try_array<T, const N: usize>(values: Vec<T>, expected: &str) -> Result<[T; N], PdfShadingError> {
+    values
+        .try_into()
+        .map_err(|_| invalid_mesh_data(format!("Patch did not contain {expected}")))
+}
+
+fn optional_functions(
+    dictionary: &Dictionary,
+    objects: &dyn ObjectResolver,
+) -> Result<Vec<Function>, PdfShadingError> {
+    if dictionary.get("Function").is_some() {
+        parse_functions(dictionary, objects)
+    } else {
+        Ok(Vec::new())
+    }
+}
+
+fn missing_previous_patch(kind: &str, flag: u8) -> PdfShadingError {
+    invalid_mesh_data(format!(
+        "{kind} continuation flag {flag} used without a previous patch"
+    ))
+}
+
+fn invalid_continuation(kind: &str, flag: u8) -> PdfShadingError {
+    invalid_mesh_data(format!("Unsupported {kind} continuation flag {flag}"))
+}
+
+fn invalid_mesh_data(reason: impl Into<String>) -> PdfShadingError {
+    PdfShadingError::InvalidShadingMeshData {
+        reason: reason.into(),
+    }
+}

--- a/crates/pdf-shading/tests/mesh.rs
+++ b/crates/pdf-shading/tests/mesh.rs
@@ -1,7 +1,12 @@
-use pdf_graphics::{color::Color, point::Point, rect::Rect, transform::Transform};
+#![allow(clippy::arithmetic_side_effects, clippy::expect_used)]
 
-use super::{
-    MeshPatchRef, patch_mesh_bounds, patch_subdivision, rasterize_patch_mesh, rasterize_triangle,
+use pdf_graphics::{color::Color, point::Point, rect::Rect, transform::Transform};
+use pdf_shading::{
+    mesh::{
+        MeshPatchRef, patch_mesh_bounds, patch_subdivision, rasterize_patch_mesh,
+        rasterize_triangle, rasterize_triangle_mesh, triangle_mesh_bounds,
+    },
+    model::{MeshTriangle, MeshVertex},
 };
 
 fn coons_patch() -> MeshPatchRef<'static> {
@@ -84,15 +89,15 @@ fn rasterize_triangle_writes_pixels() {
         bottom: 4.0,
     };
     let triangle = [
-        super::MeshVertex {
+        MeshVertex {
             point: Point::new(0.0, 0.0),
             color: Color::from_rgb(1.0, 0.0, 0.0),
         },
-        super::MeshVertex {
+        MeshVertex {
             point: Point::new(3.0, 0.0),
             color: Color::from_rgb(0.0, 1.0, 0.0),
         },
-        super::MeshVertex {
+        MeshVertex {
             point: Point::new(0.0, 3.0),
             color: Color::from_rgb(0.0, 0.0, 1.0),
         },
@@ -101,4 +106,51 @@ fn rasterize_triangle_writes_pixels() {
     rasterize_triangle(&mut pixels, 4, 4, &bounds, triangle);
 
     assert!(pixels.iter().any(|component| *component != 255));
+}
+
+#[test]
+fn triangle_mesh_bounds_and_raster_preserve_transparent_unpainted_pixels() {
+    let triangle = MeshTriangle {
+        vertices: [
+            MeshVertex {
+                point: Point::new(0.0, 0.0),
+                color: Color::from_rgb(1.0, 0.0, 0.0),
+            },
+            MeshVertex {
+                point: Point::new(4.0, 0.0),
+                color: Color::from_rgb(0.0, 1.0, 0.0),
+            },
+            MeshVertex {
+                point: Point::new(0.0, 4.0),
+                color: Color::from_rgb(0.0, 0.0, 1.0),
+            },
+        ],
+    };
+    let transform = Transform::from_translate(2.0, 3.0);
+    let bounds = triangle_mesh_bounds(std::iter::once(&triangle), &transform)
+        .expect("triangle should have bounds");
+    assert_eq!(
+        bounds,
+        Rect {
+            left: 2.0,
+            top: 3.0,
+            right: 6.0,
+            bottom: 7.0,
+        }
+    );
+
+    let raster = rasterize_triangle_mesh(std::iter::once(&triangle), bounds, &transform, 16);
+    let painted = raster
+        .pixels
+        .chunks_exact(4)
+        .next()
+        .expect("raster should contain a first pixel");
+    let unpainted = raster
+        .pixels
+        .chunks_exact(4)
+        .last()
+        .expect("raster should contain a last pixel");
+
+    assert_eq!(painted.get(3), Some(&u8::MAX));
+    assert_eq!(unpainted, [0, 0, 0, 0]);
 }

--- a/crates/pdf-shading/tests/mesh_decoder.rs
+++ b/crates/pdf-shading/tests/mesh_decoder.rs
@@ -1,0 +1,19 @@
+//! Unit tests for private mesh decoding helpers.
+
+use super::{MeshBitWidths, decode_sample};
+
+#[test]
+fn decodes_sample_range_endpoints_and_midpoint() {
+    assert_eq!(decode_sample(0, 8, -1.0, 1.0).expect("minimum"), -1.0);
+    assert_eq!(decode_sample(255, 8, -1.0, 1.0).expect("maximum"), 1.0);
+    let midpoint = decode_sample(128, 8, 0.0, 1.0).expect("midpoint");
+    assert!((midpoint - (128.0 / 255.0)).abs() < f32::EPSILON);
+}
+
+#[test]
+fn validates_pdf_mesh_bit_widths() {
+    assert!(MeshBitWidths::new(12, 4, 2).is_ok());
+    assert!(MeshBitWidths::new(3, 4, 2).is_err());
+    assert!(MeshBitWidths::new(8, 32, 2).is_err());
+    assert!(MeshBitWidths::new(8, 8, 1).is_err());
+}

--- a/crates/pdf-shading/tests/mesh_sample_reader.rs
+++ b/crates/pdf-shading/tests/mesh_sample_reader.rs
@@ -1,0 +1,36 @@
+//! Unit tests for the private packed-sample reader.
+
+use super::MeshSampleReader;
+
+#[test]
+fn reads_fields_across_byte_boundaries() {
+    let mut reader = MeshSampleReader::new(&[0b1011_0010, 0b0110_0000]);
+
+    assert_eq!(reader.read_bits(3).expect("first field"), Some(0b101));
+    assert_eq!(
+        reader.read_bits(7).expect("cross-byte field"),
+        Some(0b100_1001)
+    );
+    assert_eq!(reader.read_bits(6).expect("last field"), Some(0b10_0000));
+    assert_eq!(reader.read_bits(1).expect("end of stream"), None);
+}
+
+#[test]
+fn aligns_to_the_next_byte() {
+    let mut reader = MeshSampleReader::new(&[0b1110_0000, 0b1010_0101]);
+
+    assert_eq!(reader.read_bits(3).expect("prefix"), Some(0b111));
+    reader.align_to_byte();
+    assert_eq!(
+        reader.read_bits(8).expect("aligned byte"),
+        Some(0b1010_0101)
+    );
+}
+
+#[test]
+fn rejects_invalid_widths_and_truncated_fields() {
+    let mut reader = MeshSampleReader::new(&[0]);
+    assert!(reader.read_bits(0).is_err());
+    assert!(reader.read_bits(33).is_err());
+    assert!(reader.read_bits(9).is_err());
+}

--- a/crates/pdf-shading/tests/paint.rs
+++ b/crates/pdf-shading/tests/paint.rs
@@ -1,0 +1,133 @@
+#![allow(clippy::expect_used)]
+
+use pdf_color_space::color_space::ColorSpace;
+use pdf_graphics::{color::Color, point::Point, rect::Rect, transform::Transform};
+use pdf_shading::{
+    model::{MeshTriangle, MeshVertex, Shading},
+    paint::{ShadingPaint, build_shading_paint},
+};
+
+#[test]
+fn builds_transformed_free_form_triangle_raster_paint() {
+    let shading = Shading::FreeFormTriangleMesh {
+        color_space: ColorSpace::DeviceRGB,
+        bbox: None,
+        anti_alias: None,
+        triangles: vec![MeshTriangle {
+            vertices: [
+                MeshVertex {
+                    point: Point::new(0.0, 0.0),
+                    color: Color::from_rgb(1.0, 0.0, 0.0),
+                },
+                MeshVertex {
+                    point: Point::new(4.0, 0.0),
+                    color: Color::from_rgb(0.0, 1.0, 0.0),
+                },
+                MeshVertex {
+                    point: Point::new(0.0, 4.0),
+                    color: Color::from_rgb(0.0, 0.0, 1.0),
+                },
+            ],
+        }],
+    };
+
+    let paint = build_shading_paint(&shading, Some(Transform::from_translate(2.0, 3.0)))
+        .expect("free-form triangle mesh should build raster paint");
+    assert!(matches!(paint, ShadingPaint::RasterImage { .. }));
+    let ShadingPaint::RasterImage {
+        pixels,
+        width,
+        height,
+        dest_rect,
+        transform,
+    } = paint
+    else {
+        return;
+    };
+
+    assert_eq!(width, 4);
+    assert_eq!(height, 4);
+    assert_eq!(dest_rect.left, 2.0);
+    assert_eq!(dest_rect.top, 3.0);
+    assert_eq!(dest_rect.right, 6.0);
+    assert_eq!(dest_rect.bottom, 7.0);
+    assert_eq!(transform, None);
+    assert!(
+        pixels
+            .chunks_exact(4)
+            .any(|pixel| pixel.get(3) == Some(&u8::MAX))
+    );
+    assert!(pixels.chunks_exact(4).any(|pixel| pixel == [0, 0, 0, 0]));
+}
+
+#[test]
+fn free_form_triangle_mesh_falls_back_from_empty_bbox_to_geometry() {
+    let shading = Shading::FreeFormTriangleMesh {
+        color_space: ColorSpace::DeviceRGB,
+        bbox: Some(Rect {
+            left: 0.0,
+            top: 0.0,
+            right: 0.0,
+            bottom: 0.0,
+        }),
+        anti_alias: None,
+        triangles: vec![MeshTriangle {
+            vertices: [
+                MeshVertex {
+                    point: Point::new(10.0, 20.0),
+                    color: Color::from_rgb(1.0, 0.0, 0.0),
+                },
+                MeshVertex {
+                    point: Point::new(30.0, 20.0),
+                    color: Color::from_rgb(0.0, 1.0, 0.0),
+                },
+                MeshVertex {
+                    point: Point::new(10.0, 40.0),
+                    color: Color::from_rgb(0.0, 0.0, 1.0),
+                },
+            ],
+        }],
+    };
+
+    let paint =
+        build_shading_paint(&shading, None).expect("triangle geometry should provide bounds");
+    let ShadingPaint::RasterImage { dest_rect, .. } = paint else {
+        return;
+    };
+
+    assert_eq!(dest_rect.left, 10.0);
+    assert_eq!(dest_rect.top, 20.0);
+    assert_eq!(dest_rect.right, 30.0);
+    assert_eq!(dest_rect.bottom, 40.0);
+}
+
+#[test]
+fn fully_degenerate_free_form_mesh_builds_transparent_paint() {
+    let vertex = MeshVertex {
+        point: Point::new(5.0, 5.0),
+        color: Color::from_rgb(1.0, 0.0, 0.0),
+    };
+    let shading = Shading::FreeFormTriangleMesh {
+        color_space: ColorSpace::DeviceRGB,
+        bbox: None,
+        anti_alias: None,
+        triangles: vec![MeshTriangle {
+            vertices: [vertex; 3],
+        }],
+    };
+
+    let paint = build_shading_paint(&shading, None).expect("degenerate mesh should be a no-op");
+    let ShadingPaint::RasterImage {
+        pixels,
+        width,
+        height,
+        ..
+    } = paint
+    else {
+        return;
+    };
+
+    assert_eq!(width, 1);
+    assert_eq!(height, 1);
+    assert_eq!(pixels.as_ref(), [0, 0, 0, 0]);
+}

--- a/crates/pdf-shading/tests/parse.rs
+++ b/crates/pdf-shading/tests/parse.rs
@@ -1,0 +1,319 @@
+//! End-to-end regression tests for shading parsing.
+
+#![allow(clippy::expect_used, clippy::indexing_slicing)]
+
+use std::collections::BTreeMap;
+
+use pdf_object::{
+    dictionary::Dictionary, object_resolver::PassthroughResolver, object_variant::ObjectVariant,
+    stream::StreamObject,
+};
+use pdf_shading::{
+    error::PdfShadingError,
+    model::{MeshTriangle, Shading},
+};
+
+fn integer(value: i64) -> ObjectVariant {
+    ObjectVariant::Integer(value)
+}
+
+fn number_array(values: &[f32]) -> ObjectVariant {
+    ObjectVariant::Array(
+        values
+            .iter()
+            .map(|value| ObjectVariant::Real(f64::from(*value)))
+            .collect(),
+    )
+}
+
+fn type_2_rgb_function() -> ObjectVariant {
+    ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([
+        ("FunctionType".to_string(), integer(2)),
+        ("Domain".to_string(), number_array(&[0.0, 1.0])),
+        ("C0".to_string(), number_array(&[1.0, 0.0, 0.0])),
+        ("C1".to_string(), number_array(&[0.0, 0.0, 1.0])),
+        ("N".to_string(), ObjectVariant::Real(1.0)),
+    ]))))
+}
+
+fn free_form_stream(
+    data: Vec<u8>,
+    bits_per_flag: i64,
+    component_pairs: usize,
+    function: Option<ObjectVariant>,
+) -> ObjectVariant {
+    let mut decode = vec![0.0, 15.0, 0.0, 15.0];
+    for _ in 0..component_pairs {
+        decode.extend([0.0, 1.0]);
+    }
+    let mut entries = mesh_entries(4, 4, 4, bits_per_flag, decode);
+    if let Some(function) = function {
+        entries.insert("Function".to_string(), function);
+    }
+
+    shading_stream(entries, data)
+}
+
+fn patch_stream(
+    shading_type: i64,
+    data: Vec<u8>,
+    widths: [i64; 3],
+    decode: Vec<f32>,
+    function: Option<ObjectVariant>,
+) -> ObjectVariant {
+    let [coordinate, component, flag] = widths;
+    let mut entries = mesh_entries(shading_type, coordinate, component, flag, decode);
+    if let Some(function) = function {
+        entries.insert("Function".to_string(), function);
+    }
+    shading_stream(entries, data)
+}
+
+fn mesh_entries(
+    shading_type: i64,
+    bits_per_coordinate: i64,
+    bits_per_component: i64,
+    bits_per_flag: i64,
+    decode: Vec<f32>,
+) -> BTreeMap<String, ObjectVariant> {
+    BTreeMap::from([
+        ("ShadingType".to_string(), integer(shading_type)),
+        (
+            "ColorSpace".to_string(),
+            ObjectVariant::Name(b"DeviceRGB".to_vec()),
+        ),
+        (
+            "BitsPerCoordinate".to_string(),
+            integer(bits_per_coordinate),
+        ),
+        ("BitsPerComponent".to_string(), integer(bits_per_component)),
+        ("BitsPerFlag".to_string(), integer(bits_per_flag)),
+        ("Decode".to_string(), number_array(&decode)),
+    ])
+}
+
+fn shading_stream(entries: BTreeMap<String, ObjectVariant>, data: Vec<u8>) -> ObjectVariant {
+    ObjectVariant::Stream(StreamObject::new(
+        1,
+        0,
+        Box::new(Dictionary::new(entries)),
+        data,
+    ))
+}
+
+fn push_field(bits: &mut Vec<bool>, value: u32, width: usize) {
+    for shift in (0..width).rev() {
+        bits.push(value & (1_u32 << shift) != 0);
+    }
+}
+
+fn encode_vertex(flag: u32, point: [u32; 2], components: &[u32], bits_per_flag: usize) -> Vec<u8> {
+    let mut bits = Vec::new();
+    push_field(&mut bits, flag, bits_per_flag);
+    push_field(&mut bits, point[0], 4);
+    push_field(&mut bits, point[1], 4);
+    for component in components {
+        push_field(&mut bits, *component, 4);
+    }
+
+    bits.chunks(8)
+        .map(|chunk| {
+            let value = chunk
+                .iter()
+                .fold(0_u8, |value, bit| (value << 1) | u8::from(*bit));
+            value << (8_usize.saturating_sub(chunk.len()))
+        })
+        .collect()
+}
+
+fn append_vertex(
+    data: &mut Vec<u8>,
+    flag: u32,
+    point: [u32; 2],
+    components: &[u32],
+    bits_per_flag: usize,
+) {
+    data.extend(encode_vertex(flag, point, components, bits_per_flag));
+}
+
+fn parsed_triangles(object: &ObjectVariant) -> Vec<MeshTriangle> {
+    let shading = Shading::from_dictionary(object, &PassthroughResolver)
+        .expect("free-form triangle mesh should parse");
+    match shading {
+        Shading::FreeFormTriangleMesh { triangles, .. } => triangles,
+        _ => Vec::new(),
+    }
+}
+
+fn append_patch_record(data: &mut Vec<u8>, flag: u8, point_count: usize, color_count: usize) {
+    data.push(flag);
+    for index in 0..point_count {
+        data.extend([
+            u8::try_from(index).expect("test point index fits in u8"),
+            u8::try_from(index.saturating_add(1)).expect("test point index fits in u8"),
+        ]);
+    }
+    for index in 0..color_count {
+        let component =
+            u8::try_from(index.saturating_mul(32)).expect("test color component fits in u8");
+        data.extend([component, component, component]);
+    }
+}
+
+fn patch_decode() -> Vec<f32> {
+    vec![0.0, 255.0, 0.0, 255.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0]
+}
+
+#[test]
+fn parses_byte_aligned_free_form_triangle_vertices() {
+    let mut data = Vec::new();
+    append_vertex(&mut data, 0, [0, 0], &[15, 0, 0], 2);
+    append_vertex(&mut data, 3, [15, 0], &[0, 15, 0], 2);
+    append_vertex(&mut data, 3, [0, 15], &[0, 0, 15], 2);
+
+    let triangles = parsed_triangles(&free_form_stream(data, 2, 3, None));
+
+    assert_eq!(triangles.len(), 1);
+    let triangle = triangles.first().expect("triangle should exist");
+    let [red, green, blue] = triangle.vertices;
+    assert_eq!(red.point, pdf_graphics::point::Point::new(0.0, 0.0));
+    assert_eq!(green.point, pdf_graphics::point::Point::new(15.0, 0.0));
+    assert_eq!(blue.point, pdf_graphics::point::Point::new(0.0, 15.0));
+    assert_eq!(
+        red.color,
+        pdf_graphics::color::Color::from_rgb(1.0, 0.0, 0.0)
+    );
+    assert_eq!(
+        green.color,
+        pdf_graphics::color::Color::from_rgb(0.0, 1.0, 0.0)
+    );
+    assert_eq!(
+        blue.color,
+        pdf_graphics::color::Color::from_rgb(0.0, 0.0, 1.0)
+    );
+}
+
+#[test]
+fn reconstructs_free_form_continuations_from_low_flag_bits() {
+    let mut data = Vec::new();
+    append_vertex(&mut data, 0, [0, 0], &[15, 0, 0], 4);
+    append_vertex(&mut data, 0, [15, 0], &[0, 15, 0], 4);
+    append_vertex(&mut data, 0, [0, 15], &[0, 0, 15], 4);
+    append_vertex(&mut data, 0b1101, [15, 15], &[15, 15, 15], 4);
+    append_vertex(&mut data, 0b1110, [8, 8], &[0, 0, 0], 4);
+
+    let triangles = parsed_triangles(&free_form_stream(data, 4, 3, None));
+    let first = triangles.first().expect("first triangle should exist");
+    let second = triangles.get(1).expect("second triangle should exist");
+    let third = triangles.get(2).expect("third triangle should exist");
+
+    assert_eq!(
+        second.vertices,
+        [first.vertices[1], first.vertices[2], second.vertices[2]]
+    );
+    assert_eq!(
+        third.vertices,
+        [second.vertices[0], second.vertices[2], third.vertices[2]]
+    );
+}
+
+#[test]
+fn applies_optional_function_to_vertex_parameter() {
+    let mut data = Vec::new();
+    append_vertex(&mut data, 0, [0, 0], &[0], 2);
+    append_vertex(&mut data, 0, [15, 0], &[15], 2);
+    append_vertex(&mut data, 0, [0, 15], &[0], 2);
+
+    let triangles = parsed_triangles(&free_form_stream(data, 2, 1, Some(type_2_rgb_function())));
+    let triangle = triangles.first().expect("triangle should exist");
+
+    assert_eq!(
+        triangle.vertices[0].color,
+        pdf_graphics::color::Color::from_rgb(1.0, 0.0, 0.0)
+    );
+    assert_eq!(
+        triangle.vertices[1].color,
+        pdf_graphics::color::Color::from_rgb(0.0, 0.0, 1.0)
+    );
+}
+
+#[test]
+fn rejects_invalid_or_incomplete_triangle_streams() {
+    let error_cases = [
+        free_form_stream(Vec::new(), 2, 3, None),
+        free_form_stream(encode_vertex(1, [0, 0], &[15, 0, 0], 2), 2, 3, None),
+        free_form_stream(encode_vertex(3, [0, 0], &[15, 0, 0], 2), 2, 3, None),
+        free_form_stream(encode_vertex(0, [0, 0], &[15, 0, 0], 2), 2, 3, None),
+        free_form_stream(vec![0], 2, 3, None),
+    ];
+
+    for object in error_cases {
+        assert!(matches!(
+            Shading::from_dictionary(&object, &PassthroughResolver),
+            Err(PdfShadingError::InvalidShadingMeshData { .. })
+        ));
+    }
+}
+
+#[test]
+fn parses_coons_and_tensor_patch_streams() {
+    let cases = [(6, 12), (7, 16)];
+
+    for (shading_type, point_count) in cases {
+        let mut data = Vec::new();
+        append_patch_record(&mut data, 0, point_count, 4);
+        let object = patch_stream(shading_type, data, [8, 8, 8], patch_decode(), None);
+
+        let shading = Shading::from_dictionary(&object, &PassthroughResolver)
+            .expect("patch mesh should parse");
+        assert!(matches!(
+            shading,
+            Shading::PatchMesh { ref patches, .. } if patches.len() == 1
+        ));
+    }
+}
+
+#[test]
+fn patch_parser_uses_only_the_low_two_flag_bits() {
+    let mut data = Vec::new();
+    append_patch_record(&mut data, 0, 12, 4);
+    append_patch_record(&mut data, 0b1111_1101, 8, 2);
+    let object = patch_stream(6, data, [8, 8, 8], patch_decode(), None);
+
+    let shading =
+        Shading::from_dictionary(&object, &PassthroughResolver).expect("patches should parse");
+    assert!(matches!(
+        shading,
+        Shading::PatchMesh { ref patches, .. } if patches.len() == 2
+    ));
+}
+
+#[test]
+fn rejects_invalid_patch_widths_and_decode_arity() {
+    let error_cases = [
+        patch_stream(6, Vec::new(), [3, 8, 8], patch_decode(), None),
+        patch_stream(6, Vec::new(), [8, 3, 8], patch_decode(), None),
+        patch_stream(6, Vec::new(), [8, 8, 1], patch_decode(), None),
+        patch_stream(
+            6,
+            Vec::new(),
+            [8, 8, 8],
+            vec![0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
+            None,
+        ),
+        patch_stream(
+            6,
+            Vec::new(),
+            [8, 8, 8],
+            patch_decode(),
+            Some(type_2_rgb_function()),
+        ),
+    ];
+
+    for object in error_cases {
+        assert!(matches!(
+            Shading::from_dictionary(&object, &PassthroughResolver),
+            Err(PdfShadingError::InvalidShadingMeshData { .. })
+        ));
+    }
+}


### PR DESCRIPTION
Parse Type 4 free-form triangle meshes and Type 6/7 Coons and tensor patch meshes from packed shading streams, including continuation flags, decode ranges, optional functions, and malformed stream validation.

Rasterize Gouraud triangles with transparent uncovered pixels and use decal sampling in the Skia backend. Move shading models into the pdf-shading crate and add focused parser, decoder, paint, and mesh regressions.