### PR TITLE
pdf-font: move dictionary parsing onto domain types

### DIFF
--- a/crates/pdf-cmap/src/error.rs
+++ b/crates/pdf-cmap/src/error.rs
@@ -3,6 +3,8 @@ use thiserror::Error;
 /// Errors that can occur while parsing or resolving PDF CMaps.
 #[derive(Debug, Error, PartialEq)]
 pub enum CMapError {
+    #[error("Object error while reading a CMap: {0}")]
+    ObjectError(#[from] pdf_object::error::ObjectError),
     #[error("Unsupported Type0 /Encoding CMap '{0}'")]
     UnsupportedType0EncodingCMap(String),
     #[error("Invalid Type0 /Encoding CMap: {0}")]

--- a/crates/pdf-cmap/src/predefined/mod.rs
+++ b/crates/pdf-cmap/src/predefined/mod.rs
@@ -58,52 +58,6 @@ pub struct PredefinedCMap {
     maps: Vec<&'static GeneratedCMap>,
 }
 
-/// Known Adobe CIDSystemInfo ordering values with bundled Unicode CMap support.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CidOrdering {
-    /// Adobe-Japan1 character collection.
-    Japan1,
-    /// Adobe-GB1 character collection.
-    GB1,
-    /// Adobe-CNS1 character collection.
-    CNS1,
-    /// Adobe-Korea1 character collection.
-    Korea1,
-}
-
-impl CidOrdering {
-    /// Resolve a known Adobe CIDSystemInfo ordering value.
-    pub fn from_name(name: &str) -> Option<Self> {
-        match name {
-            "Japan1" => Some(Self::Japan1),
-            "GB1" => Some(Self::GB1),
-            "CNS1" => Some(Self::CNS1),
-            "Korea1" => Some(Self::Korea1),
-            _ => None,
-        }
-    }
-
-    /// Return whether an ordering name has bundled CJK fallback support.
-    pub fn is_known_cjk_name(name: &str) -> bool {
-        Self::from_name(name).is_some()
-    }
-
-    /// Build a best-effort CID to Unicode map for this ordering.
-    pub fn cid_to_unicode_map(self) -> Result<Option<HashMap<u16, char>>, CMapError> {
-        Ok(PredefinedCMap::from_name(self.unicode_cmap_name())?
-            .map(|cmap| cmap.cid_to_unicode_map()))
-    }
-
-    fn unicode_cmap_name(self) -> &'static str {
-        match self {
-            Self::Japan1 => "UniJIS-UCS2-HW-H",
-            Self::GB1 => "UniGB-UCS2-H",
-            Self::CNS1 => "UniCNS-UCS2-H",
-            Self::Korea1 => "UniKS-UCS2-H",
-        }
-    }
-}
-
 impl PredefinedCMap {
     /// Resolve a predefined CMap by name.
     pub fn from_name(name: &str) -> Result<Option<Self>, CMapError> {
@@ -200,17 +154,6 @@ impl Type0CodeMap for PredefinedCMap {
     }
 }
 
-/// Build a best-effort CID to Unicode map for a known Adobe CIDSystemInfo ordering.
-pub fn cid_to_unicode_map_for_ordering(
-    ordering: &str,
-) -> Result<Option<HashMap<u16, char>>, CMapError> {
-    let Some(ordering) = CidOrdering::from_name(ordering) else {
-        return Ok(None);
-    };
-
-    ordering.cid_to_unicode_map()
-}
-
 /// Find a generated CMap by resource name.
 fn find_cmap(name: &str) -> Option<&'static GeneratedCMap> {
     generated::CMAPS
@@ -277,20 +220,12 @@ mod tests {
 
     #[test]
     fn japan1_cid_to_unicode_includes_half_width_ascii_and_space_variants() {
-        let map = cid_to_unicode_map_for_ordering("Japan1").unwrap().unwrap();
+        let map = PredefinedCMap::from_name("UniJIS-UCS2-HW-H")
+            .unwrap()
+            .unwrap()
+            .cid_to_unicode_map();
 
         assert_eq!(map.get(&231), Some(&' '));
         assert_eq!(map.get(&633), Some(&'\u{2003}'));
-    }
-
-    #[test]
-    fn cid_ordering_rejects_unknown_orderings() {
-        assert!(CidOrdering::from_name("Unknown").is_none());
-        assert!(!CidOrdering::is_known_cjk_name("Unknown"));
-        assert!(
-            cid_to_unicode_map_for_ordering("Unknown")
-                .unwrap()
-                .is_none()
-        );
     }
 }

--- a/crates/pdf-cmap/src/to_unicode.rs
+++ b/crates/pdf-cmap/src/to_unicode.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
+
 use crate::{cmap::parser::CMapParser, error::CMapError};
 
 /// A parsed ToUnicode CMap that maps PDF character codes to Unicode scalar values.
@@ -7,6 +9,18 @@ use crate::{cmap::parser::CMapParser, error::CMapError};
 pub struct ToUnicodeCMap(HashMap<u16, Vec<char>>);
 
 impl ToUnicodeCMap {
+    /// Parse the optional `/ToUnicode` CMap from a font dictionary.
+    pub fn from_dictionary(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+    ) -> Result<Option<Self>, CMapError> {
+        dictionary
+            .get("ToUnicode")
+            .and_then(|value| value.try_stream(objects).ok())
+            .map(|stream| Self::try_from(stream.raw_data()))
+            .transpose()
+    }
+
     /// Look up the Unicode characters for the given PDF character code.
     pub fn map_char_code(&self, code: u16) -> Option<&[char]> {
         self.0.get(&code).map(Vec::as_slice)

--- a/crates/pdf-cmap/src/type0/mod.rs
+++ b/crates/pdf-cmap/src/type0/mod.rs
@@ -2,7 +2,10 @@
 
 use std::convert::TryFrom;
 
-use pdf_object::text_encoding::BigEndianU16Units;
+use pdf_object::{
+    dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
+    text_encoding::BigEndianU16Units,
+};
 
 mod embedded;
 mod parser;
@@ -25,6 +28,23 @@ pub enum Type0EncodingCMap {
 }
 
 impl Type0EncodingCMap {
+    /// Parse the optional `/Encoding` entry of a Type0 font dictionary.
+    pub fn from_dictionary(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+    ) -> Result<Option<Self>, CMapError> {
+        dictionary
+            .get("Encoding")
+            .map(|value| {
+                let resolved = objects.resolve_object(value)?;
+                match resolved {
+                    ObjectVariant::Stream(stream) => Self::from_bytes(stream.raw_data()),
+                    _ => Self::from_name(value.try_str(objects)?),
+                }
+            })
+            .transpose()
+    }
+
     /// Build a Type0 encoding CMap from a predefined CMap name.
     pub fn from_name(name: &str) -> Result<Self, CMapError> {
         if let Ok(writing_mode) = WritingMode::try_from(name) {

--- a/crates/pdf-font/src/cid_font_subtype.rs
+++ b/crates/pdf-font/src/cid_font_subtype.rs
@@ -1,0 +1,32 @@
+//! CIDFont subtype parsing.
+
+use pdf_object::{
+    dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
+};
+
+use crate::error::FontError;
+
+/// CIDFont subtypes supported by the parser.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CidFontSubType {
+    /// Type 1/CFF based CID-keyed font.
+    Type0,
+    /// TrueType based CID-keyed font.
+    Type2,
+}
+
+impl CidFontSubType {
+    /// Parse the CIDFont subtype from a descendant font dictionary.
+    pub fn from_dictionary(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+    ) -> Result<Self, FontError> {
+        match dictionary.required_str("Subtype", objects)? {
+            "CIDFontType0" => Ok(Self::Type0),
+            "CIDFontType2" => Ok(Self::Type2),
+            other => Err(FontError::UnsupportedCidFontSubtype {
+                subtype: other.to_string(),
+            }),
+        }
+    }
+}

--- a/crates/pdf-font/src/cid_system_info.rs
+++ b/crates/pdf-font/src/cid_system_info.rs
@@ -1,32 +1,72 @@
-use pdf_cmap::predefined::CidOrdering;
+use std::collections::HashMap;
+
+use pdf_cmap::{error::CMapError, predefined::PredefinedCMap};
 use pdf_object::{
     dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
 };
 
 use crate::error::FontError;
 
-/// Extract a supported CID ordering from a font dictionary's `/CIDSystemInfo`.
-///
-/// # Paramaters
-///
-/// - `dictionary`: The PDF font dictionary that may contain `/CIDSystemInfo`.
-/// - `objects`: The resolver used to dereference indirect PDF objects.
-///
-/// # Returns
-///
-/// A known [`CidOrdering`] when `/CIDSystemInfo /Ordering` is present and
-/// supported, or `None` when the entry is absent or unknown.
-pub(crate) fn cid_ordering_from_dictionary(
-    dictionary: &Dictionary,
-    objects: &dyn ObjectResolver,
-) -> Result<Option<CidOrdering>, FontError> {
-    let Some(cid_system_info) = dictionary.optional_dictionary("CIDSystemInfo", objects)? else {
-        return Ok(None);
-    };
+/// Known Adobe CIDSystemInfo ordering values with bundled Unicode CMap support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CidOrdering {
+    /// Adobe-Japan1 character collection.
+    Japan1,
+    /// Adobe-GB1 character collection.
+    GB1,
+    /// Adobe-CNS1 character collection.
+    CNS1,
+    /// Adobe-Korea1 character collection.
+    Korea1,
+}
 
-    let Some(ordering) = cid_system_info.optional_str("Ordering", objects)? else {
-        return Ok(None);
-    };
+impl CidOrdering {
+    /// Extract a supported CID ordering from a font dictionary's `/CIDSystemInfo`.
+    ///
+    /// # Paramaters
+    ///
+    /// - `dictionary`: The PDF font dictionary that may contain `/CIDSystemInfo`.
+    /// - `objects`: The resolver used to dereference indirect PDF objects.
+    ///
+    /// # Returns
+    ///
+    /// A known [`CidOrdering`] when `/CIDSystemInfo /Ordering` is present and
+    /// supported, or `None` when the entry is absent or unknown.
+    pub(crate) fn from_dictionary(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+    ) -> Result<Option<Self>, FontError> {
+        let Some(cid_system_info) = dictionary.optional_dictionary("CIDSystemInfo", objects)?
+        else {
+            return Ok(None);
+        };
 
-    Ok(CidOrdering::from_name(ordering))
+        let Some(ordering) = cid_system_info.optional_str("Ordering", objects)? else {
+            return Ok(None);
+        };
+
+        Ok(Self::from_name(ordering))
+    }
+
+    /// Build a best-effort CID to Unicode map for this ordering.
+    pub(crate) fn cid_to_unicode_map(self) -> Result<Option<HashMap<u16, char>>, CMapError> {
+        let unicode_cmap_name = match self {
+            Self::Japan1 => "UniJIS-UCS2-HW-H",
+            Self::GB1 => "UniGB-UCS2-H",
+            Self::CNS1 => "UniCNS-UCS2-H",
+            Self::Korea1 => "UniKS-UCS2-H",
+        };
+
+        Ok(PredefinedCMap::from_name(unicode_cmap_name)?.map(|cmap| cmap.cid_to_unicode_map()))
+    }
+
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "Japan1" => Some(Self::Japan1),
+            "GB1" => Some(Self::GB1),
+            "CNS1" => Some(Self::CNS1),
+            "Korea1" => Some(Self::Korea1),
+            _ => None,
+        }
+    }
 }

--- a/crates/pdf-font/src/fallback.rs
+++ b/crates/pdf-font/src/fallback.rs
@@ -5,7 +5,7 @@ use pdf_object::{
 };
 
 use crate::{
-    cid_system_info::cid_ordering_from_dictionary,
+    cid_system_info::CidOrdering,
     encoding::{Encoding, FontEncoding},
     error::FontError,
     flags::FontFlags,
@@ -20,26 +20,18 @@ pub(crate) struct FallbackFontProgram {
     pub(crate) flags: FontFlags,
 }
 
-/// Select fallback font bytes and metadata for a font dictionary.
-///
-/// # Paramaters
-///
-/// - `dictionary`: The PDF font dictionary that needs fallback font data.
-/// - `objects`: The resolver used to dereference indirect PDF objects.
-///
-/// # Returns
-///
-/// A fallback font program with borrowed bundled bytes, the selected Standard
-/// 14 identity, and descriptor flags.
-pub(crate) fn fallback_program_from_dictionary(
-    dictionary: &Dictionary,
-    objects: &dyn ObjectResolver,
-) -> Result<FallbackFontProgram, FontError> {
-    let flags = descriptor_flags(dictionary, objects)?;
-    let standard14 = standard14_from_dictionary(dictionary, objects, flags);
-    let is_cjk = is_cjk_cid_font(dictionary, objects)?;
+impl FallbackFontProgram {
+    /// Select fallback font bytes and metadata for a font dictionary.
+    pub(crate) fn from_dictionary(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+    ) -> Result<Self, FontError> {
+        let flags = descriptor_flags(dictionary, objects)?;
+        let standard14 = Standard14Font::from_dictionary(dictionary, objects, flags);
+        let is_cjk = is_cjk_cid_font(dictionary, objects)?;
 
-    Ok(fallback_program(flags, standard14, is_cjk))
+        Ok(fallback_program(flags, standard14, is_cjk))
+    }
 }
 
 /// Build a synthetic TrueType font from fallback font data.
@@ -57,7 +49,7 @@ pub(crate) fn fallback_true_type_from_dictionary(
     dictionary: &Dictionary,
     objects: &dyn ObjectResolver,
 ) -> Result<TrueTypeFont, FontError> {
-    let fallback = fallback_program_from_dictionary(dictionary, objects)?;
+    let fallback = FallbackFontProgram::from_dictionary(dictionary, objects)?;
     let widths = SimpleFontGlyphWidthsMap::from_dictionary(dictionary, objects)?;
     let encoding = simple_font_encoding(dictionary, objects);
     let to_unicode = to_unicode_cmap(dictionary, objects)?;
@@ -83,29 +75,12 @@ pub(crate) fn fallback_true_type_from_dictionary_best_effort(
 ) -> TrueTypeFont {
     let flags = descriptor_flags(dictionary, objects).unwrap_or_default();
     let is_cjk = is_cjk_cid_font(dictionary, objects).unwrap_or(false);
-    let standard14 = standard14_from_dictionary(dictionary, objects, flags);
+    let standard14 = Standard14Font::from_dictionary(dictionary, objects, flags);
     let fallback = fallback_program(flags, standard14, is_cjk);
     let mut font = TrueTypeFont::from_bytes(fallback.font_file, Some(fallback.standard14));
     font.flags = fallback.flags;
 
     font
-}
-
-/// Resolve the Standard 14 identity to use for fallback substitution.
-///
-/// This prefers a readable `/BaseFont` name when it maps to a known Standard 14
-/// font. If `/BaseFont` is missing, malformed, or unrecognized, it falls back
-/// to the flag-driven Standard 14 selection.
-fn standard14_from_dictionary(
-    dictionary: &Dictionary,
-    objects: &dyn ObjectResolver,
-    flags: FontFlags,
-) -> Standard14Font {
-    dictionary
-        .get("BaseFont")
-        .and_then(|value| value.try_str(objects).ok())
-        .and_then(Standard14Font::from_base_font_name)
-        .unwrap_or_else(|| Standard14Font::from(flags))
 }
 
 /// Build the fallback font program descriptor from already-decided inputs.
@@ -217,5 +192,5 @@ fn is_cjk_cid_font(
     dictionary: &Dictionary,
     objects: &dyn ObjectResolver,
 ) -> Result<bool, FontError> {
-    Ok(cid_ordering_from_dictionary(dictionary, objects)?.is_some())
+    Ok(CidOrdering::from_dictionary(dictionary, objects)?.is_some())
 }

--- a/crates/pdf-font/src/lib.rs
+++ b/crates/pdf-font/src/lib.rs
@@ -1,5 +1,6 @@
 mod cff_builder;
 pub mod char_vec;
+pub mod cid_font_subtype;
 mod cid_system_info;
 pub mod encoding;
 pub mod error;

--- a/crates/pdf-font/src/standard14.rs
+++ b/crates/pdf-font/src/standard14.rs
@@ -5,6 +5,8 @@
 /// name alone we substitute a metrically-similar bundled TrueType font.
 use std::fmt;
 
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
+
 use crate::flags::FontFlags;
 
 /// One of the 14 standard Type 1 fonts defined by the PDF specification
@@ -119,6 +121,19 @@ impl From<FontFlags> for Standard14Font {
 }
 
 impl Standard14Font {
+    /// Resolve the Standard 14 identity to use for fallback substitution.
+    pub(crate) fn from_dictionary(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+        flags: FontFlags,
+    ) -> Self {
+        dictionary
+            .get("BaseFont")
+            .and_then(|value| value.try_str(objects).ok())
+            .and_then(Self::from_base_font_name)
+            .unwrap_or_else(|| Self::from(flags))
+    }
+
     /// Try to match a `/BaseFont` name to a Standard 14 font.
     ///
     /// Recognises both the canonical names and common aliases

--- a/crates/pdf-font/src/true_type_font.rs
+++ b/crates/pdf-font/src/true_type_font.rs
@@ -9,7 +9,7 @@ use pdf_object::{
 use crate::{
     encoding::{Encoding, FontEncoding},
     error::FontError,
-    fallback::fallback_program_from_dictionary,
+    fallback::FallbackFontProgram,
     flags::FontFlags,
     font_data::FontData,
     simple_font_glyph_map::SimpleFontGlyphWidthsMap,
@@ -187,7 +187,7 @@ impl TrueTypeFont {
             }
         }
 
-        let fallback = fallback_program_from_dictionary(dictionary, objects)?;
+        let fallback = FallbackFontProgram::from_dictionary(dictionary, objects)?;
         Ok(TrueTypeFontProgram {
             font_file: fallback.font_file.into(),
             standard14: Some(fallback.standard14),

--- a/crates/pdf-font/src/type0_font.rs
+++ b/crates/pdf-font/src/type0_font.rs
@@ -3,14 +3,15 @@ use std::collections::HashMap;
 use pdf_cmap::{ToUnicodeCMap, Type0EncodingCMap};
 use pdf_object::{
     dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
-    object_variant::ObjectVariant,
 };
 use read_fonts::{FontRef, TableProvider};
 
+pub use crate::cid_font_subtype::CidFontSubType;
+
 use crate::{
-    cid_system_info::cid_ordering_from_dictionary,
+    cid_system_info::CidOrdering,
     error::FontError,
-    fallback::fallback_program_from_dictionary,
+    fallback::FallbackFontProgram,
     font_data::FontData,
     glyph_widths_map::GlyphWidthsMap,
     true_type_font::TrueTypeFont,
@@ -51,15 +52,6 @@ impl Type0Font {
     const DEFAULT_WIDTH: f32 = 1000.0;
 }
 
-/// CIDFont subtypes supported by the parser.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum CidFontSubType {
-    /// Type 1/CFF based CID-keyed font
-    Type0,
-    /// TrueType based CID-keyed font
-    Type2,
-}
-
 /// Font program format resolved for a Type0 descendant font.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Type0FontProgramFormat {
@@ -88,8 +80,8 @@ impl Type0Font {
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
     ) -> Result<Self, FontError> {
-        let encoding = parse_encoding(dictionary, objects)?;
-        let to_unicode = parse_to_unicode(dictionary, objects)?;
+        let encoding = Type0EncodingCMap::from_dictionary(dictionary, objects)?;
+        let to_unicode = ToUnicodeCMap::from_dictionary(dictionary, objects)?;
         let descendant = Type0DescendantFont::from_dictionary(dictionary, objects)?;
         let Type0FontProgram {
             font_file,
@@ -171,11 +163,13 @@ impl<'a> Type0DescendantFont<'a> {
         objects: &'a dyn ObjectResolver,
     ) -> Result<Self, FontError> {
         let dictionary = descendant_font_dictionary(dictionary, objects)?;
-
+        let default_width = dictionary
+            .optional_number::<f32>("DW", objects)?
+            .unwrap_or(Type0Font::DEFAULT_WIDTH);
         Ok(Self {
             dictionary,
-            subtype: cid_font_subtype(dictionary, objects)?,
-            default_width: default_width(dictionary, objects)?,
+            subtype: CidFontSubType::from_dictionary(dictionary, objects)?,
+            default_width,
             widths: widths_map(dictionary, objects)?,
         })
     }
@@ -185,56 +179,6 @@ struct Type0FontProgram {
     font_file: FontData,
     program_format: Type0FontProgramFormat,
     fallback_cid_to_unicode: Option<HashMap<u16, char>>,
-}
-
-/// Parse the optional `/Encoding` entry of a Type0 font dictionary.
-///
-/// # Paramaters
-///
-/// - `dictionary`: The top-level Type0 font dictionary.
-/// - `objects`: The resolver used to dereference indirect PDF objects.
-///
-/// # Returns
-///
-/// The parsed Type0 encoding CMap when the dictionary contains `/Encoding`.
-fn parse_encoding(
-    dictionary: &Dictionary,
-    objects: &dyn ObjectResolver,
-) -> Result<Option<Type0EncodingCMap>, FontError> {
-    dictionary
-        .get("Encoding")
-        .map(|value| {
-            let resolved = objects.resolve_object(value)?;
-            match resolved {
-                ObjectVariant::Stream(stream) => {
-                    Ok(Type0EncodingCMap::from_bytes(stream.raw_data())?)
-                }
-                _ => Ok(Type0EncodingCMap::from_name(value.try_str(objects)?)?),
-            }
-        })
-        .transpose()
-}
-
-/// Parse the optional `/ToUnicode` CMap from a Type0 font dictionary.
-///
-/// # Paramaters
-///
-/// - `dictionary`: The top-level Type0 font dictionary.
-/// - `objects`: The resolver used to dereference indirect PDF objects.
-///
-/// # Returns
-///
-/// The parsed ToUnicode CMap when a valid `/ToUnicode` stream is present.
-fn parse_to_unicode(
-    dictionary: &Dictionary,
-    objects: &dyn ObjectResolver,
-) -> Result<Option<ToUnicodeCMap>, FontError> {
-    dictionary
-        .get("ToUnicode")
-        .and_then(|e| e.try_stream(objects).ok())
-        .map(|s| ToUnicodeCMap::try_from(s.raw_data()))
-        .transpose()
-        .map_err(FontError::from)
 }
 
 /// Resolve the sole descendant CIDFont dictionary from `/DescendantFonts`.
@@ -264,48 +208,6 @@ fn descendant_font_dictionary<'a>(
         .ok_or(FontError::InvalidDescendantFonts("Array is empty"))?
         .try_dictionary(objects)
         .map_err(FontError::from)
-}
-
-/// Parse the CIDFont subtype from a descendant font dictionary.
-///
-/// # Paramaters
-///
-/// - `dictionary`: The descendant CIDFont dictionary.
-/// - `objects`: The resolver used to dereference indirect PDF objects.
-///
-/// # Returns
-///
-/// The supported CIDFont subtype, or an unsupported-subtype error for unknown
-/// subtype names.
-fn cid_font_subtype(
-    dictionary: &Dictionary,
-    objects: &dyn ObjectResolver,
-) -> Result<CidFontSubType, FontError> {
-    match dictionary.required_str("Subtype", objects)? {
-        "CIDFontType0" => Ok(CidFontSubType::Type0),
-        "CIDFontType2" => Ok(CidFontSubType::Type2),
-        other => Err(FontError::UnsupportedCidFontSubtype {
-            subtype: other.to_string(),
-        }),
-    }
-}
-
-/// Parse the default glyph width from a descendant font dictionary.
-///
-/// # Paramaters
-///
-/// - `dictionary`: The descendant CIDFont dictionary.
-/// - `objects`: The resolver used to dereference indirect PDF objects.
-///
-/// # Returns
-///
-/// The `/DW` value, or [`Type0Font::DEFAULT_WIDTH`] when `/DW` is absent.
-fn default_width(dictionary: &Dictionary, objects: &dyn ObjectResolver) -> Result<f32, FontError> {
-    Ok(dictionary
-        .get("DW")
-        .map(|dw| dw.try_number::<f32>(objects))
-        .transpose()?
-        .unwrap_or(Type0Font::DEFAULT_WIDTH))
 }
 
 /// Parse explicit CID width overrides from a descendant font dictionary.
@@ -404,7 +306,7 @@ fn fallback_type0_program(
     dictionary: &Dictionary,
     objects: &dyn ObjectResolver,
 ) -> Result<Type0FontProgram, FontError> {
-    let fallback = fallback_program_from_dictionary(dictionary, objects)?;
+    let fallback = FallbackFontProgram::from_dictionary(dictionary, objects)?;
     let fallback_cid_to_unicode = cid_to_unicode_map(dictionary, objects)?;
 
     Ok(Type0FontProgram {
@@ -499,7 +401,7 @@ fn cid_to_unicode_map(
     descendant_font: &Dictionary,
     objects: &dyn ObjectResolver,
 ) -> Result<Option<HashMap<u16, char>>, FontError> {
-    let Some(ordering) = cid_ordering_from_dictionary(descendant_font, objects)? else {
+    let Some(ordering) = CidOrdering::from_dictionary(descendant_font, objects)? else {
         return Ok(None);
     };
 


### PR DESCRIPTION
Move Type0 encoding, ToUnicode, CID subtype, CID ordering, fallback program, and Standard 14 parsing onto their owning types. Keep Type0 font loading focused on composing parsed font data.