### PR TITLE
pdf-resources: share resource dictionaries

### DIFF
--- a/crates/pdf-annotation-form/src/free_text_appearance_stream_builder.rs
+++ b/crates/pdf-annotation-form/src/free_text_appearance_stream_builder.rs
@@ -158,7 +158,7 @@ impl<'a> FreeTextAppearanceStreamBuilder<'a> {
         let form = FormXObject {
             bbox: Rect::new(bounds.width(), bounds.height()),
             matrix: None,
-            resources: Some(resources),
+            resources: Some(Rc::new(resources)),
             content_stream: ContentStream { operators, id: 0 },
         };
         AppearanceDictionary {

--- a/crates/pdf-annotations/src/render.rs
+++ b/crates/pdf-annotations/src/render.rs
@@ -162,7 +162,7 @@ impl<'a, B: CanvasBackend> AnnotationRenderer<'a, B> {
             &appearance.content_stream,
             Some(placement),
             Some(&appearance_bbox),
-            appearance.resources.as_ref(),
+            appearance.resources.as_deref(),
             None,
         )?;
 

--- a/crates/pdf-canvas/src/canvas_external_object_ops.rs
+++ b/crates/pdf-canvas/src/canvas_external_object_ops.rs
@@ -93,7 +93,7 @@ impl<B: CanvasBackend> XObjectOps for PdfCanvas<'_, B> {
                 &form.content_stream,
                 form.matrix,
                 Some(&form.bbox),
-                form.resources.as_ref(),
+                form.resources.as_deref(),
                 None,
             )?,
         }

--- a/crates/pdf-canvas/src/canvas_graphics_state_ops.rs
+++ b/crates/pdf-canvas/src/canvas_graphics_state_ops.rs
@@ -160,7 +160,7 @@ impl<B: CanvasBackend> GraphicsStateOps for PdfCanvas<'_, B> {
                                 &form.content_stream,
                                 form.matrix,
                                 &form.bbox,
-                                form.resources.as_ref(),
+                                form.resources.as_deref(),
                                 None,
                             )?;
 

--- a/crates/pdf-canvas/src/pdf_canvas.rs
+++ b/crates/pdf-canvas/src/pdf_canvas.rs
@@ -364,7 +364,7 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
                     content_stream,
                     None,
                     &bbox,
-                    Some(resources),
+                    Some(resources.as_ref()),
                     filter,
                 )?;
 

--- a/crates/pdf-document/src/page.rs
+++ b/crates/pdf-document/src/page.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use pdf_annotation_types::{Annotation, AnnotationError, annotation_id::AnnotationId};
 use pdf_content_stream::{ContentStream, ContentStreamIdAllocator};
 use pdf_graphics::rect::Rect;
@@ -22,7 +24,7 @@ pub struct PdfPage {
     /// `/MediaBox` attribute which defines the page boundaries.
     pub media_box: Option<Rect>,
     /// `/Resources` attribute which defines the resources used by the page.
-    pub resources: Option<Resources>,
+    pub resources: Option<Rc<Resources>>,
     /// Next page-scoped annotation identifier.
     #[doc(hidden)]
     pub annotation_id_high_watermark: usize,

--- a/crates/pdf-document/src/pages.rs
+++ b/crates/pdf-document/src/pages.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::page::PdfPage;
 use pdf_content_stream::ContentStreamIdAllocator;
 use pdf_graphics::rect::Rect;
@@ -115,12 +117,14 @@ impl PdfPages {
     /// - A page with no `/Resources` inherits the ancestor's resources directly.
     /// - A page with its own `/Resources` keeps its own entries and fills in any
     ///   categories or names that are absent from the ancestor.
-    fn apply_resource_inheritance(pages: &mut [PdfPage], resources: &Resources) {
+    fn apply_resource_inheritance(pages: &mut [PdfPage], resources: &Rc<Resources>) {
         for page in pages {
-            if let Some(page_resources) = page.resources.as_mut() {
-                page_resources.merge_from_parent(resources);
+            if let Some(page_resources) = page.resources.as_ref() {
+                if let Some(merged) = page_resources.merged_with_parent(resources) {
+                    page.resources = Some(Rc::new(merged));
+                }
             } else {
-                page.resources = Some(resources.clone());
+                page.resources = Some(Rc::clone(resources));
             }
         }
     }
@@ -149,7 +153,7 @@ mod tests {
 
     #[test]
     fn leaf_page_with_no_resources_inherits_parent_resources() {
-        let parent = resources_with_color_space("CS1");
+        let parent = Rc::new(resources_with_color_space("CS1"));
 
         let mut page = PdfPage {
             resources: None,
@@ -163,7 +167,10 @@ mod tests {
 
         let inherited = page
             .resources
+            .as_ref()
             .expect("page should have inherited resources");
+        assert!(Rc::ptr_eq(inherited, &parent));
+
         assert!(
             inherited.color_spaces.contains_key("CS1"),
             "inherited resources should contain the parent color space"
@@ -173,7 +180,7 @@ mod tests {
     #[test]
     fn leaf_page_child_entries_take_priority_during_inheritance() {
         // Parent has a color space "CS1" (DeviceGray).
-        let parent = resources_with_color_space("CS1");
+        let parent = Rc::new(resources_with_color_space("CS1"));
 
         // Child already defines "CS1" (DeviceRGB) and also has "CS2".
         let mut child_res = Resources::default();
@@ -186,8 +193,9 @@ mod tests {
             Resource::ColorSpace(Rc::new(ColorSpace::DeviceGray)),
         );
 
+        let child_res = Rc::new(child_res);
         let mut page = PdfPage {
-            resources: Some(child_res),
+            resources: Some(Rc::clone(&child_res)),
             contents: None,
             annotations: None,
             media_box: None,
@@ -200,6 +208,7 @@ mod tests {
             .resources
             .as_ref()
             .expect("page should still have resources");
+        assert!(!Rc::ptr_eq(result, &child_res));
 
         // "CS1" must remain the child's version (DeviceRGB), not replaced by the parent's (DeviceGray).
         assert!(
@@ -225,6 +234,7 @@ mod tests {
             "CS2".to_owned(),
             Resource::ColorSpace(Rc::new(ColorSpace::DeviceRGB)),
         );
+        let parent = Rc::new(parent);
 
         // Child only defines "CS1" (DeviceRGB); it is missing "CS2".
         let mut child_res = Resources::default();
@@ -234,7 +244,7 @@ mod tests {
         );
 
         let mut page = PdfPage {
-            resources: Some(child_res),
+            resources: Some(Rc::new(child_res)),
             contents: None,
             annotations: None,
             media_box: None,

--- a/crates/pdf-renderer/src/lib.rs
+++ b/crates/pdf-renderer/src/lib.rs
@@ -83,7 +83,7 @@ impl PdfRenderer {
                     cs,
                     None,
                     None,
-                    page.resources.as_ref(),
+                    page.resources.as_deref(),
                     None,
                 )?;
             }
@@ -114,7 +114,7 @@ impl PdfRenderer {
                     cs,
                     None,
                     None,
-                    page.resources.as_ref(),
+                    page.resources.as_deref(),
                     None,
                 )?;
             }
@@ -139,7 +139,7 @@ impl PdfRenderer {
             let mut canvas =
                 PdfCanvas::new_with_text_sink(&mut backend, page, None, &mut collector)?;
             if let Some(cs) = &page.contents {
-                canvas.render_content_stream(cs, None, None, page.resources.as_ref(), None)?;
+                canvas.render_content_stream(cs, None, None, page.resources.as_deref(), None)?;
             }
         }
 

--- a/crates/pdf-resources/src/form.rs
+++ b/crates/pdf-resources/src/form.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use pdf_content_stream::{ContentStream, ContentStreamIdAllocator};
 use pdf_graphics::rect::Rect;
 use pdf_graphics::transform::Transform;
@@ -17,7 +19,7 @@ pub struct FormXObject {
     /// Optional transformation matrix.
     pub matrix: Option<Transform>,
     /// Resources used by the form.
-    pub resources: Option<Resources>,
+    pub resources: Option<Rc<Resources>>,
     /// The content stream that defines the graphics of the pattern cell.
     pub content_stream: ContentStream,
 }

--- a/crates/pdf-resources/src/lazy_cache_value.rs
+++ b/crates/pdf-resources/src/lazy_cache_value.rs
@@ -1,5 +1,7 @@
 //! Trait implementations for cache entries that support lazy placeholder resolution.
 
+use std::rc::Rc;
+
 use crate::{
     resource::{Resource, ResourceReference},
     resource_cache::ResourceCache,
@@ -12,30 +14,37 @@ use crate::{
 /// Implementations describe how the value is stored in a [`ResourceCache`] and
 /// how to create a placeholder/reference pair so recursive lookups can observe
 /// the entry while the final value is still being constructed.
-pub trait LazyCacheValue: Clone {
+pub trait LazyCacheValue: Sized {
+    /// The shareable representation stored in and returned from the cache.
+    type Shared: Clone;
+
     /// The reference handle stored inside the placeholder value.
     type Reference;
 
     /// Returns a cached value if one already exists for `obj_num`.
-    fn get_cached<'a>(cache: &'a dyn ResourceCache, obj_num: &usize) -> Option<&'a Self>;
+    fn get_cached<'a>(cache: &'a dyn ResourceCache, obj_num: &usize) -> Option<&'a Self::Shared>;
 
     /// Inserts `value` into the cache under `obj_num`.
-    fn insert_cached(cache: &mut dyn ResourceCache, obj_num: usize, value: Self);
+    fn insert_cached(cache: &mut dyn ResourceCache, obj_num: usize, value: Self::Shared);
 
     /// Removes the cached value stored under `obj_num`, if any.
-    fn remove_cached(cache: &mut dyn ResourceCache, obj_num: &usize) -> Option<Self>;
+    fn remove_cached(cache: &mut dyn ResourceCache, obj_num: &usize) -> Option<Self::Shared>;
 
     /// Creates a placeholder/reference pair for `object_number`.
     ///
     /// The placeholder is inserted into the cache immediately, while the
     /// returned reference is later resolved with the fully parsed value.
-    fn cyclic_reference(object_number: usize) -> (Self, Self::Reference);
+    fn cyclic_reference(object_number: usize) -> (Self::Shared, Self::Reference);
+
+    /// Converts a freshly parsed value into its shareable representation.
+    fn into_shared(value: Self) -> Self::Shared;
 
     /// Resolves `reference` so it points at the fully parsed `value`.
-    fn resolve(reference: &Self::Reference, value: Self);
+    fn resolve(reference: &Self::Reference, value: &Self::Shared);
 }
 
 impl LazyCacheValue for Resource {
+    type Shared = Self;
     type Reference = ResourceReference;
 
     fn get_cached<'a>(cache: &'a dyn ResourceCache, obj_num: &usize) -> Option<&'a Self> {
@@ -54,31 +63,41 @@ impl LazyCacheValue for Resource {
         Self::cyclic_reference(object_number)
     }
 
-    fn resolve(reference: &Self::Reference, value: Self) {
-        reference.resolve(value);
+    fn into_shared(value: Self) -> Self::Shared {
+        value
+    }
+
+    fn resolve(reference: &Self::Reference, value: &Self::Shared) {
+        reference.resolve(value.clone());
     }
 }
 
 impl LazyCacheValue for Resources {
+    type Shared = Rc<Self>;
     type Reference = ResourcesReference;
 
-    fn get_cached<'a>(cache: &'a dyn ResourceCache, obj_num: &usize) -> Option<&'a Self> {
+    fn get_cached<'a>(cache: &'a dyn ResourceCache, obj_num: &usize) -> Option<&'a Self::Shared> {
         cache.get_resources(obj_num)
     }
 
-    fn insert_cached(cache: &mut dyn ResourceCache, obj_num: usize, value: Self) {
+    fn insert_cached(cache: &mut dyn ResourceCache, obj_num: usize, value: Self::Shared) {
         cache.insert_resources(obj_num, value);
     }
 
-    fn remove_cached(cache: &mut dyn ResourceCache, obj_num: &usize) -> Option<Self> {
+    fn remove_cached(cache: &mut dyn ResourceCache, obj_num: &usize) -> Option<Self::Shared> {
         cache.remove_resources(obj_num)
     }
 
-    fn cyclic_reference(object_number: usize) -> (Self, Self::Reference) {
-        Self::cyclic_reference(object_number)
+    fn cyclic_reference(object_number: usize) -> (Self::Shared, Self::Reference) {
+        let (placeholder, reference) = Self::cyclic_reference(object_number);
+        (Rc::new(placeholder), reference)
     }
 
-    fn resolve(reference: &Self::Reference, value: Self) {
-        reference.resolve(value);
+    fn into_shared(value: Self) -> Self::Shared {
+        Rc::new(value)
+    }
+
+    fn resolve(reference: &Self::Reference, value: &Self::Shared) {
+        reference.resolve(Rc::clone(value));
     }
 }

--- a/crates/pdf-resources/src/pattern.rs
+++ b/crates/pdf-resources/src/pattern.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use pdf_content_stream::{ContentStream, ContentStreamIdAllocator};
 use pdf_graphics::{rect::Rect, transform::Transform};
 use pdf_object::{
@@ -102,7 +104,7 @@ pub enum Pattern {
         /// An optional transformation matrix to be applied to the pattern.
         matrix: Option<Transform>,
         /// A dictionary of resources required by the pattern's content stream.
-        resources: Resources,
+        resources: Rc<Resources>,
         /// The content stream that defines the graphics of the pattern cell.
         content_stream: ContentStream,
     },
@@ -170,10 +172,7 @@ impl Pattern {
                 // Read the `/Resources` entry. Needed by the pattern's content stream.
                 let parsed_resources =
                     Resources::read(dictionary, objects, cache, cycle_tracker, id_allocator)?;
-                let mut resources = Resources::default();
-                if let Some(parsed) = parsed_resources {
-                    resources = parsed;
-                }
+                let resources = parsed_resources.unwrap_or_else(|| Rc::new(Resources::default()));
 
                 let content_stream = ContentStream::new(object, objects, id_allocator)?;
 

--- a/crates/pdf-resources/src/resource_cache.rs
+++ b/crates/pdf-resources/src/resource_cache.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, rc::Rc};
 
 pub use crate::lazy_cache_value::LazyCacheValue;
 use crate::{resource::Resource, resources::Resources};
@@ -33,12 +33,12 @@ pub trait ResourceCache {
     fn insert(&mut self, obj_num: usize, resource: Resource);
 
     /// Retrieves a reference to a parsed `/Resources` dictionary associated with the object number.
-    fn get_resources(&self, _obj_num: &usize) -> Option<&Resources> {
+    fn get_resources(&self, _obj_num: &usize) -> Option<&Rc<Resources>> {
         None
     }
 
     /// Inserts a parsed `/Resources` dictionary into the cache.
-    fn insert_resources(&mut self, _obj_num: usize, _resources: Resources) {}
+    fn insert_resources(&mut self, _obj_num: usize, _resources: Rc<Resources>) {}
 
     /// Removes a cached resource for the given object number, if present.
     fn remove(&mut self, _obj_num: &usize) -> Option<Resource> {
@@ -46,7 +46,7 @@ pub trait ResourceCache {
     }
 
     /// Removes a cached `/Resources` dictionary for the given object number, if present.
-    fn remove_resources(&mut self, _obj_num: &usize) -> Option<Resources> {
+    fn remove_resources(&mut self, _obj_num: &usize) -> Option<Rc<Resources>> {
         None
     }
 }
@@ -55,7 +55,7 @@ pub trait ResourceCache {
 #[derive(Default)]
 pub struct DefaultResourceCache {
     resources: HashMap<usize, Resource>,
-    resource_dictionaries: HashMap<usize, Resources>,
+    resource_dictionaries: HashMap<usize, Rc<Resources>>,
 }
 
 impl ResourceCache for DefaultResourceCache {
@@ -67,11 +67,11 @@ impl ResourceCache for DefaultResourceCache {
         self.resources.insert(obj_num, resource);
     }
 
-    fn get_resources(&self, obj_num: &usize) -> Option<&Resources> {
+    fn get_resources(&self, obj_num: &usize) -> Option<&Rc<Resources>> {
         self.resource_dictionaries.get(obj_num)
     }
 
-    fn insert_resources(&mut self, obj_num: usize, resources: Resources) {
+    fn insert_resources(&mut self, obj_num: usize, resources: Rc<Resources>) {
         self.resource_dictionaries.insert(obj_num, resources);
     }
 
@@ -79,7 +79,7 @@ impl ResourceCache for DefaultResourceCache {
         self.resources.remove(obj_num)
     }
 
-    fn remove_resources(&mut self, obj_num: &usize) -> Option<Resources> {
+    fn remove_resources(&mut self, obj_num: &usize) -> Option<Rc<Resources>> {
         self.resource_dictionaries.remove(obj_num)
     }
 }
@@ -93,13 +93,13 @@ pub(crate) fn read_resource_lazy<T, E, F>(
     cache: &mut dyn ResourceCache,
     obj_num: Option<usize>,
     read: F,
-) -> Result<T, E>
+) -> Result<T::Shared, E>
 where
     T: LazyCacheValue,
     F: FnOnce(&mut dyn ResourceCache) -> Result<T, E>,
 {
     let Some(obj_num) = obj_num else {
-        return read(cache);
+        return read(cache).map(T::into_shared);
     };
 
     if let Some(cached) = T::get_cached(cache, &obj_num) {
@@ -111,7 +111,8 @@ where
 
     match read(cache) {
         Ok(value) => {
-            T::resolve(&reference, value.clone());
+            let value = T::into_shared(value);
+            T::resolve(&reference, &value);
             T::insert_cached(cache, obj_num, value.clone());
             Ok(value)
         }

--- a/crates/pdf-resources/src/resources.rs
+++ b/crates/pdf-resources/src/resources.rs
@@ -33,7 +33,14 @@ use pdf_color_space::color_space::ColorSpace;
 /// (PDF spec §7.8.3). Keeping them separate ensures that resource names are scoped per
 /// category: a font named `"F1"` and an XObject named `"F1"` are independent entries and
 /// will never collide during page-tree resource inheritance (PDF spec §7.7.4).
-#[derive(Default, Clone)]
+///
+/// ```compile_fail
+/// use pdf_resources::resources::Resources;
+///
+/// fn requires_clone<T: Clone>() {}
+/// requires_clone::<Resources>();
+/// ```
+#[derive(Default)]
 pub struct Resources {
     /// Resources from the `/Font` sub-dictionary.
     pub fonts: HashMap<String, Resource>,
@@ -86,7 +93,7 @@ pub(crate) fn read_font_resource(
     // parsed Type3 fonts consume nested resources; whole-font fallbacks do not.
     let font = Font::from_dictionary(dictionary, objects, id_allocator);
     let resources = if matches!(&font, Font::Type3(_)) {
-        Resources::read(dictionary, objects, cache, cycle_tracker, id_allocator)?.map(Rc::new)
+        Resources::read(dictionary, objects, cache, cycle_tracker, id_allocator)?
     } else {
         None
     };
@@ -479,8 +486,8 @@ impl Resources {
     ///
     /// # Returns
     ///
-    /// Returns `Ok(Some(Resources))` if resources are found and parsed successfully, `Ok(None)`
-    /// if no `/Resources` entry exists, or an error if parsing fails for any resource type.
+    /// Returns a shared [`Resources`] value when resources are found, `None` if no
+    /// `/Resources` entry exists, or an error if parsing fails for any resource type.
     ///
     /// # Errors
     ///
@@ -491,7 +498,7 @@ impl Resources {
         cache: &mut dyn ResourceCache,
         cycle_tracker: &mut ReadCycleTracker,
         id_allocator: &mut ContentStreamIdAllocator,
-    ) -> Result<Option<Self>, PdfPagesError> {
+    ) -> Result<Option<Rc<Self>>, PdfPagesError> {
         const KEY: &str = "Resources";
 
         let Some(resources_entry) = dictionary.get(KEY) else {
@@ -519,7 +526,7 @@ impl Resources {
         .map(Some)
     }
 
-    /// Merges inherited resources from a parent `/Pages` node into `self`.
+    /// Returns a resource dictionary containing `self` and inherited parent entries.
     ///
     /// Per PDF spec §7.7.4, child-defined entries always take precedence. Only
     /// entries that are absent in `self` are inherited from `parent`. Merging is
@@ -527,30 +534,37 @@ impl Resources {
     /// in one category (e.g. a font named `"F1"`) never blocks inheritance of a
     /// parent entry of a different category with the same name (e.g. an XObject
     /// named `"F1"`).
-    pub fn merge_from_parent(&mut self, parent: &Self) {
-        let Some(parent) = parent.resolved() else {
-            return;
-        };
-        let Some(mut child) = self.resolved().cloned() else {
-            return;
-        };
+    pub fn merged_with_parent(&self, parent: &Self) -> Option<Self> {
+        let parent = parent.resolved()?;
+        let child = self.resolved()?;
 
-        Self::inherit_category(&mut child.fonts, &parent.fonts);
-        Self::inherit_category(&mut child.ext_g_states, &parent.ext_g_states);
-        Self::inherit_category(&mut child.patterns, &parent.patterns);
-        Self::inherit_category(&mut child.xobjects, &parent.xobjects);
-        Self::inherit_category(&mut child.shadings, &parent.shadings);
-        Self::inherit_category(&mut child.color_spaces, &parent.color_spaces);
-        *self = child;
+        Some(Self {
+            fonts: Self::merged_category(&child.fonts, &parent.fonts),
+            ext_g_states: Self::merged_category(&child.ext_g_states, &parent.ext_g_states),
+            patterns: Self::merged_category(&child.patterns, &parent.patterns),
+            xobjects: Self::merged_category(&child.xobjects, &parent.xobjects),
+            shadings: Self::merged_category(&child.shadings, &parent.shadings),
+            color_spaces: Self::merged_category(&child.color_spaces, &parent.color_spaces),
+            lazy_reference: None,
+        })
     }
 
-    /// Copies entries from `parent` into `child` for a single resource category,
-    /// inserting only names that are not already present in `child`.
-    fn inherit_category(child: &mut HashMap<String, Resource>, parent: &HashMap<String, Resource>) {
+    /// Returns one merged resource category with child entries taking precedence.
+    fn merged_category(
+        child: &HashMap<String, Resource>,
+        parent: &HashMap<String, Resource>,
+    ) -> HashMap<String, Resource> {
+        let mut merged = HashMap::with_capacity(child.len().saturating_add(parent.len()));
+        merged.extend(
+            child
+                .iter()
+                .map(|(name, value)| (name.clone(), value.clone())),
+        );
         for (k, v) in parent {
-            if !child.contains_key(k) {
-                child.insert(k.clone(), v.clone());
+            if !merged.contains_key(k) {
+                merged.insert(k.clone(), v.clone());
             }
         }
+        merged
     }
 }

--- a/crates/pdf-resources/src/resources_reference.rs
+++ b/crates/pdf-resources/src/resources_reference.rs
@@ -11,7 +11,7 @@ use crate::resources::Resources;
 /// value has been fully parsed.
 #[derive(Clone)]
 pub struct ResourcesReference {
-    resources: Rc<OnceCell<Resources>>,
+    resources: Rc<OnceCell<Rc<Resources>>>,
 }
 
 impl ResourcesReference {
@@ -27,12 +27,12 @@ impl ResourcesReference {
     }
 
     /// Publishes the parsed `/Resources` dictionary to all clones of this handle.
-    pub(crate) fn resolve(&self, resources: Resources) {
+    pub(crate) fn resolve(&self, resources: Rc<Resources>) {
         let _ = self.resources.set(resources);
     }
 
     /// Returns the parsed `/Resources` dictionary once it has been published.
     pub(crate) fn resolved(&self) -> Option<&Resources> {
-        self.resources.get()
+        self.resources.get().map(Rc::as_ref)
     }
 }

--- a/crates/pdf-resources/tests/resources.rs
+++ b/crates/pdf-resources/tests/resources.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, rc::Rc};
 
 use pdf_content_stream::ContentStreamIdAllocator;
 use pdf_font::font::Font;
@@ -421,6 +421,17 @@ fn cyclic_form_resources_resolve_lazily_without_recursing_forever() {
     )
     .expect("cyclic resources should parse")
     .expect("page resources should exist");
+
+    let cached_resources = Resources::read(
+        &page_dict,
+        &objects,
+        &mut cache,
+        &mut cycle_tracker,
+        &mut ids,
+    )
+    .expect("cached resources should parse")
+    .expect("cached page resources should exist");
+    assert!(Rc::ptr_eq(&resources, &cached_resources));
 
     let form = resources.xobject("Self");
     assert!(


### PR DESCRIPTION
Make Resources non-Clone and teach LazyCacheValue to return an associated shared representation. Store parsed resource dictionaries behind Rc across caches, pages, forms, and patterns while leaving their resource maps unchanged.

Share inherited page resources directly and build a merged dictionary only for child overrides. Preserve recursive placeholder resolution and cover non-Clone, cache identity, and inheritance behavior.