### PR TITLE
pdf-graphics: preserve unknown blend modes

### DIFF
--- a/crates/pdf-canvas/src/canvas_external_object_ops.rs
+++ b/crates/pdf-canvas/src/canvas_external_object_ops.rs
@@ -135,7 +135,7 @@ impl<B: CanvasBackend> PdfCanvas<'_, B> {
             pixel_format: image.pixel_format,
         };
 
-        let blend_mode = self.current_state()?.blend_mode;
+        let blend_mode = self.current_state()?.blend_mode.clone();
         if inline_image {
             self.canvas.draw_inline_image(
                 &rendered_image,

--- a/crates/pdf-canvas/src/canvas_graphics_state_ops.rs
+++ b/crates/pdf-canvas/src/canvas_graphics_state_ops.rs
@@ -129,7 +129,7 @@ impl<B: CanvasBackend> GraphicsStateOps for PdfCanvas<'_, B> {
                         ));
                     }
                     if let Some(mode) = modes.first() {
-                        self.current_state_mut()?.blend_mode = Some(*mode);
+                        self.current_state_mut()?.blend_mode = Some(mode.clone());
                     }
                 }
                 ExternalGraphicsStateKey::SoftMask(smask) => {

--- a/crates/pdf-canvas/src/pdf_canvas.rs
+++ b/crates/pdf-canvas/src/pdf_canvas.rs
@@ -401,7 +401,7 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
 
         let fill_color = state.fill_color;
         let stroke_color = state.stroke_color;
-        let blend_mode = state.blend_mode;
+        let blend_mode = state.blend_mode.clone();
         let line_width = state.line_width * state.transform.sx;
         let stroke_style = StrokeStyle {
             dash_pattern: state.dash_pattern.clone(),
@@ -428,8 +428,13 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
             PaintMode::FillAndStroke => {
                 // First fill the path using the current fill settings
                 let fill_shader = self.compute_shader(false)?;
-                self.canvas
-                    .fill_path(path, fill_type, fill_color, &fill_shader, blend_mode)?;
+                self.canvas.fill_path(
+                    path,
+                    fill_type,
+                    fill_color,
+                    &fill_shader,
+                    blend_mode.clone(),
+                )?;
 
                 // Then stroke the path using the current stroke settings
                 let stroke_shader = self.compute_shader(true)?;

--- a/crates/pdf-canvas/src/recording_canvas.rs
+++ b/crates/pdf-canvas/src/recording_canvas.rs
@@ -110,7 +110,7 @@ impl RecordingCanvas {
                     shader,
                     blend_mode,
                 } => {
-                    backend.fill_path(path, *fill_type, *color, shader, *blend_mode)?;
+                    backend.fill_path(path, *fill_type, *color, shader, blend_mode.clone())?;
                 }
                 StrokePath {
                     path,
@@ -126,7 +126,7 @@ impl RecordingCanvas {
                         *line_width,
                         stroke_style,
                         shader,
-                        *blend_mode,
+                        blend_mode.clone(),
                     )?;
                 }
                 SetClipRegion { path, mode } => backend.set_clip_region(path, *mode)?,
@@ -138,7 +138,12 @@ impl RecordingCanvas {
                     dest_rect,
                     image_rotation,
                 } => {
-                    backend.draw_image_rect(image, *blend_mode, *dest_rect, *image_rotation)?;
+                    backend.draw_image_rect(
+                        image,
+                        blend_mode.clone(),
+                        *dest_rect,
+                        *image_rotation,
+                    )?;
                 }
                 DrawInlineImage {
                     image,
@@ -146,7 +151,12 @@ impl RecordingCanvas {
                     dest_rect,
                     image_rotation,
                 } => {
-                    backend.draw_inline_image(image, *blend_mode, *dest_rect, *image_rotation)?;
+                    backend.draw_inline_image(
+                        image,
+                        blend_mode.clone(),
+                        *dest_rect,
+                        *image_rotation,
+                    )?;
                 }
                 BeginMaskLayer {
                     transform,

--- a/crates/pdf-canvas/src/shading.rs
+++ b/crates/pdf-canvas/src/shading.rs
@@ -21,7 +21,7 @@ impl<B: CanvasBackend> ShadingOps for PdfCanvas<'_, B> {
         };
 
         let fill_color = state.fill_color;
-        let blend_mode = state.blend_mode;
+        let blend_mode = state.blend_mode.clone();
         let mat = state.transform;
         let shader = Some(self.build_shading_shader(shading, &Some(mat))?);
 

--- a/crates/pdf-graphics-skia/src/skia_canvas_backend.rs
+++ b/crates/pdf-graphics-skia/src/skia_canvas_backend.rs
@@ -200,6 +200,7 @@ fn to_skia_blend_mode(mode: BlendMode) -> skia_safe::BlendMode {
         BlendMode::Color => skia_safe::BlendMode::Color,
         BlendMode::Luminosity => skia_safe::BlendMode::Luminosity,
         BlendMode::DestinationIn => skia_safe::BlendMode::DstIn,
+        BlendMode::Unknown(_) => skia_safe::BlendMode::SrcOver,
     }
 }
 
@@ -655,5 +656,20 @@ impl CanvasBackend for SkiaCanvasBackend<'_> {
         self.surface.canvas().restore();
         self.surface.canvas().restore();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pdf_graphics::BlendMode;
+
+    use super::to_skia_blend_mode;
+
+    #[test]
+    fn unknown_blend_mode_uses_normal_compositing() {
+        assert_eq!(
+            to_skia_blend_mode(BlendMode::Unknown("VendorBlend".to_owned())),
+            skia_safe::BlendMode::SrcOver
+        );
     }
 }

--- a/crates/pdf-graphics/src/blend_mode.rs
+++ b/crates/pdf-graphics/src/blend_mode.rs
@@ -1,0 +1,61 @@
+/// Represents the blend mode used for compositing graphics.
+///
+/// Blend modes determine how colors from different layers are combined.
+#[derive(Debug, PartialEq, Clone)]
+pub enum BlendMode {
+    Normal,
+    Multiply,
+    Screen,
+    Overlay,
+    Darken,
+    Lighten,
+    ColorDodge,
+    ColorBurn,
+    HardLight,
+    SoftLight,
+    Difference,
+    Exclusion,
+    Hue,
+    Saturation,
+    Color,
+    Luminosity,
+    DestinationIn,
+    Unknown(String),
+}
+
+impl From<&str> for BlendMode {
+    fn from(value: &str) -> Self {
+        match value {
+            "Normal" => Self::Normal,
+            "Multiply" => Self::Multiply,
+            "Screen" => Self::Screen,
+            "Overlay" => Self::Overlay,
+            "Darken" => Self::Darken,
+            "Lighten" => Self::Lighten,
+            "ColorDodge" => Self::ColorDodge,
+            "ColorBurn" => Self::ColorBurn,
+            "HardLight" => Self::HardLight,
+            "SoftLight" => Self::SoftLight,
+            "Difference" => Self::Difference,
+            "Exclusion" => Self::Exclusion,
+            "Hue" => Self::Hue,
+            "Saturation" => Self::Saturation,
+            "Color" => Self::Color,
+            "Luminosity" => Self::Luminosity,
+            other => Self::Unknown(other.to_owned()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BlendMode;
+
+    #[test]
+    fn preserves_unknown_blend_mode() {
+        assert_eq!(
+            BlendMode::from("VendorBlend"),
+            BlendMode::Unknown("VendorBlend".to_owned())
+        );
+    }
+}

--- a/crates/pdf-graphics/src/lib.rs
+++ b/crates/pdf-graphics/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bezier;
+pub mod blend_mode;
 mod bounds_accumulator;
 pub mod color;
 pub mod dash_pattern;
@@ -7,6 +8,7 @@ pub mod point;
 pub mod rect;
 pub mod transform;
 
+pub use blend_mode::BlendMode;
 pub use bounds_accumulator::BoundsAccumulator;
 pub use dash_pattern::DashPattern;
 use num_derive::FromPrimitive;
@@ -31,32 +33,6 @@ pub enum LineJoin {
     Round = 1,
     /// Beveled (flattened) join at the corner.
     Bevel = 2,
-}
-
-/// Represents the standard blend modes allowed in PDF for compositing graphics.
-///
-/// Blend modes determine how colors from different layers are combined:
-/// - `Normal`: No blending, just overlays the color.
-/// - `Multiply`, `Screen`, `Overlay`, etc.: Various blending effects as defined by the PDF specification.
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub enum BlendMode {
-    Normal,
-    Multiply,
-    Screen,
-    Overlay,
-    Darken,
-    Lighten,
-    ColorDodge,
-    ColorBurn,
-    HardLight,
-    SoftLight,
-    Difference,
-    Exclusion,
-    Hue,
-    Saturation,
-    Color,
-    Luminosity,
-    DestinationIn,
 }
 
 /// Specifies how a path should be painted in PDF graphics operations.

--- a/crates/pdf-resources/src/external_graphics_state.rs
+++ b/crates/pdf-resources/src/external_graphics_state.rs
@@ -211,31 +211,6 @@ fn parse_font(
     Ok(ExternalGraphicsStateKey::Font(resource, font_size))
 }
 
-fn to_blend_mode(s: &str) -> Result<BlendMode, PdfPagesError> {
-    match s {
-        "Normal" => Ok(BlendMode::Normal),
-        "Multiply" => Ok(BlendMode::Multiply),
-        "Screen" => Ok(BlendMode::Screen),
-        "Overlay" => Ok(BlendMode::Overlay),
-        "Darken" => Ok(BlendMode::Darken),
-        "Lighten" => Ok(BlendMode::Lighten),
-        "ColorDodge" => Ok(BlendMode::ColorDodge),
-        "ColorBurn" => Ok(BlendMode::ColorBurn),
-        "HardLight" => Ok(BlendMode::HardLight),
-        "SoftLight" => Ok(BlendMode::SoftLight),
-        "Difference" => Ok(BlendMode::Difference),
-        "Exclusion" => Ok(BlendMode::Exclusion),
-        "Hue" => Ok(BlendMode::Hue),
-        "Saturation" => Ok(BlendMode::Saturation),
-        "Color" => Ok(BlendMode::Color),
-        "Luminosity" => Ok(BlendMode::Luminosity),
-        _ => Err(invalid_ext_gstate_entry_value(
-            "BM",
-            format!("unsupported blend mode '{s}'"),
-        )),
-    }
-}
-
 fn parse_blend_mode(
     value: &ObjectVariant,
     objects: &dyn ObjectResolver,
@@ -244,10 +219,10 @@ fn parse_blend_mode(
         value
             .try_array(objects)?
             .iter()
-            .map(|obj| to_blend_mode(obj.try_str(objects)?))
+            .map(|obj| obj.try_str(objects).map(BlendMode::from))
             .collect::<Result<Vec<BlendMode>, _>>()?
     } else {
-        let mode = to_blend_mode(value.try_str(objects)?)?;
+        let mode = BlendMode::from(value.try_str(objects)?);
         vec![mode]
     };
 


### PR DESCRIPTION
Move BlendMode into a dedicated module and convert PDF names through From<&str>. Preserve unsupported names as Unknown(String) instead of failing resource parsing.

Update canvas ownership for non-Copy modes and use normal compositing when Skia receives an unknown mode.