### PR TITLE
xtask: align Emscripten exception ABI

### DIFF
--- a/crates/pdf-canvas/src/pdf_canvas.rs
+++ b/crates/pdf-canvas/src/pdf_canvas.rs
@@ -350,8 +350,7 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
                     )
                 };
 
-                let filter: Option<&mut (dyn FnMut(&PdfOperatorVariant) -> bool)> = match paint_type
-                {
+                let filter: Option<&mut dyn FnMut(&PdfOperatorVariant) -> bool> = match paint_type {
                     PaintType::Colored => None,
                     PaintType::Uncolored => Some(&mut uncolored_filter),
                 };

--- a/crates/pdf-canvas/src/truetype_font_renderer.rs
+++ b/crates/pdf-canvas/src/truetype_font_renderer.rs
@@ -57,7 +57,7 @@ impl<'a, 'b, B: CanvasBackend> TrueTypeFontRenderer<'a, 'b, B> {
         );
 
         if glyph_id == GlyphId::NOTDEF && !self.is_symbolic {
-            println!("Warning: No glyph found for char code {}", code);
+            println!("Warning: No glyph found for char code {code}");
         }
 
         glyph_id

--- a/crates/pdf-content-stream/src/operator_stream_parser.rs
+++ b/crates/pdf-content-stream/src/operator_stream_parser.rs
@@ -152,7 +152,7 @@ fn map_operator_name_error(error: ParserError) -> PdfOperatorError {
         ParserError::UnexpectedEndOfFile => {
             PdfOperatorError::UnknownOperator("(end of input)".to_string())
         }
-        ParserError::InvalidToken(c) => PdfOperatorError::UnknownOperator(format!("{:?}", c)),
+        ParserError::InvalidToken(c) => PdfOperatorError::UnknownOperator(format!("{c:?}")),
         other => PdfOperatorError::ParserError(other),
     }
 }

--- a/crates/pdf-document/src/encryption.rs
+++ b/crates/pdf-document/src/encryption.rs
@@ -78,7 +78,7 @@ impl std::fmt::Display for EncryptionVersion {
             EncryptionVersion::V4 => 4,
             EncryptionVersion::V5 => 5,
         };
-        write!(f, "{}", version_num)
+        write!(f, "{version_num}")
     }
 }
 

--- a/crates/pdf-object-collection/src/object_collection.rs
+++ b/crates/pdf-object-collection/src/object_collection.rs
@@ -201,7 +201,7 @@ impl ObjectCollection {
                 // Encode hex string as base64 for JSON compatibility
                 use std::fmt::Write;
                 let hex: String = bytes.iter().fold(String::new(), |mut acc, b| {
-                    let _ = write!(acc, "{:02x}", b);
+                    let _ = write!(acc, "{b:02x}");
                     acc
                 });
                 json!({ "type": "HexString", "value": hex })

--- a/crates/pdf-parser/src/parser.rs
+++ b/crates/pdf-parser/src/parser.rs
@@ -319,7 +319,7 @@ impl<'a> PdfParser<'a> {
             PdfToken::LeftParenthesis => ObjectVariant::LiteralString(self.parse_literal_string()?),
             token => {
                 return Err(ParserError::UnexpectedTokenAt {
-                    token: format!("{:?}", token),
+                    token: format!("{token:?}"),
                     position: self.tokenizer.position,
                 });
             }

--- a/crates/pdf-tokenizer/src/error.rs
+++ b/crates/pdf-tokenizer/src/error.rs
@@ -37,11 +37,11 @@ impl std::fmt::Display for PdfToken {
             PdfToken::LeftParenthesis => write!(f, "("),
             PdfToken::RightParenthesis => write!(f, ")"),
             PdfToken::Solidus => write!(f, "/"),
-            PdfToken::Number(num) => write!(f, "{}", num),
+            PdfToken::Number(num) => write!(f, "{num}"),
             PdfToken::Alphabetic(c) => write!(f, "{}", char::from(*c)),
             PdfToken::NewLine => writeln!(f),
             PdfToken::CarriageReturn => write!(f, "\r"),
-            PdfToken::Unknown(byte) => write!(f, "Unknown token: {}", byte),
+            PdfToken::Unknown(byte) => write!(f, "Unknown token: {byte}"),
             PdfToken::Space => write!(f, " "),
         }
     }

--- a/examples/emscripten.rs
+++ b/examples/emscripten.rs
@@ -144,7 +144,7 @@ fn with_text_layout<R>(
                 let layout = match renderer.text_layout(page_index, width as f32, height as f32) {
                     Ok(layout) => layout,
                     Err(e) => {
-                        eprintln!("Text layout error: {:?}", e);
+                        eprintln!("Text layout error: {e:?}");
                         return None;
                     }
                 };
@@ -213,7 +213,7 @@ pub unsafe extern "C" fn sk_load_pdf(data_ptr: *const u8, data_len: usize) -> i3
             0
         }
         Err(e) => {
-            eprintln!("Failed to parse PDF: {:?}", e);
+            eprintln!("Failed to parse PDF: {e:?}");
             -1
         }
     }
@@ -301,7 +301,7 @@ pub extern "C" fn sk_render_page(width: i32, height: i32, page_index: usize) -> 
                 match render_page_cached(renderer, page_index, &mut cache, &mut skia_backend) {
                     Ok(()) => 0,
                     Err(e) => {
-                        eprintln!("Render error: {:?}", e);
+                        eprintln!("Render error: {e:?}");
                         -3
                     }
                 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
-channel = "1.89.0"
+# rust-skia 0.91's Emscripten binaries use the pre-1.89 JavaScript exception ABI.
+channel = "1.88"
 components = ["clippy", "rustfmt"]
 profile = "minimal"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -132,6 +132,8 @@ fn build_emscripten(
     let emsdk_path = get_emsdk_path(emsdk_override)?;
 
     // Set EMCC_CFLAGS
+    // Keep setjmp/longjmp on the JavaScript ABI used by rust-skia's
+    // precompiled Emscripten libraries.
     let emcc_cflags = [
         "--no-entry",
         "-sASSERTIONS=1",
@@ -140,6 +142,7 @@ fn build_emscripten(
         "-sENVIRONMENT=web",
         "-sERROR_ON_UNDEFINED_SYMBOLS=0",
         "-sMAX_WEBGL_VERSION=2",
+        "-sSUPPORT_LONGJMP=emscripten",
     ]
     .join(" ");
 
@@ -161,6 +164,7 @@ fn build_emscripten(
         "-C link-args=-sINITIAL_MEMORY=134217728",
         "-C link-args=-sSTACK_SIZE=2097152",
         "-C link-args=-sALLOW_MEMORY_GROWTH=1",
+        "-C link-args=-sSUPPORT_LONGJMP=emscripten",
     ]
     .join(" ");
 
@@ -206,7 +210,7 @@ fn build_emscripten(
         .context("Failed to execute cargo build")?;
 
     if !status.success() {
-        bail!("Cargo build failed with status: {}", status);
+        bail!("Cargo build failed with status: {status}");
     }
 
     // Copy artifacts
@@ -289,7 +293,7 @@ fn copy_artifacts(from: &Path, to: &Path) -> Result<()> {
 
         fs::copy(&src, &dst)
             .with_context(|| format!("Failed to copy {} to {}", src.display(), dst.display()))?;
-        println!("   ✓ {}", artifact);
+        println!("   ✓ {artifact}");
     }
 
     Ok(())
@@ -317,7 +321,7 @@ fn serve_examples(port: u16) -> Result<()> {
     let web_dir = root.join("examples").join("web");
 
     println!();
-    println!("🌐 Starting dev server at http://localhost:{}", port);
+    println!("🌐 Starting dev server at http://localhost:{port}");
     println!("   Press Ctrl+C to stop");
     println!();
 
@@ -332,7 +336,7 @@ fn serve_examples(port: u16) -> Result<()> {
         .context("Failed to start HTTP server. Make sure Python 3 is installed.")?;
 
     if !status.success() {
-        bail!("HTTP server exited with status: {}", status);
+        bail!("HTTP server exited with status: {status}");
     }
 
     Ok(())
@@ -364,7 +368,7 @@ fn clean() -> Result<()> {
         if path.exists() {
             fs::remove_file(&path)
                 .with_context(|| format!("Failed to remove {}", path.display()))?;
-            println!("   ✓ Removed examples/web/dist/{}", artifact);
+            println!("   ✓ Removed examples/web/dist/{artifact}");
         }
     }
 
@@ -375,7 +379,7 @@ fn clean() -> Result<()> {
         if path.exists() {
             fs::remove_file(&path)
                 .with_context(|| format!("Failed to remove {}", path.display()))?;
-            println!("   ✓ Removed examples/{}", artifact);
+            println!("   ✓ Removed examples/{artifact}");
         }
     }
 
@@ -406,7 +410,7 @@ fn generate_cmaps(source_dir: &Path, output: &Path) -> Result<()> {
         .context("Failed to execute pdf-cmap CMap generator")?;
 
     if !status.success() {
-        bail!("pdf-cmap CMap generator failed with status: {}", status);
+        bail!("pdf-cmap CMap generator failed with status: {status}");
     }
 
     Ok(())


### PR DESCRIPTION
Pin Rust to 1.88 to retain the JavaScript exception ABI expected by rust-skia 0.91's prebuilt libraries.

Pass SUPPORT_LONGJMP=emscripten through native compilation and the final link so Emscripten does not select an incompatible Wasm longjmp implementation.