### PR TITLE
pdf-resources: remove color stops re-export

### DIFF
--- a/crates/pdf-resources/src/color_stops.rs
+++ b/crates/pdf-resources/src/color_stops.rs
@@ -1,3 +1,0 @@
-//! Compatibility re-export for the shared shading crate.
-
-pub use pdf_shading::color_stops::ColorStops;

--- a/crates/pdf-resources/src/lib.rs
+++ b/crates/pdf-resources/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod color_stops;
 pub mod error;
 pub mod external_graphics_state;
 pub mod form;


### PR DESCRIPTION
Remove the obsolete compatibility module now that color stops live in the shared shading crate.