### PR TITLE
pdf-image: separate metadata and sample decoding

### DIFF
--- a/crates/pdf-filter/src/filter.rs
+++ b/crates/pdf-filter/src/filter.rs
@@ -73,6 +73,81 @@ pub enum Filter {
     Unsupported(String),
 }
 
+/// An ordered chain of filters applied to a PDF stream.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Filters {
+    filters: Vec<Filter>,
+}
+
+impl Filters {
+    const KEY: &'static str = "Filter";
+
+    /// Returns whether the chain contains `filter`.
+    pub fn has_filter(&self, filter: &Filter) -> bool {
+        self.filters.contains(filter)
+    }
+
+    /// Returns whether the chain contains a JPEG 2000 decoding filter.
+    pub fn has_jpx_filter(&self) -> bool {
+        self.has_filter(&Filter::JPXDecode)
+    }
+
+    /// Returns whether the chain contains a JPEG decoding filter.
+    pub fn has_dct_filter(&self) -> bool {
+        self.has_filter(&Filter::DCTDecode)
+    }
+
+    /// Parses the `/Filter` entry from a PDF object dictionary.
+    ///
+    /// Returns `Ok(None)` when no `/Filter` key is present, or
+    /// `Ok(Some(filters))` with the ordered chain of filters to apply.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FilterError::Object`] if an object reference cannot be
+    /// resolved or a name cannot be extracted.
+    pub fn from_dictionary(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+    ) -> Result<Option<Self>, FilterError> {
+        let Some(filter_obj) = dictionary.get(Self::KEY) else {
+            return Ok(None);
+        };
+
+        let resolved = objects.resolve_object(filter_obj)?;
+
+        // Parse the `/Filter` entry: can be either a single Name or an Array of Names.
+        // Per PDF spec, filters are applied in order when multiple are present.
+        let filters = match resolved {
+            ObjectVariant::Array(arr) => arr
+                .iter()
+                .map(|item| item.try_str(objects).map(Filter::from))
+                .collect::<Result<Vec<_>, _>>()?,
+            other => {
+                // Handle single name that wasn't parsed as Name variant
+                vec![Filter::from(other.try_str(objects)?)]
+            }
+        };
+
+        Ok(Some(Self { filters }))
+    }
+}
+
+impl From<Vec<Filter>> for Filters {
+    fn from(filters: Vec<Filter>) -> Self {
+        Self { filters }
+    }
+}
+
+impl<'a> IntoIterator for &'a Filters {
+    type Item = &'a Filter;
+    type IntoIter = std::slice::Iter<'a, Filter>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.filters.iter()
+    }
+}
+
 impl From<&str> for Filter {
     fn from(name: &str) -> Self {
         match name {
@@ -114,8 +189,6 @@ impl fmt::Display for Filter {
 
 /// Methods for parsing the `/Filter` entry from a PDF dictionary.
 impl Filter {
-    const KEY: &'static str = "Filter";
-
     /// Parses the `/Filter` entry from a PDF object dictionary.
     ///
     /// Returns `Ok(None)` when no `/Filter` key is present, or
@@ -129,26 +202,7 @@ impl Filter {
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
     ) -> Result<Option<Vec<Filter>>, FilterError> {
-        let Some(filter_obj) = dictionary.get(Self::KEY) else {
-            return Ok(None);
-        };
-
-        let resolved = objects.resolve_object(filter_obj)?;
-
-        // Parse the `/Filter` entry: can be either a single Name or an Array of Names.
-        // Per PDF spec, filters are applied in order when multiple are present.
-        let filters = match resolved {
-            ObjectVariant::Array(arr) => arr
-                .iter()
-                .map(|item| item.try_str(objects).map(Filter::from))
-                .collect::<Result<Vec<_>, _>>()?,
-            other => {
-                // Handle single name that wasn't parsed as Name variant
-                vec![Filter::from(other.try_str(objects)?)]
-            }
-        };
-
-        Ok(Some(filters))
+        Ok(Filters::from_dictionary(dictionary, objects)?.map(|filters| filters.filters))
     }
 }
 
@@ -258,7 +312,7 @@ pub fn decode_data_with_resolver(
     objects: &dyn ObjectResolver,
 ) -> Result<Arc<Vec<u8>>, FilterError> {
     let mut data = stream_data;
-    let filters = Filter::from_dictionary(dictionary, objects)?;
+    let filters = Filters::from_dictionary(dictionary, objects)?;
 
     let Some(filters) = &filters else {
         return Ok(data);
@@ -269,7 +323,7 @@ pub fn decode_data_with_resolver(
         .map(|entry| objects.resolve_object(entry))
         .transpose()?;
 
-    for (index, filter) in filters.iter().enumerate() {
+    for (index, filter) in filters.into_iter().enumerate() {
         let param_dict = match decode_parms {
             None => None,
             Some(ObjectVariant::Dictionary(dictionary)) => Some(dictionary.as_ref()),
@@ -450,6 +504,15 @@ mod tests {
         let filter = Filter::from("JBIG2Decode");
         assert_eq!(filter, Filter::JBIG2Decode);
         assert_eq!(filter.to_string(), "JBIG2Decode");
+    }
+
+    #[test]
+    fn filter_chain_queries_detect_corresponding_variants() {
+        let filters = Filters::from(vec![Filter::ASCII85Decode, Filter::JPXDecode]);
+
+        assert!(filters.has_filter(&Filter::ASCII85Decode));
+        assert!(filters.has_jpx_filter());
+        assert!(!filters.has_dct_filter());
     }
 
     #[test]

--- a/crates/pdf-image/src/decoded_samples.rs
+++ b/crates/pdf-image/src/decoded_samples.rs
@@ -1,0 +1,202 @@
+use std::borrow::Cow;
+
+use pdf_color_space::{color_space::ColorSpace, indexed_color_space::IndexedColorSpace};
+use pdf_decode::{DecodeMap, SampleLayout, decode_sample_bytes, expand_indexed_values};
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
+
+use crate::error::PdfImageError;
+use crate::image_metadata::ImageMetadata;
+
+/// Stores decoded sample bytes before the final pixel format conversion.
+#[derive(Debug, Clone)]
+pub(crate) struct DecodedSamples {
+    pub(crate) bits_per_component: usize,
+    pub(crate) stored_color_space: Option<ColorSpace>,
+    pub(crate) num_color_components: usize,
+    pub(crate) image_data: Vec<u8>,
+}
+
+impl DecodedSamples {
+    /// Decodes raw image bytes into component samples based on the configured color space.
+    pub(crate) fn decode(
+        dictionary: &Dictionary,
+        raw_data: &[u8],
+        objects: &dyn ObjectResolver,
+        metadata: &ImageMetadata,
+    ) -> Result<Self, PdfImageError> {
+        if let Some(decoded_samples) = Self::decode_preconverted_jpx(raw_data, metadata) {
+            return Ok(decoded_samples);
+        }
+
+        if let Some(decoded_samples) = Self::decode_preconverted_dct(raw_data, metadata) {
+            return Ok(decoded_samples);
+        }
+
+        match metadata.color_space.as_ref() {
+            Some(ColorSpace::Indexed(indexed)) => {
+                Self::decode_indexed(dictionary, raw_data, objects, metadata, indexed)
+            }
+            _ => Self::decode_direct(dictionary, raw_data, objects, metadata),
+        }
+    }
+
+    /// Uses DCT decoder output as display samples when the JPEG decoder already converted color.
+    fn decode_preconverted_dct(raw_data: &[u8], metadata: &ImageMetadata) -> Option<Self> {
+        let has_dct_filter = metadata
+            .filters
+            .as_ref()
+            .is_some_and(|filters| filters.has_dct_filter());
+        if metadata.bits_per_component != 8 || !has_dct_filter {
+            return None;
+        }
+
+        let num_pixels = metadata.width.saturating_mul(metadata.height);
+        let num_color_components = Self::decoded_dct_component_count(raw_data, num_pixels)
+            .or_else(|| Self::decoded_single_pixel_component_count(raw_data))?;
+
+        let stored_color_space = match num_color_components {
+            1 => Some(ColorSpace::DeviceGray),
+            3 => Some(ColorSpace::DeviceRGB),
+            _ => metadata.color_space.clone(),
+        };
+        let image_data = if raw_data.len() == num_color_components && num_pixels > 1 {
+            raw_data.repeat(num_pixels)
+        } else {
+            raw_data.to_vec()
+        };
+
+        Some(Self {
+            bits_per_component: metadata.bits_per_component,
+            stored_color_space,
+            num_color_components,
+            image_data,
+        })
+    }
+
+    /// Uses JPX decoder output as display samples when the decoder already expanded pixels.
+    fn decode_preconverted_jpx(raw_data: &[u8], metadata: &ImageMetadata) -> Option<Self> {
+        let has_jpx_filter = metadata
+            .filters
+            .as_ref()
+            .is_some_and(|filters| filters.has_jpx_filter());
+        if !has_jpx_filter {
+            return None;
+        }
+
+        let num_pixels = metadata.width.saturating_mul(metadata.height);
+        let bytes_per_pixel = raw_data.len().checked_div(num_pixels)?;
+        if bytes_per_pixel.saturating_mul(num_pixels) != raw_data.len() {
+            return None;
+        }
+
+        let (num_color_components, bits_per_component, stored_color_space) = match bytes_per_pixel {
+            1 => (1, 8, Some(ColorSpace::DeviceGray)),
+            2 => (1, 16, Some(ColorSpace::DeviceGray)),
+            3 => (3, 8, Some(ColorSpace::DeviceRGB)),
+            6 => (3, 16, Some(ColorSpace::DeviceRGB)),
+            _ => return None,
+        };
+
+        Some(Self {
+            bits_per_component,
+            stored_color_space,
+            num_color_components,
+            image_data: raw_data.to_vec(),
+        })
+    }
+
+    fn decoded_dct_component_count(raw_data: &[u8], num_pixels: usize) -> Option<usize> {
+        [1, 3, 4]
+            .into_iter()
+            .find(|components| raw_data.len() == num_pixels.saturating_mul(*components))
+    }
+
+    fn decoded_single_pixel_component_count(raw_data: &[u8]) -> Option<usize> {
+        [1, 3, 4]
+            .into_iter()
+            .find(|components| raw_data.len() == *components)
+    }
+
+    /// Decodes indexed image samples, applies `/Decode`, and expands palette entries.
+    fn decode_indexed(
+        dictionary: &Dictionary,
+        raw_data: &[u8],
+        objects: &dyn ObjectResolver,
+        metadata: &ImageMetadata,
+        indexed: &IndexedColorSpace,
+    ) -> Result<Self, PdfImageError> {
+        let sample_codes = Self::decode_image_sample_codes(raw_data, 1, metadata)?;
+        let sample_max = Self::sample_max(metadata.bits_per_component)?;
+        let decode = DecodeMap::from_dictionary(dictionary, objects, 1, metadata.image_mask)?;
+        let decoded_indices = decode.apply_to_bytes(sample_codes.as_ref(), sample_max, sample_max);
+        let base_components = indexed.base.num_color_components();
+
+        let image_data = expand_indexed_values(
+            &decoded_indices,
+            &indexed.lookup,
+            indexed.hival,
+            base_components,
+        )?;
+
+        Ok(Self {
+            bits_per_component: metadata.bits_per_component,
+            stored_color_space: Some(*indexed.base.clone()),
+            num_color_components: base_components,
+            image_data,
+        })
+    }
+
+    /// Decodes non-indexed image samples and applies the `/Decode` transform.
+    fn decode_direct(
+        dictionary: &Dictionary,
+        raw_data: &[u8],
+        objects: &dyn ObjectResolver,
+        metadata: &ImageMetadata,
+    ) -> Result<Self, PdfImageError> {
+        let num_components = metadata
+            .color_space
+            .as_ref()
+            .map_or(1, ColorSpace::num_color_components);
+        let sample_codes = Self::decode_image_sample_codes(raw_data, num_components, metadata)?;
+        let decode =
+            DecodeMap::from_dictionary(dictionary, objects, num_components, metadata.image_mask)?;
+
+        Ok(Self {
+            bits_per_component: metadata.bits_per_component,
+            stored_color_space: metadata.color_space.clone(),
+            num_color_components: num_components,
+            image_data: decode.apply_to_bytes(
+                sample_codes.as_ref(),
+                Self::sample_max(metadata.bits_per_component)?,
+                255,
+            ),
+        })
+    }
+
+    fn decode_image_sample_codes<'a>(
+        raw_data: &'a [u8],
+        samples_per_pixel: usize,
+        metadata: &ImageMetadata,
+    ) -> Result<Cow<'a, [u8]>, PdfImageError> {
+        Ok(decode_sample_bytes(
+            raw_data,
+            metadata.bits_per_component,
+            SampleLayout::RowAligned {
+                width: metadata.width,
+                height: metadata.height,
+                samples_per_pixel,
+            },
+        )?)
+    }
+
+    /// Returns the maximum encoded sample value for a supported bit depth.
+    fn sample_max(bits_per_component: usize) -> Result<u8, PdfImageError> {
+        match bits_per_component {
+            1 => Ok(1),
+            2 => Ok(3),
+            4 => Ok(15),
+            8 => Ok(255),
+            _ => Err(PdfImageError::UnsupportedImageBitsPerComponent { bits_per_component }),
+        }
+    }
+}

--- a/crates/pdf-image/src/image_metadata.rs
+++ b/crates/pdf-image/src/image_metadata.rs
@@ -1,0 +1,297 @@
+use pdf_color_space::color_space::ColorSpace;
+use pdf_filter::filter::Filters;
+use pdf_object::{
+    dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
+};
+
+use crate::error::PdfImageError;
+
+/// Stores the normalized metadata needed to decode an image stream.
+#[derive(Debug, Clone)]
+pub(crate) struct ImageMetadata {
+    pub(crate) width: usize,
+    pub(crate) height: usize,
+    pub(crate) bits_per_component: usize,
+    pub(crate) color_space: Option<ColorSpace>,
+    pub(crate) image_mask: bool,
+    pub(crate) filters: Option<Filters>,
+}
+
+impl ImageMetadata {
+    /// Reads and validates normalized image metadata from an image dictionary.
+    pub(crate) fn from_dictionary(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+    ) -> Result<Self, PdfImageError> {
+        let width = dictionary.required_number::<usize>("Width", objects)?;
+        let height = dictionary.required_number::<usize>("Height", objects)?;
+
+        if width == 0 || height == 0 {
+            return Err(PdfImageError::InvalidImageDimensions { width, height });
+        }
+
+        let image_mask = dictionary
+            .optional_boolean("ImageMask", objects)?
+            .unwrap_or(false);
+        let (bits_per_component, color_space, filters) = if image_mask {
+            let bits_per_component = dictionary
+                .optional_number::<usize>("BitsPerComponent", objects)?
+                .unwrap_or(1);
+            validate_bits_per_component(bits_per_component, image_mask, None)?;
+            let filters = Filters::from_dictionary(dictionary, objects)?;
+            (bits_per_component, None, filters)
+        } else {
+            let filters = Filters::from_dictionary(dictionary, objects)?;
+            let has_jpx_filter = filters.as_ref().is_some_and(Filters::has_jpx_filter);
+            let bits_per_component = if has_jpx_filter {
+                dictionary
+                    .optional_number::<usize>("BitsPerComponent", objects)?
+                    .unwrap_or(8)
+            } else {
+                dictionary.required_number::<usize>("BitsPerComponent", objects)?
+            };
+            let color_space = ColorSpace::from_dictionary(dictionary, objects)?;
+            validate_bits_per_component(bits_per_component, image_mask, color_space.as_ref())?;
+            (bits_per_component, color_space, filters)
+        };
+
+        Ok(Self {
+            width,
+            height,
+            bits_per_component,
+            color_space,
+            image_mask,
+            filters,
+        })
+    }
+}
+
+/// Validates the allowed bit depths for indexed and non-indexed images.
+fn validate_bits_per_component(
+    bits_per_component: usize,
+    image_mask: bool,
+    color_space: Option<&ColorSpace>,
+) -> Result<(), PdfImageError> {
+    if image_mask {
+        return match bits_per_component {
+            1 => Ok(()),
+            _ => Err(PdfImageError::UnsupportedImageBitsPerComponent { bits_per_component }),
+        };
+    }
+
+    if matches!(color_space, Some(ColorSpace::Indexed(_))) {
+        return match bits_per_component {
+            1 | 2 | 4 | 8 => Ok(()),
+            _ => Err(PdfImageError::UnsupportedIndexedBits { bits_per_component }),
+        };
+    }
+
+    match bits_per_component {
+        1 | 8 => Ok(()),
+        _ => Err(PdfImageError::UnsupportedImageBitsPerComponent { bits_per_component }),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use pdf_filter::filter::{Filter, Filters};
+    use pdf_object::{
+        dictionary::Dictionary, error::ObjectError, object_resolver::PassthroughResolver,
+        object_variant::ObjectVariant,
+    };
+
+    use super::ImageMetadata;
+    use crate::error::PdfImageError;
+
+    #[test]
+    fn rejects_zero_dimensions() {
+        let dictionary = direct_dictionary(0, 1, 8);
+
+        let error = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect_err("zero width should be rejected");
+
+        assert!(matches!(
+            error,
+            PdfImageError::InvalidImageDimensions {
+                width: 0,
+                height: 1
+            }
+        ));
+    }
+
+    #[test]
+    fn image_mask_defaults_bits_per_component_to_one() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("ImageMask".to_string(), ObjectVariant::Boolean(true)),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
+        ]));
+
+        let metadata = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect("image mask metadata should be valid");
+
+        assert_eq!(metadata.bits_per_component, 1);
+        assert!(metadata.color_space.is_none());
+        assert!(metadata.image_mask);
+        assert!(metadata.filters.is_none());
+    }
+
+    #[test]
+    fn image_mask_rejects_non_one_bit_components() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            ("BitsPerComponent".to_string(), ObjectVariant::Integer(8)),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("ImageMask".to_string(), ObjectVariant::Boolean(true)),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
+        ]));
+
+        let error = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect_err("8-bpc image mask should be rejected");
+
+        assert!(matches!(
+            error,
+            PdfImageError::UnsupportedImageBitsPerComponent {
+                bits_per_component: 8
+            }
+        ));
+    }
+
+    #[test]
+    fn indexed_images_accept_two_bit_components() {
+        let dictionary = indexed_dictionary(2);
+
+        let metadata = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect("2-bpc indexed metadata should be valid");
+
+        assert_eq!(metadata.bits_per_component, 2);
+    }
+
+    #[test]
+    fn indexed_images_reject_unsupported_bit_components() {
+        let dictionary = indexed_dictionary(3);
+
+        let error = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect_err("3-bpc indexed metadata should be rejected");
+
+        assert!(matches!(
+            error,
+            PdfImageError::UnsupportedIndexedBits {
+                bits_per_component: 3
+            }
+        ));
+    }
+
+    #[test]
+    fn direct_images_reject_unsupported_bit_components() {
+        let dictionary = direct_dictionary(1, 1, 2);
+
+        let error = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect_err("2-bpc direct metadata should be rejected");
+
+        assert!(matches!(
+            error,
+            PdfImageError::UnsupportedImageBitsPerComponent {
+                bits_per_component: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn jpx_images_default_bits_per_component_to_eight() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            (
+                "Filter".to_string(),
+                ObjectVariant::Name(b"JPXDecode".to_vec()),
+            ),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
+        ]));
+
+        let metadata = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect("JPX metadata should default missing BitsPerComponent");
+
+        assert_eq!(metadata.bits_per_component, 8);
+        assert_eq!(
+            metadata.filters,
+            Some(Filters::from(vec![Filter::JPXDecode]))
+        );
+    }
+
+    #[test]
+    fn stores_ordered_filter_chain() {
+        let mut dictionary = direct_dictionary(1, 1, 8);
+        dictionary.dictionary.insert(
+            "Filter".to_string(),
+            ObjectVariant::Array(vec![
+                ObjectVariant::Name(b"ASCII85Decode".to_vec()),
+                ObjectVariant::Name(b"DCTDecode".to_vec()),
+            ]),
+        );
+
+        let metadata = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect("ordered filter chain should parse");
+
+        assert_eq!(
+            metadata.filters,
+            Some(Filters::from(vec![
+                Filter::ASCII85Decode,
+                Filter::DCTDecode
+            ]))
+        );
+    }
+
+    #[test]
+    fn non_jpx_images_require_bits_per_component() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
+        ]));
+
+        let error = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect_err("non-JPX metadata should require BitsPerComponent");
+
+        assert!(matches!(
+            error,
+            PdfImageError::Object(ObjectError::MissingRequiredKey { ref key })
+                if key == "BitsPerComponent"
+        ));
+    }
+
+    fn direct_dictionary(width: i64, height: i64, bits_per_component: i64) -> Dictionary {
+        Dictionary::new(BTreeMap::from([
+            (
+                "BitsPerComponent".to_string(),
+                ObjectVariant::Integer(bits_per_component),
+            ),
+            (
+                "ColorSpace".to_string(),
+                ObjectVariant::Name(b"DeviceGray".to_vec()),
+            ),
+            ("Height".to_string(), ObjectVariant::Integer(height)),
+            ("Width".to_string(), ObjectVariant::Integer(width)),
+        ]))
+    }
+
+    fn indexed_dictionary(bits_per_component: i64) -> Dictionary {
+        Dictionary::new(BTreeMap::from([
+            (
+                "BitsPerComponent".to_string(),
+                ObjectVariant::Integer(bits_per_component),
+            ),
+            (
+                "ColorSpace".to_string(),
+                ObjectVariant::Array(vec![
+                    ObjectVariant::Name(b"Indexed".to_vec()),
+                    ObjectVariant::Name(b"DeviceRGB".to_vec()),
+                    ObjectVariant::Integer(1),
+                    ObjectVariant::HexString(vec![0, 0, 0, 255, 255, 255]),
+                ]),
+            ),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
+        ]))
+    }
+}

--- a/crates/pdf-image/src/image_xobject.rs
+++ b/crates/pdf-image/src/image_xobject.rs
@@ -1,16 +1,14 @@
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
-use pdf_color_space::{color_space::ColorSpace, indexed_color_space::IndexedColorSpace};
-use pdf_decode::{DecodeMap, SampleLayout, decode_sample_bytes, expand_indexed_values};
-use pdf_filter::filter::{Filter, decode_data_with_resolver, decode_with_resolver};
+use pdf_color_space::color_space::ColorSpace;
+use pdf_filter::filter::{decode_data_with_resolver, decode_with_resolver};
 use pdf_graphics::PixelFormat;
-use pdf_object::{
-    dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
-    stream::StreamObject,
-};
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver, stream::StreamObject};
 
 use crate::InlineImage;
+use crate::decoded_samples::DecodedSamples;
 use crate::error::PdfImageError;
+use crate::image_metadata::ImageMetadata;
 
 /// Represents a PDF Image XObject, which is a self-contained raster image.
 #[derive(Debug, Clone)]
@@ -29,25 +27,6 @@ pub struct ImageXObject {
     pub color_space: Option<ColorSpace>,
 }
 
-/// Stores the normalized metadata needed to decode an image stream.
-#[derive(Debug, Clone)]
-struct ImageMetadata {
-    width: usize,
-    height: usize,
-    bits_per_component: usize,
-    color_space: Option<ColorSpace>,
-    image_mask: bool,
-}
-
-/// Stores decoded sample bytes before the final pixel format conversion.
-#[derive(Debug, Clone)]
-struct DecodedSamples {
-    bits_per_component: usize,
-    stored_color_space: Option<ColorSpace>,
-    num_color_components: usize,
-    image_data: Vec<u8>,
-}
-
 impl ImageXObject {
     /// Parses an Image XObject from a PDF stream dictionary and data.
     pub fn read_xobject(
@@ -56,17 +35,25 @@ impl ImageXObject {
         objects: &dyn ObjectResolver,
         soft_mask: Option<ImageXObject>,
     ) -> Result<Self, PdfImageError> {
-        match Self::decode_normalized_image(
+        let metadata = ImageMetadata::from_dictionary(dictionary, objects)?;
+        match Self::decode_normalized_image_with_metadata(
             dictionary,
             stream_data.raw_data(),
             objects,
             soft_mask.clone(),
+            &metadata,
         ) {
             Ok(image) => Ok(image),
-            Err(original_error) if Filter::from_dictionary(dictionary, objects)?.is_some() => {
+            Err(original_error) if metadata.filters.is_some() => {
                 let decoded = decode_with_resolver(stream_data, objects)?;
-                Self::decode_normalized_image(dictionary, decoded.as_ref(), objects, soft_mask)
-                    .map_err(|_| original_error)
+                Self::decode_normalized_image_with_metadata(
+                    dictionary,
+                    decoded.as_ref(),
+                    objects,
+                    soft_mask,
+                    &metadata,
+                )
+                .map_err(|_| original_error)
             }
             Err(error) => Err(error),
         }
@@ -94,11 +81,22 @@ impl ImageXObject {
         objects: &dyn ObjectResolver,
         soft_mask: Option<ImageXObject>,
     ) -> Result<Self, PdfImageError> {
-        let metadata = Self::read_metadata(dictionary, objects)?;
-        let decoded_samples = Self::decode_samples(dictionary, raw_data, objects, &metadata)?;
-        Self::validate_decoded_samples(&metadata, &decoded_samples)?;
-        let (data, pixel_format) =
-            Self::assemble_pixel_data(&metadata, &decoded_samples, soft_mask);
+        let metadata = ImageMetadata::from_dictionary(dictionary, objects)?;
+        Self::decode_normalized_image_with_metadata(
+            dictionary, raw_data, objects, soft_mask, &metadata,
+        )
+    }
+
+    fn decode_normalized_image_with_metadata(
+        dictionary: &Dictionary,
+        raw_data: &[u8],
+        objects: &dyn ObjectResolver,
+        soft_mask: Option<ImageXObject>,
+        metadata: &ImageMetadata,
+    ) -> Result<Self, PdfImageError> {
+        let decoded_samples = DecodedSamples::decode(dictionary, raw_data, objects, metadata)?;
+        Self::validate_decoded_samples(metadata, &decoded_samples)?;
+        let (data, pixel_format) = Self::assemble_pixel_data(metadata, &decoded_samples, soft_mask);
 
         Ok(Self {
             width: metadata.width,
@@ -108,285 +106,6 @@ impl ImageXObject {
             pixel_format,
             color_space: decoded_samples.stored_color_space,
         })
-    }
-
-    /// Reads and validates the normalized image metadata from the image dictionary.
-    fn read_metadata(
-        dictionary: &Dictionary,
-        objects: &dyn ObjectResolver,
-    ) -> Result<ImageMetadata, PdfImageError> {
-        let width = dictionary.required_number::<usize>("Width", objects)?;
-        let height = dictionary.required_number::<usize>("Height", objects)?;
-
-        if width == 0 || height == 0 {
-            return Err(PdfImageError::InvalidImageDimensions { width, height });
-        }
-
-        let image_mask = dictionary
-            .optional_boolean("ImageMask", objects)?
-            .unwrap_or(false);
-        let (bits_per_component, color_space) = if image_mask {
-            let bits_per_component = dictionary
-                .optional_number::<usize>("BitsPerComponent", objects)?
-                .unwrap_or(1);
-            Self::validate_bits_per_component(bits_per_component, image_mask, None)?;
-            (bits_per_component, None)
-        } else {
-            let bits_per_component = if Self::has_jpx_filter(dictionary, objects)? {
-                dictionary
-                    .optional_number::<usize>("BitsPerComponent", objects)?
-                    .unwrap_or(8)
-            } else {
-                dictionary.required_number::<usize>("BitsPerComponent", objects)?
-            };
-            let color_space = ColorSpace::from_dictionary(dictionary, objects)?;
-            Self::validate_bits_per_component(
-                bits_per_component,
-                image_mask,
-                color_space.as_ref(),
-            )?;
-            (bits_per_component, color_space)
-        };
-
-        Ok(ImageMetadata {
-            width,
-            height,
-            bits_per_component,
-            color_space,
-            image_mask,
-        })
-    }
-
-    /// Validates the allowed bit depths for indexed and non-indexed images.
-    fn validate_bits_per_component(
-        bits_per_component: usize,
-        image_mask: bool,
-        color_space: Option<&ColorSpace>,
-    ) -> Result<(), PdfImageError> {
-        if image_mask {
-            return match bits_per_component {
-                1 => Ok(()),
-                _ => Err(PdfImageError::UnsupportedImageBitsPerComponent { bits_per_component }),
-            };
-        }
-
-        if matches!(color_space, Some(ColorSpace::Indexed(_))) {
-            return match bits_per_component {
-                1 | 2 | 4 | 8 => Ok(()),
-                _ => Err(PdfImageError::UnsupportedIndexedBits { bits_per_component }),
-            };
-        }
-
-        match bits_per_component {
-            1 | 8 => Ok(()),
-            _ => Err(PdfImageError::UnsupportedImageBitsPerComponent { bits_per_component }),
-        }
-    }
-
-    /// Decodes raw image bytes into component samples based on the configured color space.
-    fn decode_samples(
-        dictionary: &Dictionary,
-        raw_data: &[u8],
-        objects: &dyn ObjectResolver,
-        metadata: &ImageMetadata,
-    ) -> Result<DecodedSamples, PdfImageError> {
-        if let Some(decoded_samples) =
-            Self::decode_preconverted_jpx_samples(dictionary, raw_data, objects, metadata)?
-        {
-            return Ok(decoded_samples);
-        }
-
-        if let Some(decoded_samples) =
-            Self::decode_preconverted_dct_samples(dictionary, raw_data, objects, metadata)?
-        {
-            return Ok(decoded_samples);
-        }
-
-        match metadata.color_space.as_ref() {
-            Some(ColorSpace::Indexed(indexed)) => {
-                Self::decode_indexed_samples(dictionary, raw_data, objects, metadata, indexed)
-            }
-            _ => Self::decode_direct_samples(dictionary, raw_data, objects, metadata),
-        }
-    }
-
-    /// Uses DCT decoder output as display samples when the JPEG decoder already converted color.
-    fn decode_preconverted_dct_samples(
-        dictionary: &Dictionary,
-        raw_data: &[u8],
-        objects: &dyn ObjectResolver,
-        metadata: &ImageMetadata,
-    ) -> Result<Option<DecodedSamples>, PdfImageError> {
-        if metadata.bits_per_component != 8 || !Self::has_dct_filter(dictionary, objects)? {
-            return Ok(None);
-        }
-
-        let num_pixels = metadata.width.saturating_mul(metadata.height);
-        let Some(num_color_components) = Self::decoded_dct_component_count(raw_data, num_pixels)
-            .or_else(|| Self::decoded_single_pixel_component_count(raw_data))
-        else {
-            return Ok(None);
-        };
-
-        let stored_color_space = match num_color_components {
-            1 => Some(ColorSpace::DeviceGray),
-            3 => Some(ColorSpace::DeviceRGB),
-            _ => metadata.color_space.clone(),
-        };
-        let image_data = if raw_data.len() == num_color_components && num_pixels > 1 {
-            raw_data.repeat(num_pixels)
-        } else {
-            raw_data.to_vec()
-        };
-
-        Ok(Some(DecodedSamples {
-            bits_per_component: metadata.bits_per_component,
-            stored_color_space,
-            num_color_components,
-            image_data,
-        }))
-    }
-
-    /// Uses JPX decoder output as display samples when the decoder already expanded pixels.
-    fn decode_preconverted_jpx_samples(
-        dictionary: &Dictionary,
-        raw_data: &[u8],
-        objects: &dyn ObjectResolver,
-        metadata: &ImageMetadata,
-    ) -> Result<Option<DecodedSamples>, PdfImageError> {
-        if !Self::has_jpx_filter(dictionary, objects)? {
-            return Ok(None);
-        }
-
-        let num_pixels = metadata.width.saturating_mul(metadata.height);
-        let Some(bytes_per_pixel) = raw_data.len().checked_div(num_pixels) else {
-            return Ok(None);
-        };
-        if bytes_per_pixel.saturating_mul(num_pixels) != raw_data.len() {
-            return Ok(None);
-        }
-
-        let (num_color_components, bits_per_component, stored_color_space) = match bytes_per_pixel {
-            1 => (1, 8, Some(ColorSpace::DeviceGray)),
-            2 => (1, 16, Some(ColorSpace::DeviceGray)),
-            3 => (3, 8, Some(ColorSpace::DeviceRGB)),
-            6 => (3, 16, Some(ColorSpace::DeviceRGB)),
-            _ => return Ok(None),
-        };
-
-        Ok(Some(DecodedSamples {
-            bits_per_component,
-            stored_color_space,
-            num_color_components,
-            image_data: raw_data.to_vec(),
-        }))
-    }
-
-    fn has_dct_filter(
-        dictionary: &Dictionary,
-        objects: &dyn ObjectResolver,
-    ) -> Result<bool, PdfImageError> {
-        Self::has_filter(dictionary, objects, Filter::DCTDecode)
-    }
-
-    fn has_jpx_filter(
-        dictionary: &Dictionary,
-        objects: &dyn ObjectResolver,
-    ) -> Result<bool, PdfImageError> {
-        Self::has_filter(dictionary, objects, Filter::JPXDecode)
-    }
-
-    fn has_filter(
-        dictionary: &Dictionary,
-        objects: &dyn ObjectResolver,
-        target: Filter,
-    ) -> Result<bool, PdfImageError> {
-        Ok(Filter::from_dictionary(dictionary, objects)?
-            .is_some_and(|filters| filters.contains(&target)))
-    }
-
-    fn decoded_dct_component_count(raw_data: &[u8], num_pixels: usize) -> Option<usize> {
-        [1, 3, 4]
-            .into_iter()
-            .find(|components| raw_data.len() == num_pixels.saturating_mul(*components))
-    }
-
-    fn decoded_single_pixel_component_count(raw_data: &[u8]) -> Option<usize> {
-        [1, 3, 4]
-            .into_iter()
-            .find(|components| raw_data.len() == *components)
-    }
-
-    /// Decodes indexed image samples, applies `/Decode`, and expands palette entries.
-    fn decode_indexed_samples(
-        dictionary: &Dictionary,
-        raw_data: &[u8],
-        objects: &dyn ObjectResolver,
-        metadata: &ImageMetadata,
-        indexed: &IndexedColorSpace,
-    ) -> Result<DecodedSamples, PdfImageError> {
-        let sample_codes = Self::decode_image_sample_codes(raw_data, 1, metadata)?;
-        let sample_max = Self::sample_max(metadata.bits_per_component)?;
-        let decode = DecodeMap::from_dictionary(dictionary, objects, 1, metadata.image_mask)?;
-        let decoded_indices = decode.apply_to_bytes(sample_codes.as_ref(), sample_max, sample_max);
-        let base_components = indexed.base.num_color_components();
-
-        let image_data = expand_indexed_values(
-            &decoded_indices,
-            &indexed.lookup,
-            indexed.hival,
-            base_components,
-        )?;
-
-        Ok(DecodedSamples {
-            bits_per_component: metadata.bits_per_component,
-            stored_color_space: Some(*indexed.base.clone()),
-            num_color_components: base_components,
-            image_data,
-        })
-    }
-
-    /// Decodes non-indexed image samples and applies the `/Decode` transform.
-    fn decode_direct_samples(
-        dictionary: &Dictionary,
-        raw_data: &[u8],
-        objects: &dyn ObjectResolver,
-        metadata: &ImageMetadata,
-    ) -> Result<DecodedSamples, PdfImageError> {
-        let num_components = metadata
-            .color_space
-            .as_ref()
-            .map_or(1, ColorSpace::num_color_components);
-        let sample_codes = Self::decode_image_sample_codes(raw_data, num_components, metadata)?;
-        let decode =
-            DecodeMap::from_dictionary(dictionary, objects, num_components, metadata.image_mask)?;
-
-        Ok(DecodedSamples {
-            bits_per_component: metadata.bits_per_component,
-            stored_color_space: metadata.color_space.clone(),
-            num_color_components: num_components,
-            image_data: decode.apply_to_bytes(
-                sample_codes.as_ref(),
-                Self::sample_max(metadata.bits_per_component)?,
-                255,
-            ),
-        })
-    }
-
-    fn decode_image_sample_codes<'a>(
-        raw_data: &'a [u8],
-        samples_per_pixel: usize,
-        metadata: &ImageMetadata,
-    ) -> Result<Cow<'a, [u8]>, PdfImageError> {
-        Ok(decode_sample_bytes(
-            raw_data,
-            metadata.bits_per_component,
-            SampleLayout::RowAligned {
-                width: metadata.width,
-                height: metadata.height,
-                samples_per_pixel,
-            },
-        )?)
     }
 
     /// Ensures the decoded component stream is large enough for the declared dimensions.
@@ -408,17 +127,6 @@ impl ImageXObject {
         }
 
         Ok(())
-    }
-
-    /// Returns the maximum encoded sample value for a supported bit depth.
-    fn sample_max(bits_per_component: usize) -> Result<u8, PdfImageError> {
-        match bits_per_component {
-            1 => Ok(1),
-            2 => Ok(3),
-            4 => Ok(15),
-            8 => Ok(255),
-            _ => Err(PdfImageError::UnsupportedImageBitsPerComponent { bits_per_component }),
-        }
     }
 
     /// Builds the final pixel buffer and pixel format after optional soft-mask application.

--- a/crates/pdf-image/src/lib.rs
+++ b/crates/pdf-image/src/lib.rs
@@ -1,4 +1,6 @@
+mod decoded_samples;
 pub mod error;
+mod image_metadata;
 pub mod image_xobject;
 pub mod inline_image;
 


### PR DESCRIPTION
Move image dictionary metadata and decoded sample construction into separate modules, keeping ImageXObject focused on orchestration and pixel assembly.

Represent filter chains with Filters, cache them in ImageMetadata, and reuse named DCT and JPX queries throughout image decoding.