### PR TITLE
pdf-object: add bounding box readers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,6 +2325,7 @@ name = "pdf-object"
 version = "0.1.0"
 dependencies = [
  "num-traits",
+ "pdf-graphics",
  "thiserror 2.0.12",
 ]
 

--- a/crates/pdf-object/Cargo.toml
+++ b/crates/pdf-object/Cargo.toml
@@ -12,4 +12,5 @@ default = []
 
 [dependencies]
 num-traits = "0.2.19"
+pdf-graphics = { path = "../pdf-graphics" }
 thiserror = "2.0.12"

--- a/crates/pdf-object/src/dictionary.rs
+++ b/crates/pdf-object/src/dictionary.rs
@@ -1,6 +1,11 @@
 use std::collections::BTreeMap;
 
-use crate::{error::ObjectError, object_variant::ObjectVariant};
+use pdf_graphics::rect::Rect;
+
+use crate::{
+    error::ObjectError, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
+    object_variant::ObjectVariant,
+};
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Dictionary {
@@ -77,11 +82,31 @@ impl Dictionary {
                 key: key.to_owned(),
             })
     }
+
+    /// Reads the optional `/BBox` entry as a rectangle.
+    ///
+    /// Missing entries and explicit PDF `null` values are treated as absent.
+    /// The coordinates are returned in their original order.
+    pub fn optional_bbox(&self, objects: &dyn ObjectResolver) -> Result<Option<Rect>, ObjectError> {
+        Ok(self
+            .optional_array_of::<f32, 4>("BBox", objects)?
+            .map(Rect::from))
+    }
+
+    /// Reads the required `/BBox` entry as a rectangle.
+    ///
+    /// The coordinates are returned in their original order.
+    pub fn required_bbox(&self, objects: &dyn ObjectResolver) -> Result<Rect, ObjectError> {
+        self.required_array_of::<f32, 4>("BBox", objects)
+            .map(Rect::from)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+
+    use crate::object_resolver::PassthroughResolver;
 
     use super::*;
 
@@ -136,5 +161,101 @@ mod tests {
             .expect_err("name is not an integer");
 
         assert_eq!(error, "expected integer");
+    }
+
+    #[test]
+    fn optional_bbox_parses_rectangle() {
+        let dictionary = dictionary_with(
+            "BBox",
+            ObjectVariant::Array(vec![
+                ObjectVariant::Integer(1),
+                ObjectVariant::Real(2.5),
+                ObjectVariant::Integer(3),
+                ObjectVariant::Real(4.5),
+            ]),
+        );
+
+        let bbox = dictionary
+            .optional_bbox(&PassthroughResolver)
+            .expect("bounding box parses");
+
+        assert_eq!(
+            bbox,
+            Some(Rect {
+                left: 1.0,
+                top: 2.5,
+                right: 3.0,
+                bottom: 4.5,
+            })
+        );
+    }
+
+    #[test]
+    fn optional_bbox_returns_none_for_missing_or_null_entry() {
+        let missing = Dictionary::new(BTreeMap::new());
+        let null = dictionary_with("BBox", ObjectVariant::Null);
+
+        assert_eq!(
+            missing
+                .optional_bbox(&PassthroughResolver)
+                .expect("missing bounding box is optional"),
+            None
+        );
+        assert_eq!(
+            null.optional_bbox(&PassthroughResolver)
+                .expect("null bounding box is optional"),
+            None
+        );
+    }
+
+    #[test]
+    fn required_bbox_parses_rectangle() {
+        let dictionary = dictionary_with(
+            "BBox",
+            ObjectVariant::Array(vec![
+                ObjectVariant::Integer(1),
+                ObjectVariant::Integer(2),
+                ObjectVariant::Integer(3),
+                ObjectVariant::Integer(4),
+            ]),
+        );
+
+        let bbox = dictionary
+            .required_bbox(&PassthroughResolver)
+            .expect("bounding box parses");
+
+        assert_eq!(
+            bbox,
+            Rect {
+                left: 1.0,
+                top: 2.0,
+                right: 3.0,
+                bottom: 4.0,
+            }
+        );
+    }
+
+    #[test]
+    fn required_bbox_propagates_invalid_array_length() {
+        let dictionary = dictionary_with(
+            "BBox",
+            ObjectVariant::Array(vec![
+                ObjectVariant::Integer(1),
+                ObjectVariant::Integer(2),
+                ObjectVariant::Integer(3),
+            ]),
+        );
+
+        let error = dictionary
+            .required_bbox(&PassthroughResolver)
+            .expect_err("bounding box must contain four numbers");
+
+        assert_eq!(
+            error,
+            ObjectError::InvalidArrayLength {
+                expected: 4,
+                found: 3,
+            }
+        );
     }
 }

--- a/crates/pdf-resources/src/form.rs
+++ b/crates/pdf-resources/src/form.rs
@@ -1,7 +1,6 @@
 use pdf_content_stream::{ContentStream, ContentStreamIdAllocator};
 use pdf_graphics::rect::Rect;
 use pdf_graphics::transform::Transform;
-use pdf_object::object_lookup::ObjectLookupExt;
 use pdf_object::{
     dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
 };
@@ -38,8 +37,7 @@ impl FormXObject {
         content_stream: ContentStream,
     ) -> Result<Self, PdfPagesError> {
         // Retrieve the `/BBox` entry.
-        let bbox =
-            Rect::from(dictionary.required_array_of::<f32, 4>("BBox", objects)?).normalized();
+        let bbox = dictionary.required_bbox(objects)?.normalized();
 
         // Retrieve the `/Matrix` entry if present.
         let matrix = Matrix::from_dictionary(dictionary, objects)?;

--- a/crates/pdf-resources/src/pattern.rs
+++ b/crates/pdf-resources/src/pattern.rs
@@ -160,9 +160,7 @@ impl Pattern {
                 let tiling_type = TilingType::try_from(tiling_type_int)?;
 
                 // Read the `/BBox` entry.
-                let bbox = dictionary
-                    .required_array_of::<f32, 4>("BBox", objects)?
-                    .into();
+                let bbox = dictionary.required_bbox(objects)?;
 
                 // Read the `/XStep` entry.
                 let x_step = dictionary.required_number::<f32>("XStep", objects)?;

--- a/crates/pdf-shading/src/free_form_mesh.rs
+++ b/crates/pdf-shading/src/free_form_mesh.rs
@@ -14,7 +14,7 @@ use crate::{
     error::PdfShadingError,
     mesh_decoder::{MeshBitWidths, MeshDecoder, read_mesh_bits},
     model::{MeshTriangle, MeshVertex, Shading},
-    parse::{optional_bbox, parse_functions, required_color_space},
+    parse::{parse_functions, required_color_space},
 };
 
 /// Errors produced while reconstructing a Type 4 free-form triangle mesh.
@@ -80,7 +80,7 @@ impl FreeFormMeshConfig {
             dictionary.required_number::<usize>("BitsPerFlag", objects)?,
         )?;
         let decode = dictionary.required_vec_of::<f32>("Decode", objects)?;
-        let bbox = optional_bbox(dictionary, objects)?;
+        let bbox = dictionary.optional_bbox(objects)?;
         let anti_alias = dictionary.optional_boolean("AntiAlias", objects)?;
         let functions = optional_functions(dictionary, objects)?;
 

--- a/crates/pdf-shading/src/parse.rs
+++ b/crates/pdf-shading/src/parse.rs
@@ -6,7 +6,6 @@
 
 use pdf_color_space::color_space::ColorSpace;
 use pdf_function::function::{Function, FunctionImpl};
-use pdf_graphics::rect::Rect;
 use pdf_object::{
     dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
     object_variant::ObjectVariant,
@@ -67,7 +66,7 @@ fn parse_function_based(
 ) -> Result<Shading, PdfShadingError> {
     let color_space = ColorSpace::from_dictionary(dictionary, objects)?;
     let background = dictionary.optional_vec_of::<f32>("Background", objects)?;
-    let bbox = optional_bbox(dictionary, objects)?;
+    let bbox = dictionary.optional_bbox(objects)?;
     let domain = dictionary.optional_vec_of::<f32>("Domain", objects)?;
     let anti_alias = dictionary.optional_boolean("AntiAlias", objects)?;
     let functions = parse_functions(dictionary, objects)?;
@@ -106,7 +105,7 @@ fn parse_radial(
 ) -> Result<Shading, PdfShadingError> {
     let coords = dictionary.required_array_of::<f32, 6>("Coords", objects)?;
     let color_space = required_color_space(dictionary, objects)?;
-    let bbox = optional_bbox(dictionary, objects)?;
+    let bbox = dictionary.optional_bbox(objects)?;
     let function = Function::parse(dictionary.get_or_err("Function")?, objects)?;
     let color_stops = ColorStops::from_function(&function, &color_space)?;
 
@@ -126,14 +125,4 @@ pub(crate) fn required_color_space(
     ColorSpace::from_dictionary(dictionary, objects)?.ok_or(PdfShadingError::MissingRequiredEntry {
         entry: "ColorSpace",
     })
-}
-
-/// Reads the optional shading bounding box.
-pub(crate) fn optional_bbox(
-    dictionary: &Dictionary,
-    objects: &dyn ObjectResolver,
-) -> Result<Option<Rect>, PdfShadingError> {
-    Ok(dictionary
-        .optional_array_of::<f32, 4>("BBox", objects)?
-        .map(Rect::from))
 }

--- a/crates/pdf-shading/src/patch_mesh_config.rs
+++ b/crates/pdf-shading/src/patch_mesh_config.rs
@@ -11,7 +11,7 @@ use crate::{
     error::PdfShadingError,
     mesh_decoder::{MeshBitWidths, MeshDecoder},
     model::{MeshPatch, Shading, ShadingType},
-    parse::{optional_bbox, parse_functions, required_color_space},
+    parse::{parse_functions, required_color_space},
 };
 
 /// Validated, owned values from a patch-mesh shading dictionary.
@@ -40,7 +40,7 @@ impl PatchMeshConfig {
             dictionary.required_number::<usize>("BitsPerFlag", objects)?,
         )?;
         let decode = dictionary.required_vec_of::<f32>("Decode", objects)?;
-        let bbox = optional_bbox(dictionary, objects)?;
+        let bbox = dictionary.optional_bbox(objects)?;
         let anti_alias = dictionary.optional_boolean("AntiAlias", objects)?;
         let functions = optional_functions(dictionary, objects)?;
 


### PR DESCRIPTION
Add optional and required Dictionary helpers for parsing /BBox entries directly into Rect values.

Use the shared readers for shading, form XObject, and tiling pattern parsing while preserving caller-specific normalization.