### PR TITLE
pdf-resources: flatten xobject resources

### DIFF
--- a/crates/pdf-canvas/src/canvas_external_object_ops.rs
+++ b/crates/pdf-canvas/src/canvas_external_object_ops.rs
@@ -14,7 +14,7 @@ use pdf_content_stream_operators::pdf_operator_backend::XObjectOps;
 use pdf_graphics::{rect::Rect, transform::Transform};
 use pdf_image::{ImageXObject, InlineImage};
 use pdf_object::object_resolver::PassthroughResolver;
-use pdf_resources::xobject::XObject;
+use pdf_resources::resource::Resource;
 
 use crate::{
     canvas_backend::{CanvasBackend, Image},
@@ -87,15 +87,16 @@ impl<B: CanvasBackend> XObjectOps for PdfCanvas<'_, B> {
             .ok_or_else(|| PdfCanvasError::XObjectNotFound(xobject_name.to_string()))?;
 
         match xobj {
-            XObject::Image(image) => self.render_image_xobject(image)?,
-            XObject::UnavailableImage => {}
-            XObject::Form(form) => self.render_content_stream(
+            Resource::Image(image) => self.render_image_xobject(image)?,
+            Resource::UnavailableImage => {}
+            Resource::Form(form) => self.render_content_stream(
                 &form.content_stream,
                 form.matrix,
                 Some(&form.bbox),
                 form.resources.as_deref(),
                 None,
             )?,
+            _ => return Err(PdfCanvasError::XObjectNotFound(xobject_name.to_string())),
         }
 
         Ok(())

--- a/crates/pdf-canvas/src/canvas_graphics_state_ops.rs
+++ b/crates/pdf-canvas/src/canvas_graphics_state_ops.rs
@@ -2,9 +2,7 @@ use std::sync::Arc;
 
 use pdf_content_stream_operators::pdf_operator_backend::GraphicsStateOps;
 use pdf_graphics::{DashPattern, LineCap, LineJoin, MaskMode, transform::Transform};
-use pdf_resources::{
-    external_graphics_state::ExternalGraphicsStateKey, resource::Resource, xobject::XObject,
-};
+use pdf_resources::{external_graphics_state::ExternalGraphicsStateKey, resource::Resource};
 
 use crate::{
     canvas_backend::CanvasBackend, error::PdfCanvasError, pdf_canvas::PdfCanvas,
@@ -139,47 +137,38 @@ impl<B: CanvasBackend> GraphicsStateOps for PdfCanvas<'_, B> {
                             continue;
                         }
 
-                        if let XObject::Image(_) = &smask.shape {
-                            return Err(PdfCanvasError::UnsupportedFeature(
-                                "SoftMask with Image shape".into(),
-                            ));
-                        } else if let XObject::Form(form) = &smask.shape {
-                            // The soft mask is defined by a Form XObject.
-                            // We need to render this form's content into a separate mask surface.
-                            if !Self::can_record_offscreen_bbox(&form.bbox) {
-                                continue;
-                            }
-
-                            // Create a recording canvas to act as the mask layer.
-                            let mut recording_canvas =
-                                RecordingCanvas::new(form.bbox.width(), form.bbox.height());
-
-                            // Render the form's content stream into the mask canvas.
-                            self.record_content_stream(
-                                &mut recording_canvas,
-                                &form.content_stream,
-                                form.matrix,
-                                &form.bbox,
-                                form.resources.as_deref(),
-                                None,
-                            )?;
-
-                            let transform = self.current_state()?.transform;
-
-                            let arc = Arc::new(recording_canvas);
-
-                            // Enable the mask on the main canvas. Subsequent drawing operations
-                            // will be modulated by this mask.
-                            self.canvas.begin_mask_layer(
-                                &arc,
-                                &transform,
-                                smask.mask_type.clone(),
-                            )?;
-
-                            // Store the mask in the current canvas state to be used until it's finished.
-                            self.mask =
-                                Some((Arc::clone(&arc), smask.mask_type.clone(), transform));
+                        let form = &smask.shape;
+                        // The soft mask is defined by a Form XObject.
+                        // We need to render this form's content into a separate mask surface.
+                        if !Self::can_record_offscreen_bbox(&form.bbox) {
+                            continue;
                         }
+
+                        // Create a recording canvas to act as the mask layer.
+                        let mut recording_canvas =
+                            RecordingCanvas::new(form.bbox.width(), form.bbox.height());
+
+                        // Render the form's content stream into the mask canvas.
+                        self.record_content_stream(
+                            &mut recording_canvas,
+                            &form.content_stream,
+                            form.matrix,
+                            &form.bbox,
+                            form.resources.as_deref(),
+                            None,
+                        )?;
+
+                        let transform = self.current_state()?.transform;
+
+                        let arc = Arc::new(recording_canvas);
+
+                        // Enable the mask on the main canvas. Subsequent drawing operations
+                        // will be modulated by this mask.
+                        self.canvas
+                            .begin_mask_layer(&arc, &transform, smask.mask_type.clone())?;
+
+                        // Store the mask in the current canvas state to be used until it's finished.
+                        self.mask = Some((Arc::clone(&arc), smask.mask_type.clone(), transform));
                     } else if let Some((mask, mask_type, transform)) = self.mask.take() {
                         // This branch handles the case where `/SMask` is set to `/None` in the `ExtGState`,
                         // which signals the end of the current soft mask application.

--- a/crates/pdf-canvas/tests/canvas_graphics_state_ops.rs
+++ b/crates/pdf-canvas/tests/canvas_graphics_state_ops.rs
@@ -15,7 +15,6 @@ use pdf_resources::{
     resource::Resource,
     resources::Resources,
     soft_mask::SoftMask,
-    xobject::XObject,
 };
 
 fn render(
@@ -95,7 +94,7 @@ fn soft_mask_form_with_zero_area_bbox_is_ignored() {
     let resources = graphics_state_resource(vec![ExternalGraphicsStateKey::SoftMask(Some(
         Box::new(SoftMask {
             mask_type: MaskMode::Alpha,
-            shape: XObject::Form(Box::new(form)),
+            shape: Rc::new(form),
         }),
     ))]);
     let stream = content_stream(1, b"/GS0 gs");

--- a/crates/pdf-canvas/tests/pdf_canvas.rs
+++ b/crates/pdf-canvas/tests/pdf_canvas.rs
@@ -17,7 +17,6 @@ use pdf_resources::{
     form::FormXObject,
     resource::Resource,
     resources::Resources,
-    xobject::XObject,
 };
 
 fn render(
@@ -34,7 +33,7 @@ fn form_resource(name: &str, stream: ContentStream) -> Resources {
     Resources {
         xobjects: HashMap::from([(
             name.to_string(),
-            Resource::XObject(Rc::new(XObject::Form(Box::new(FormXObject {
+            Resource::from(FormXObject {
                 bbox: Rect {
                     left: 0.0,
                     top: 0.0,
@@ -44,7 +43,7 @@ fn form_resource(name: &str, stream: ContentStream) -> Resources {
                 matrix: None,
                 resources: None,
                 content_stream: stream,
-            })))),
+            }),
         )]),
         ..Default::default()
     }
@@ -144,10 +143,7 @@ fn still_renders_nested_streams_with_distinct_ids() {
 fn unavailable_image_xobject_is_a_no_op() {
     let stream = content_stream(1, b"/Im Do");
     let resources = Resources {
-        xobjects: HashMap::from([(
-            "Im".to_string(),
-            Resource::XObject(Rc::new(XObject::UnavailableImage)),
-        )]),
+        xobjects: HashMap::from([("Im".to_string(), Resource::UnavailableImage)]),
         ..Default::default()
     };
     let mut recording = RecordingCanvas::new(100.0, 100.0);
@@ -176,10 +172,7 @@ fn inline_image_render_path_matches_image_xobject_path() {
     }));
     let resources = Resources {
         ext_g_states: HashMap::from([("GS".to_string(), graphics_state)]),
-        xobjects: HashMap::from([(
-            "Im".to_string(),
-            Resource::XObject(Rc::new(XObject::Image(image))),
-        )]),
+        xobjects: HashMap::from([("Im".to_string(), Resource::from(image))]),
         ..Default::default()
     };
 

--- a/crates/pdf-document/tests/reader.rs
+++ b/crates/pdf-document/tests/reader.rs
@@ -874,7 +874,7 @@ fn test_xobject_with_malformed_dimensions_loads_normally() {
 
     assert!(matches!(
         xobject,
-        Some(pdf_resources::xobject::XObject::UnavailableImage)
+        Some(pdf_resources::resource::Resource::UnavailableImage)
     ));
     assert!(page.contents.is_some());
 }

--- a/crates/pdf-resources/src/lib.rs
+++ b/crates/pdf-resources/src/lib.rs
@@ -4,10 +4,10 @@ pub mod form;
 pub mod pattern;
 pub mod resources;
 pub mod soft_mask;
-pub mod xobject;
 
 mod lazy_cache_value;
 pub mod object_reader;
 pub mod resource;
 pub mod resource_cache;
 mod resources_reference;
+mod xobject;

--- a/crates/pdf-resources/src/object_reader.rs
+++ b/crates/pdf-resources/src/object_reader.rs
@@ -1,16 +1,11 @@
-//! Trait-based readers for page-related PDF objects with shared cycle protection.
+//! Page-related PDF object reading with shared cycle protection.
 //!
-//! These traits centralize active-read cycle tracking
-//! used when parsing indirect objects that may recursively reference each other.
-//! Implementers provide an inner read method containing the actual parsing logic,
-//! while the default entrypoint methods handle cycle tracking consistently.
+//! This module centralizes active-read cycle tracking used when parsing indirect
+//! objects that may recursively reference each other.
 
 use crate::{error::PdfPagesError, resource_cache::ResourceCache};
 use pdf_content_stream::ContentStreamIdAllocator;
-use pdf_object::{
-    dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
-    stream::StreamObject,
-};
+use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 use std::collections::HashSet;
 
 /// Tracks objects currently being parsed by page-related object readers.
@@ -87,64 +82,6 @@ pub trait ReadFromDictionary {
         let result =
             Self::read_dictionary_inner(dictionary, objects, cache, cycle_tracker, id_allocator);
         cycle_tracker.end_read(obj_num);
-        result.map(Some)
-    }
-}
-
-/// Reads a stream-backed XObject with cycle protection.
-///
-/// Implementers provide [`ReadXObject::read_xobject_inner`] with the parsing
-/// logic for the stream and dictionary pair. The default
-/// [`ReadXObject::read_xobject`] wrapper handles cycle tracking using the
-/// stream object's number.
-pub trait ReadXObject {
-    /// Reads the XObject after cycle tracking has been started.
-    ///
-    /// Implementations should contain only the parsing logic for the XObject
-    /// and should not call `begin_read` or `end_read` directly.
-    fn read_xobject_inner(
-        content: &ObjectVariant,
-        dictionary: &Dictionary,
-        stream_data: &StreamObject,
-        objects: &dyn ObjectResolver,
-        cache: &mut dyn ResourceCache,
-        cycle_tracker: &mut ReadCycleTracker,
-        id_allocator: &mut ContentStreamIdAllocator,
-    ) -> Result<Self, PdfPagesError>
-    where
-        Self: Sized;
-
-    /// Reads an XObject and wraps the read in begin/end cycle tracking.
-    ///
-    /// This method marks `stream_data.object_number` as in-progress, delegates
-    /// to [`ReadXObject::read_xobject_inner`], and clears the in-progress marker
-    /// before returning.
-    fn read_xobject(
-        content: &ObjectVariant,
-        dictionary: &Dictionary,
-        stream_data: &StreamObject,
-        objects: &dyn ObjectResolver,
-        cache: &mut dyn ResourceCache,
-        cycle_tracker: &mut ReadCycleTracker,
-        id_allocator: &mut ContentStreamIdAllocator,
-    ) -> Result<Option<Self>, PdfPagesError>
-    where
-        Self: Sized,
-    {
-        if !cycle_tracker.begin_read(stream_data.object_number) {
-            return Ok(None);
-        }
-
-        let result = Self::read_xobject_inner(
-            content,
-            dictionary,
-            stream_data,
-            objects,
-            cache,
-            cycle_tracker,
-            id_allocator,
-        );
-        cycle_tracker.end_read(stream_data.object_number);
         result.map(Some)
     }
 }

--- a/crates/pdf-resources/src/resource.rs
+++ b/crates/pdf-resources/src/resource.rs
@@ -1,9 +1,10 @@
 use crate::{
-    external_graphics_state::ExternalGraphicsState, pattern::Pattern, resources::Resources,
-    xobject::XObject,
+    external_graphics_state::ExternalGraphicsState, form::FormXObject, pattern::Pattern,
+    resources::Resources,
 };
 use pdf_color_space::color_space::ColorSpace;
 use pdf_font::font::Font;
+use pdf_image::ImageXObject;
 use pdf_shading::model::Shading;
 use std::{cell::OnceCell, rc::Rc};
 
@@ -45,8 +46,12 @@ pub enum Resource {
     },
     /// An external graphics state resource.
     ExternalGraphicsState(Rc<ExternalGraphicsState>),
-    /// An XObject resource, such as an image or form object.
-    XObject(Rc<XObject>),
+    /// An image XObject resource.
+    Image(Rc<ImageXObject>),
+    /// An image XObject whose dimensions are malformed and cannot be rendered.
+    UnavailableImage,
+    /// A form XObject resource.
+    Form(Rc<FormXObject>),
     /// A pattern resource, used for tiling or shading fills.
     Pattern(Rc<Pattern>),
     /// A shading resource, used for gradient fills and complex color transitions.
@@ -95,13 +100,6 @@ impl Resource {
         Some(state)
     }
 
-    pub(crate) fn as_xobject(&self) -> Option<&XObject> {
-        let Self::XObject(xobject) = self.resolved()? else {
-            return None;
-        };
-        Some(xobject)
-    }
-
     pub(crate) fn as_pattern(&self) -> Option<&Pattern> {
         let Self::Pattern(pattern) = self.resolved()? else {
             return None;
@@ -121,5 +119,17 @@ impl Resource {
             return None;
         };
         Some(color_space)
+    }
+}
+
+impl From<ImageXObject> for Resource {
+    fn from(image: ImageXObject) -> Self {
+        Self::Image(Rc::new(image))
+    }
+}
+
+impl From<FormXObject> for Resource {
+    fn from(form: FormXObject) -> Self {
+        Self::Form(Rc::new(form))
     }
 }

--- a/crates/pdf-resources/src/resources.rs
+++ b/crates/pdf-resources/src/resources.rs
@@ -18,12 +18,12 @@ use pdf_shading::model::Shading;
 use crate::{
     error::PdfPagesError,
     external_graphics_state::ExternalGraphicsState,
-    object_reader::{ReadCycleTracker, ReadFromDictionary, ReadXObject},
+    object_reader::{ReadCycleTracker, ReadFromDictionary},
     pattern::Pattern,
     resource::Resource,
     resource_cache::{ResourceCache, read_resource_lazy},
     resources_reference::ResourcesReference,
-    xobject::XObject,
+    xobject::read_xobject,
 };
 use pdf_color_space::color_space::ColorSpace;
 
@@ -209,7 +209,7 @@ fn read_xobject_resource(
                 return Ok(Some(cached.clone()));
             }
 
-            let resource = match XObject::read_xobject(
+            let resource = match read_xobject(
                 value,
                 &stream.dictionary,
                 stream,
@@ -218,7 +218,7 @@ fn read_xobject_resource(
                 cycle_tracker,
                 id_allocator,
             ) {
-                Ok(Some(xobject)) => Resource::XObject(Rc::new(xobject)),
+                Ok(Some(resource)) => resource,
                 Ok(None) => return Ok(None),
                 Err(err) => return Err(err),
             };
@@ -265,7 +265,7 @@ fn read_xobject_resource(
                 )?
             };
 
-            let resource = Resource::XObject(Rc::new(XObject::Form(Box::new(form))));
+            let resource = Resource::from(form);
 
             if let Some(object_number) = object_number {
                 cache.insert(object_number, resource.clone());
@@ -424,10 +424,10 @@ impl Resources {
     ///
     /// # Returns
     ///
-    /// An `Option` containing a reference to the [`XObject`] if found, or `None`
-    /// if not present or not an XObject.
-    pub fn xobject(&self, name: &str) -> Option<&XObject> {
-        self.resolved()?.xobjects.get(name)?.as_xobject()
+    /// An `Option` containing the resolved [`Resource::Image`],
+    /// [`Resource::UnavailableImage`], or [`Resource::Form`] entry if found.
+    pub fn xobject(&self, name: &str) -> Option<&Resource> {
+        self.resolved()?.xobjects.get(name)?.resolved()
     }
 
     /// Returns a reference to a pattern resource by name, if it exists.

--- a/crates/pdf-resources/src/soft_mask.rs
+++ b/crates/pdf-resources/src/soft_mask.rs
@@ -1,5 +1,7 @@
 //! External graphics-state soft mask parsing.
 
+use std::rc::Rc;
+
 use pdf_content_stream::ContentStreamIdAllocator;
 use pdf_graphics::MaskMode;
 use pdf_object::{
@@ -7,10 +9,8 @@ use pdf_object::{
 };
 
 use crate::{
-    error::PdfPagesError,
-    object_reader::{ReadCycleTracker, ReadXObject},
-    resource_cache::ResourceCache,
-    xobject::XObject,
+    error::PdfPagesError, form::FormXObject, object_reader::ReadCycleTracker, resource::Resource,
+    resource_cache::ResourceCache, xobject::read_xobject,
 };
 
 /// Soft mask extracted from an ExtGState `SMask` entry.
@@ -20,7 +20,7 @@ pub struct SoftMask {
     pub mask_type: MaskMode,
     /// The transparency group XObject (`G`) whose rendered result provides the
     /// input used to compute the soft mask.
-    pub shape: XObject,
+    pub shape: Rc<FormXObject>,
 }
 
 impl SoftMask {
@@ -39,7 +39,15 @@ impl SoftMask {
 
         let content = dictionary.get_or_err("G")?;
         let stream = content.try_stream(objects)?;
-        let Some(shape) = XObject::read_xobject(
+        let subtype = stream.dictionary.required_str("Subtype", objects)?;
+        if subtype != "Form" {
+            return Err(PdfPagesError::InvalidExtGStateEntryValue {
+                entry: "SMask".to_string(),
+                reason: format!("group XObject must have /Subtype /Form, found /{subtype}"),
+            });
+        }
+
+        let Some(shape) = read_xobject(
             content,
             &stream.dictionary,
             stream,
@@ -50,6 +58,13 @@ impl SoftMask {
         )?
         else {
             return Ok(None);
+        };
+
+        let Resource::Form(shape) = shape else {
+            return Err(PdfPagesError::InvalidExtGStateEntryValue {
+                entry: "SMask".to_string(),
+                reason: "group XObject did not produce a Form resource".to_string(),
+            });
         };
 
         Ok(Some(Self { mask_type, shape }))
@@ -69,12 +84,12 @@ mod tests {
     };
 
     use crate::{
-        object_reader::ReadCycleTracker, resource_cache::DefaultResourceCache, xobject::XObject,
+        error::PdfPagesError, object_reader::ReadCycleTracker, resource_cache::DefaultResourceCache,
     };
 
     use super::SoftMask;
 
-    fn soft_mask_dictionary(stream_object_number: usize) -> Dictionary {
+    fn soft_mask_dictionary(stream_object_number: usize, subtype: &str) -> Dictionary {
         let form_dictionary = Dictionary::new(BTreeMap::from([
             (
                 "BBox".to_string(),
@@ -85,7 +100,10 @@ mod tests {
                     ObjectVariant::Integer(10),
                 ]),
             ),
-            ("Subtype".to_string(), ObjectVariant::Name(b"Form".to_vec())),
+            (
+                "Subtype".to_string(),
+                ObjectVariant::Name(subtype.as_bytes().to_vec()),
+            ),
         ]));
         let stream = StreamObject::new(
             stream_object_number,
@@ -102,7 +120,7 @@ mod tests {
 
     #[test]
     fn parses_soft_mask_dictionary() {
-        let dictionary = soft_mask_dictionary(7);
+        let dictionary = soft_mask_dictionary(7, "Form");
         let mut cache = DefaultResourceCache::default();
         let mut cycle_tracker = ReadCycleTracker::default();
         let mut id_allocator = ContentStreamIdAllocator::new();
@@ -118,12 +136,12 @@ mod tests {
         .expect("soft mask should be present");
 
         assert_eq!(soft_mask.mask_type, MaskMode::Alpha);
-        assert!(matches!(soft_mask.shape, XObject::Form(_)));
+        assert_eq!(soft_mask.shape.content_stream.id, 0);
     }
 
     #[test]
     fn cycle_suppressed_shape_returns_none() {
-        let dictionary = soft_mask_dictionary(7);
+        let dictionary = soft_mask_dictionary(7, "Form");
         let mut cache = DefaultResourceCache::default();
         let mut cycle_tracker = ReadCycleTracker::default();
         let mut id_allocator = ContentStreamIdAllocator::new();
@@ -139,5 +157,29 @@ mod tests {
         .expect("cycle-suppressed soft mask should not fail");
 
         assert!(soft_mask.is_none());
+    }
+
+    #[test]
+    fn non_form_shape_is_rejected() {
+        let dictionary = soft_mask_dictionary(7, "Image");
+        let mut cache = DefaultResourceCache::default();
+        let mut cycle_tracker = ReadCycleTracker::default();
+        let mut id_allocator = ContentStreamIdAllocator::new();
+
+        let error = match SoftMask::from_dictionary(
+            &dictionary,
+            &PassthroughResolver,
+            &mut cache,
+            &mut cycle_tracker,
+            &mut id_allocator,
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("an image cannot be used as an ExtGState soft-mask group"),
+        };
+
+        assert!(matches!(
+            error,
+            PdfPagesError::InvalidExtGStateEntryValue { entry, .. } if entry == "SMask"
+        ));
     }
 }

--- a/crates/pdf-resources/src/xobject.rs
+++ b/crates/pdf-resources/src/xobject.rs
@@ -1,7 +1,5 @@
 use crate::{
-    error::PdfPagesError,
-    form::FormXObject,
-    object_reader::{ReadCycleTracker, ReadXObject},
+    error::PdfPagesError, form::FormXObject, object_reader::ReadCycleTracker, resource::Resource,
     resource_cache::ResourceCache,
 };
 use pdf_content_stream::ContentStreamIdAllocator;
@@ -10,64 +8,71 @@ use pdf_object::{
     dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
     object_variant::ObjectVariant, stream::StreamObject,
 };
+use std::rc::Rc;
 
-/// Represents a PDF External Object (XObject).
-///
-/// XObjects are reusable resources within a PDF file. They can be images,
-/// self-contained graphical forms, or other types of external content.
-#[allow(clippy::large_enum_variant)]
-pub enum XObject {
-    /// An image XObject, representing a raster image.
-    Image(ImageXObject),
-    /// An image XObject whose dimensions are malformed and cannot be rendered.
-    UnavailableImage,
-    /// A form XObject, which is a self-contained sequence of graphics objects
-    /// that can be painted as a single unit.
-    Form(Box<FormXObject>),
+/// Reads a stream-backed XObject with cycle protection.
+pub(crate) fn read_xobject(
+    content: &ObjectVariant,
+    dictionary: &Dictionary,
+    stream_data: &StreamObject,
+    objects: &dyn ObjectResolver,
+    cache: &mut dyn ResourceCache,
+    cycle_tracker: &mut ReadCycleTracker,
+    id_allocator: &mut ContentStreamIdAllocator,
+) -> Result<Option<Resource>, PdfPagesError> {
+    if !cycle_tracker.begin_read(stream_data.object_number) {
+        return Ok(None);
+    }
+
+    let result = read_xobject_inner(
+        content,
+        dictionary,
+        stream_data,
+        objects,
+        cache,
+        cycle_tracker,
+        id_allocator,
+    );
+    cycle_tracker.end_read(stream_data.object_number);
+    result.map(Some)
 }
 
-impl ReadXObject for XObject {
-    fn read_xobject_inner(
-        content: &ObjectVariant,
-        dictionary: &Dictionary,
-        stream_data: &StreamObject,
-        objects: &dyn ObjectResolver,
-        cache: &mut dyn ResourceCache,
-        cycle_tracker: &mut ReadCycleTracker,
-        id_allocator: &mut ContentStreamIdAllocator,
-    ) -> Result<Self, PdfPagesError> {
-        match dictionary.required_str("Subtype", objects)? {
-            "Image" => {
-                if !has_valid_image_dimensions(dictionary, objects) {
-                    return Ok(XObject::UnavailableImage);
-                }
+fn read_xobject_inner(
+    content: &ObjectVariant,
+    dictionary: &Dictionary,
+    stream_data: &StreamObject,
+    objects: &dyn ObjectResolver,
+    cache: &mut dyn ResourceCache,
+    cycle_tracker: &mut ReadCycleTracker,
+    id_allocator: &mut ContentStreamIdAllocator,
+) -> Result<Resource, PdfPagesError> {
+    match dictionary.required_str("Subtype", objects)? {
+        "Image" => {
+            if !has_valid_image_dimensions(dictionary, objects) {
+                return Ok(Resource::UnavailableImage);
+            }
 
-                let soft_mask = resolve_image_soft_mask(
-                    dictionary,
-                    objects,
-                    cache,
-                    cycle_tracker,
-                    id_allocator,
-                )?;
-                let image_xobject =
-                    ImageXObject::read_xobject(dictionary, stream_data, objects, soft_mask)?;
-                Ok(XObject::Image(image_xobject))
-            }
-            "Form" => {
-                let form_xobject = FormXObject::read_xobject(
-                    content,
-                    dictionary,
-                    objects,
-                    cache,
-                    cycle_tracker,
-                    id_allocator,
-                )?;
-                Ok(XObject::Form(Box::new(form_xobject)))
-            }
-            other => Err(PdfPagesError::UnsupportedXObjectSubtype {
-                subtype: other.to_string(),
-            }),
+            let soft_mask =
+                resolve_image_soft_mask(dictionary, objects, cache, cycle_tracker, id_allocator)?;
+            Ok(Resource::from(ImageXObject::read_xobject(
+                dictionary,
+                stream_data,
+                objects,
+                soft_mask,
+            )?))
         }
+        "Form" => FormXObject::read_xobject(
+            content,
+            dictionary,
+            objects,
+            cache,
+            cycle_tracker,
+            id_allocator,
+        )
+        .map(Resource::from),
+        other => Err(PdfPagesError::UnsupportedXObjectSubtype {
+            subtype: other.to_string(),
+        }),
     }
 }
 
@@ -89,7 +94,7 @@ fn has_valid_image_dimensions(dictionary: &Dictionary, objects: &dyn ObjectResol
 ///
 /// `pdf-image` only decodes already-resolved image data, so page parsing owns the
 /// PDF object lookup and XObject subtype validation. Routing mask streams through
-/// [`ReadXObject::read_xobject`] keeps soft-mask parsing on the same cycle-tracked
+/// [`read_xobject`] keeps soft-mask parsing on the same cycle-tracked
 /// path as ordinary XObjects; recursive masks are therefore treated as absent.
 fn resolve_image_soft_mask(
     dictionary: &Dictionary,
@@ -112,7 +117,7 @@ fn resolve_image_soft_mask(
 
     let stream = resolved.try_stream(objects)?;
 
-    match XObject::read_xobject(
+    match read_xobject(
         resolved,
         &stream.dictionary,
         stream,
@@ -121,8 +126,10 @@ fn resolve_image_soft_mask(
         cycle_tracker,
         id_allocator,
     ) {
-        Ok(Some(XObject::Image(image))) => Ok(Some(image)),
-        Ok(Some(XObject::UnavailableImage)) => Ok(None),
+        Ok(Some(Resource::Image(image))) => Rc::try_unwrap(image)
+            .map(Some)
+            .map_err(|_| PdfImageError::InvalidSoftMaskXObject),
+        Ok(Some(Resource::UnavailableImage)) => Ok(None),
         Ok(Some(_)) => Err(PdfImageError::InvalidSoftMaskXObject),
         Ok(None) => Ok(None),
         Err(PdfPagesError::Image(err)) => Err(err),
@@ -143,11 +150,10 @@ mod tests {
     use std::collections::BTreeMap;
 
     use crate::{
-        object_reader::{ReadCycleTracker, ReadXObject},
-        resource_cache::DefaultResourceCache,
+        object_reader::ReadCycleTracker, resource::Resource, resource_cache::DefaultResourceCache,
     };
 
-    use super::{XObject, has_valid_image_dimensions};
+    use super::{has_valid_image_dimensions, read_xobject};
 
     struct MapResolver {
         objects: BTreeMap<usize, ObjectVariant>,
@@ -195,7 +201,7 @@ mod tests {
         let mut cycle_tracker = ReadCycleTracker::default();
         let mut id_allocator = ContentStreamIdAllocator::new();
 
-        let xobject = XObject::read_xobject(
+        let xobject = read_xobject(
             &ObjectVariant::Stream(stream.clone()),
             &stream.dictionary,
             &stream,
@@ -207,8 +213,8 @@ mod tests {
         .expect("self-referential soft masks should not fail image parsing")
         .expect("top-level image should be present");
 
-        assert!(matches!(&xobject, XObject::Image(_)));
-        if let XObject::Image(image) = xobject {
+        assert!(matches!(&xobject, Resource::Image(_)));
+        if let Resource::Image(image) = xobject {
             assert_eq!(image.width, 1);
             assert_eq!(image.height, 1);
             assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::Gray8);
@@ -265,7 +271,7 @@ mod tests {
         let mut cycle_tracker = ReadCycleTracker::default();
         let mut id_allocator = ContentStreamIdAllocator::new();
 
-        let xobject = XObject::read_xobject(
+        let xobject = read_xobject(
             &ObjectVariant::Stream(image_stream.clone()),
             &image_stream.dictionary,
             &image_stream,
@@ -278,15 +284,15 @@ mod tests {
         .expect("top-level image should be present");
 
         match xobject {
-            XObject::Image(image) => {
+            Resource::Image(image) => {
                 assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
                 assert_eq!(
                     image.data.as_ref(),
                     &[0x20, 0x20, 0x20, 0x10, 0xC0, 0xC0, 0xC0, 0xE0]
                 );
             }
-            XObject::UnavailableImage => panic!("expected a decoded image xobject"),
-            XObject::Form(_) => panic!("expected an image xobject"),
+            Resource::UnavailableImage => panic!("expected a decoded image xobject"),
+            _ => panic!("expected an image xobject"),
         }
     }
 
@@ -316,7 +322,7 @@ mod tests {
         let mut cycle_tracker = ReadCycleTracker::default();
         let mut id_allocator = ContentStreamIdAllocator::new();
 
-        let xobject = XObject::read_xobject(
+        let xobject = read_xobject(
             &ObjectVariant::Stream(stream.clone()),
             &stream.dictionary,
             &stream,
@@ -328,7 +334,7 @@ mod tests {
         .expect("malformed image dimensions should be recoverable")
         .expect("the unavailable image resource should be preserved");
 
-        assert!(matches!(xobject, XObject::UnavailableImage));
+        assert!(matches!(xobject, Resource::UnavailableImage));
     }
 
     #[test]

--- a/crates/pdf-resources/tests/resources.rs
+++ b/crates/pdf-resources/tests/resources.rs
@@ -10,8 +10,8 @@ use pdf_object::{
 use pdf_object_collection::object_collection::ObjectCollection;
 
 use pdf_resources::{
-    object_reader::ReadCycleTracker, pattern::Pattern, resource_cache::DefaultResourceCache,
-    resources::Resources, xobject::XObject,
+    object_reader::ReadCycleTracker, pattern::Pattern, resource::Resource,
+    resource_cache::DefaultResourceCache, resources::Resources,
 };
 use pdf_shading::model::Shading;
 
@@ -184,10 +184,10 @@ fn self_referential_tiling_pattern(object_number: usize) -> ObjectVariant {
     ))
 }
 
-fn form_content_stream_id(xobject: &XObject) -> Option<usize> {
+fn form_content_stream_id(xobject: &Resource) -> Option<usize> {
     match xobject {
-        XObject::Form(form) => Some(form.content_stream.id),
-        XObject::Image(_) | XObject::UnavailableImage => None,
+        Resource::Form(form) => Some(form.content_stream.id),
+        _ => None,
     }
 }
 
@@ -325,10 +325,10 @@ fn dictionary_only_form_xobjects_are_loaded_as_empty_forms() {
 
     let xobject = resources.xobject("Meta6");
     assert!(
-        matches!(xobject, Some(XObject::Form(_))),
+        matches!(xobject, Some(Resource::Form(_))),
         "expected dictionary-only form xobject"
     );
-    let Some(XObject::Form(form)) = xobject else {
+    let Some(Resource::Form(form)) = xobject else {
         return;
     };
 
@@ -435,10 +435,10 @@ fn cyclic_form_resources_resolve_lazily_without_recursing_forever() {
 
     let form = resources.xobject("Self");
     assert!(
-        matches!(form, Some(XObject::Form(_))),
+        matches!(form, Some(Resource::Form(_))),
         "expected the self-referential form xobject to be parsed"
     );
-    let Some(XObject::Form(form)) = form else {
+    let Some(Resource::Form(form)) = form else {
         return;
     };
 
@@ -450,10 +450,10 @@ fn cyclic_form_resources_resolve_lazily_without_recursing_forever() {
         .xobject("Self")
         .expect("recursive lookup should resolve the same form");
     assert!(
-        matches!(nested_form, XObject::Form(_)),
+        matches!(nested_form, Resource::Form(_)),
         "expected the recursive lookup to resolve the cached form xobject"
     );
-    let XObject::Form(nested_form) = nested_form else {
+    let Resource::Form(nested_form) = nested_form else {
         return;
     };
 


### PR DESCRIPTION
Remove the XObject enum and store image and form variants directly in Resource. Hide Rc construction behind From implementations and return resolved resources from XObject lookups.

Require ExtGState soft-mask groups to be forms while preserving cycle handling and unavailable-image behavior.