### PR TITLE
pdf-resources: move soft mask parsing onto type

### DIFF
--- a/crates/pdf-canvas/tests/canvas_graphics_state_ops.rs
+++ b/crates/pdf-canvas/tests/canvas_graphics_state_ops.rs
@@ -10,10 +10,11 @@ use pdf_content_stream::ContentStream;
 use pdf_document::page::PdfPage;
 use pdf_graphics::{DashPattern, MaskMode, rect::Rect};
 use pdf_resources::{
-    external_graphics_state::{ExternalGraphicsState, ExternalGraphicsStateKey, SoftMask},
+    external_graphics_state::{ExternalGraphicsState, ExternalGraphicsStateKey},
     form::FormXObject,
     resource::Resource,
     resources::Resources,
+    soft_mask::SoftMask,
     xobject::XObject,
 };
 

--- a/crates/pdf-resources/src/external_graphics_state.rs
+++ b/crates/pdf-resources/src/external_graphics_state.rs
@@ -1,29 +1,18 @@
 use pdf_object::{
-    dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
-    object_variant::ObjectVariant,
+    dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
 };
 
 use crate::{
     error::PdfPagesError,
-    object_reader::{ReadCycleTracker, ReadFromDictionary, ReadXObject},
+    object_reader::{ReadCycleTracker, ReadFromDictionary},
     resource::Resource,
     resource_cache::{ResourceCache, read_resource_lazy},
     resources::read_font_resource,
-    xobject::XObject,
+    soft_mask::SoftMask,
 };
 use num_traits::FromPrimitive;
 use pdf_content_stream::ContentStreamIdAllocator;
-use pdf_graphics::{BlendMode, DashPattern, LineCap, LineJoin, MaskMode};
-
-/// Soft mask extracted from an ExtGState `SMask` entry.
-pub struct SoftMask {
-    /// How the mask is derived from the transparency group output: from color
-    /// luminance (`Luminosity`) or from alpha/shape (`Alpha`).
-    pub mask_type: MaskMode,
-    /// The transparency group XObject (`G`) whose rendered result provides the
-    /// input used to compute the soft mask.
-    pub shape: XObject,
-}
+use pdf_graphics::{BlendMode, DashPattern, LineCap, LineJoin};
 
 /// Represents a key-value pair from a PDF External Graphics State dictionary (`ExtGState`).
 ///
@@ -218,54 +207,6 @@ fn parse_blend_mode(
     Ok(ExternalGraphicsStateKey::BlendMode(blend_modes_vec))
 }
 
-fn parse_soft_mask(
-    key_name: &str,
-    value: &ObjectVariant,
-    objects: &dyn ObjectResolver,
-    cache: &mut dyn ResourceCache,
-    cycle_tracker: &mut ReadCycleTracker,
-    id_allocator: &mut ContentStreamIdAllocator,
-) -> Result<ExternalGraphicsStateKey, PdfPagesError> {
-    let smask = match value {
-        ObjectVariant::Dictionary(dict) => {
-            let mask_type = MaskMode::from(dict.required_str("S", objects)?);
-
-            // Parse the "G" key for the `XObject`
-            let content = dict.get_or_err("G")?;
-            let stream = content.try_stream(objects)?;
-
-            let shape = match XObject::read_xobject(
-                content,
-                &stream.dictionary,
-                stream,
-                objects,
-                cache,
-                cycle_tracker,
-                id_allocator,
-            ) {
-                Ok(Some(shape)) => shape,
-                Ok(None) => {
-                    return Ok(ExternalGraphicsStateKey::SoftMask(None));
-                }
-                Err(err) => return Err(err),
-            };
-
-            Some(Box::new(SoftMask { mask_type, shape }))
-        }
-        other => match other.try_str(objects)? {
-            "None" => None,
-            _ => {
-                return Err(invalid_ext_gstate_entry_value(
-                    key_name,
-                    "expected a soft mask dictionary or the name 'None'",
-                ));
-            }
-        },
-    };
-
-    Ok(ExternalGraphicsStateKey::SoftMask(smask))
-}
-
 /// Parse a single key/value pair of the ExtGState dictionary.
 ///
 /// Returns `Ok(None)` for unrecognized keys, which are silently ignored
@@ -314,7 +255,28 @@ fn parse_entry(
         "OPM" => ExternalGraphicsStateKey::OverprintMode(value.try_number::<i32>(objects)?),
         "Font" => parse_font(name, value, objects, cache, cycle_tracker, id_allocator)?,
         "BM" => parse_blend_mode(value, objects)?,
-        "SMask" => parse_soft_mask(name, value, objects, cache, cycle_tracker, id_allocator)?,
+        "SMask" => {
+            let soft_mask = match value {
+                ObjectVariant::Dictionary(dictionary) => SoftMask::from_dictionary(
+                    dictionary,
+                    objects,
+                    cache,
+                    cycle_tracker,
+                    id_allocator,
+                )?
+                .map(Box::new),
+                other => match other.try_str(objects)? {
+                    "None" => None,
+                    _ => {
+                        return Err(invalid_ext_gstate_entry_value(
+                            name,
+                            "expected a soft mask dictionary or the name 'None'",
+                        ));
+                    }
+                },
+            };
+            ExternalGraphicsStateKey::SoftMask(soft_mask)
+        }
         "CA" => ExternalGraphicsStateKey::StrokingAlpha(value.try_number::<f32>(objects)?),
         "ca" => ExternalGraphicsStateKey::NonStrokingAlpha(value.try_number::<f32>(objects)?),
         "SA" => ExternalGraphicsStateKey::StrokeAdjustment(value.try_boolean(objects)?),
@@ -351,6 +313,22 @@ mod tests {
                 ObjectVariant::Real(f64::from(dash_phase)),
             ]),
         )]))
+    }
+
+    fn parse_ext_gstate(
+        dictionary: &Dictionary,
+    ) -> Result<Option<ExternalGraphicsState>, PdfPagesError> {
+        let mut cache = DefaultResourceCache::default();
+        let mut cycle_tracker = ReadCycleTracker::default();
+        let mut id_allocator = ContentStreamIdAllocator::new();
+
+        ExternalGraphicsState::from_dictionary(
+            dictionary,
+            &PassthroughResolver,
+            &mut cache,
+            &mut cycle_tracker,
+            &mut id_allocator,
+        )
     }
 
     #[test]
@@ -428,5 +406,40 @@ mod tests {
         .expect("extgstate should be present");
 
         assert!(ext_gstate.params.is_empty());
+    }
+
+    #[test]
+    fn soft_mask_none_is_preserved() {
+        let dictionary = Dictionary::new(BTreeMap::from([(
+            "SMask".to_string(),
+            ObjectVariant::Name(b"None".to_vec()),
+        )]));
+
+        let ext_gstate = parse_ext_gstate(&dictionary)
+            .expect("extgstate should parse")
+            .expect("extgstate should be present");
+
+        assert!(matches!(
+            ext_gstate.params.as_slice(),
+            [ExternalGraphicsStateKey::SoftMask(None)]
+        ));
+    }
+
+    #[test]
+    fn invalid_soft_mask_name_is_rejected() {
+        let dictionary = Dictionary::new(BTreeMap::from([(
+            "SMask".to_string(),
+            ObjectVariant::Name(b"Invalid".to_vec()),
+        )]));
+
+        let error = match parse_ext_gstate(&dictionary) {
+            Err(error) => error,
+            Ok(_) => panic!("invalid soft mask should fail"),
+        };
+
+        assert!(matches!(
+            error,
+            PdfPagesError::InvalidExtGStateEntryValue { entry, .. } if entry == "SMask"
+        ));
     }
 }

--- a/crates/pdf-resources/src/lib.rs
+++ b/crates/pdf-resources/src/lib.rs
@@ -3,6 +3,7 @@ pub mod external_graphics_state;
 pub mod form;
 pub mod pattern;
 pub mod resources;
+pub mod soft_mask;
 pub mod xobject;
 
 mod lazy_cache_value;

--- a/crates/pdf-resources/src/soft_mask.rs
+++ b/crates/pdf-resources/src/soft_mask.rs
@@ -1,0 +1,143 @@
+//! External graphics-state soft mask parsing.
+
+use pdf_content_stream::ContentStreamIdAllocator;
+use pdf_graphics::MaskMode;
+use pdf_object::{
+    dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
+};
+
+use crate::{
+    error::PdfPagesError,
+    object_reader::{ReadCycleTracker, ReadXObject},
+    resource_cache::ResourceCache,
+    xobject::XObject,
+};
+
+/// Soft mask extracted from an ExtGState `SMask` entry.
+pub struct SoftMask {
+    /// How the mask is derived from the transparency group output: from color
+    /// luminance (`Luminosity`) or from alpha/shape (`Alpha`).
+    pub mask_type: MaskMode,
+    /// The transparency group XObject (`G`) whose rendered result provides the
+    /// input used to compute the soft mask.
+    pub shape: XObject,
+}
+
+impl SoftMask {
+    /// Parses a soft mask dictionary.
+    ///
+    /// Returns `None` when the mask's transparency group is skipped because it
+    /// would introduce a cycle in the XObject graph.
+    pub fn from_dictionary(
+        dictionary: &Dictionary,
+        objects: &dyn ObjectResolver,
+        cache: &mut dyn ResourceCache,
+        cycle_tracker: &mut ReadCycleTracker,
+        id_allocator: &mut ContentStreamIdAllocator,
+    ) -> Result<Option<Self>, PdfPagesError> {
+        let mask_type = MaskMode::from(dictionary.required_str("S", objects)?);
+
+        let content = dictionary.get_or_err("G")?;
+        let stream = content.try_stream(objects)?;
+        let Some(shape) = XObject::read_xobject(
+            content,
+            &stream.dictionary,
+            stream,
+            objects,
+            cache,
+            cycle_tracker,
+            id_allocator,
+        )?
+        else {
+            return Ok(None);
+        };
+
+        Ok(Some(Self { mask_type, shape }))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use pdf_content_stream::ContentStreamIdAllocator;
+    use pdf_graphics::MaskMode;
+    use pdf_object::{
+        dictionary::Dictionary, object_resolver::PassthroughResolver,
+        object_variant::ObjectVariant, stream::StreamObject,
+    };
+
+    use crate::{
+        object_reader::ReadCycleTracker, resource_cache::DefaultResourceCache, xobject::XObject,
+    };
+
+    use super::SoftMask;
+
+    fn soft_mask_dictionary(stream_object_number: usize) -> Dictionary {
+        let form_dictionary = Dictionary::new(BTreeMap::from([
+            (
+                "BBox".to_string(),
+                ObjectVariant::Array(vec![
+                    ObjectVariant::Integer(0),
+                    ObjectVariant::Integer(0),
+                    ObjectVariant::Integer(10),
+                    ObjectVariant::Integer(10),
+                ]),
+            ),
+            ("Subtype".to_string(), ObjectVariant::Name(b"Form".to_vec())),
+        ]));
+        let stream = StreamObject::new(
+            stream_object_number,
+            0,
+            Box::new(form_dictionary),
+            Vec::new(),
+        );
+
+        Dictionary::new(BTreeMap::from([
+            ("G".to_string(), ObjectVariant::Stream(stream)),
+            ("S".to_string(), ObjectVariant::Name(b"Alpha".to_vec())),
+        ]))
+    }
+
+    #[test]
+    fn parses_soft_mask_dictionary() {
+        let dictionary = soft_mask_dictionary(7);
+        let mut cache = DefaultResourceCache::default();
+        let mut cycle_tracker = ReadCycleTracker::default();
+        let mut id_allocator = ContentStreamIdAllocator::new();
+
+        let soft_mask = SoftMask::from_dictionary(
+            &dictionary,
+            &PassthroughResolver,
+            &mut cache,
+            &mut cycle_tracker,
+            &mut id_allocator,
+        )
+        .expect("soft mask should parse")
+        .expect("soft mask should be present");
+
+        assert_eq!(soft_mask.mask_type, MaskMode::Alpha);
+        assert!(matches!(soft_mask.shape, XObject::Form(_)));
+    }
+
+    #[test]
+    fn cycle_suppressed_shape_returns_none() {
+        let dictionary = soft_mask_dictionary(7);
+        let mut cache = DefaultResourceCache::default();
+        let mut cycle_tracker = ReadCycleTracker::default();
+        let mut id_allocator = ContentStreamIdAllocator::new();
+        assert!(cycle_tracker.begin_read(7));
+
+        let soft_mask = SoftMask::from_dictionary(
+            &dictionary,
+            &PassthroughResolver,
+            &mut cache,
+            &mut cycle_tracker,
+            &mut id_allocator,
+        )
+        .expect("cycle-suppressed soft mask should not fail");
+
+        assert!(soft_mask.is_none());
+    }
+}


### PR DESCRIPTION
Move SoftMask into its own public module and parse soft-mask dictionaries through an associated constructor. Keep ExtGState parsing focused on dispatch while preserving cycle suppression and /None handling.