### PR TITLE
pdf-image: centralize image dimensions

### DIFF
--- a/crates/pdf-annotation-form/src/interaction_annotation_target.rs
+++ b/crates/pdf-annotation-form/src/interaction_annotation_target.rs
@@ -22,7 +22,7 @@ impl AnnotationTarget {
             .is_draggable()
             .then(|| annotation.rect.map(|rect| rect.normalized()))
             .flatten()
-            .filter(Rect::is_valid);
+            .filter(|rect| rect.is_valid());
         Some(Self {
             free_text: matches!(annotation.kind, AnnotationKind::FreeText(_)),
             draggable_rect,

--- a/crates/pdf-graphics/src/rect.rs
+++ b/crates/pdf-graphics/src/rect.rs
@@ -1,18 +1,19 @@
 use crate::{point::Point, transform::Transform};
 
+/// An axis-aligned rectangle whose edge coordinate type defaults to `f32`.
 #[derive(Debug, Default, Clone, Copy, PartialEq)]
-pub struct Rect {
+pub struct Rect<T = f32> {
     /// The left edge of the rectangle.
-    pub left: f32,
+    pub left: T,
     /// The top edge of the rectangle.
-    pub top: f32,
+    pub top: T,
     /// The right edge of the rectangle.
-    pub right: f32,
+    pub right: T,
     /// The bottom edge of the rectangle.
-    pub bottom: f32,
+    pub bottom: T,
 }
 
-impl Rect {
+impl Rect<f32> {
     pub const UNIT_RECT: Rect = Rect {
         left: 0.0,
         top: 0.0,
@@ -70,6 +71,33 @@ impl Rect {
     /// Returns the scale transform produced by dividing this rectangle's size by another.
     pub fn scale(&self, other: &Self) -> Transform {
         Transform::from_scale(self.width() / other.width(), self.height() / other.height())
+    }
+}
+
+impl Rect<usize> {
+    /// Creates an integer rectangle with the given size and its top-left corner at the origin.
+    pub const fn from_size(width: usize, height: usize) -> Self {
+        Self {
+            left: 0,
+            top: 0,
+            right: width,
+            bottom: height,
+        }
+    }
+
+    /// Returns the rectangle width without underflowing for inverted edges.
+    pub const fn width(&self) -> usize {
+        self.right.saturating_sub(self.left)
+    }
+
+    /// Returns the rectangle height without underflowing for inverted edges.
+    pub const fn height(&self) -> usize {
+        self.bottom.saturating_sub(self.top)
+    }
+
+    /// Returns whether the rectangle has positive width and height.
+    pub const fn is_valid(&self) -> bool {
+        self.width() > 0 && self.height() > 0
     }
 }
 
@@ -148,5 +176,39 @@ mod tests {
         let other = Rect::new(10.0, 5.0);
 
         assert_eq!(rect.scale(&other), Transform::from_scale(4.0, 3.0));
+    }
+
+    #[test]
+    fn integer_rect_from_size_uses_origin_and_reports_dimensions() {
+        let rect = Rect::<usize>::from_size(40, 15);
+
+        assert_eq!(
+            rect,
+            Rect {
+                left: 0,
+                top: 0,
+                right: 40,
+                bottom: 15,
+            }
+        );
+        assert_eq!(rect.width(), 40);
+        assert_eq!(rect.height(), 15);
+        assert!(rect.is_valid());
+    }
+
+    #[test]
+    fn integer_rect_dimensions_saturate_for_inverted_edges() {
+        let rect = Rect {
+            left: 10_usize,
+            top: 20_usize,
+            right: 5_usize,
+            bottom: 15_usize,
+        };
+
+        assert_eq!(rect.width(), 0);
+        assert_eq!(rect.height(), 0);
+        assert!(!rect.is_valid());
+        assert!(!Rect::<usize>::from_size(0, 15).is_valid());
+        assert!(!Rect::<usize>::from_size(40, 0).is_valid());
     }
 }

--- a/crates/pdf-image/src/decoded_samples.rs
+++ b/crates/pdf-image/src/decoded_samples.rs
@@ -49,7 +49,7 @@ impl DecodedSamples {
             return Err(PdfImageError::InvalidColorComponentCount);
         }
 
-        let num_pixels = metadata.width.saturating_mul(metadata.height);
+        let num_pixels = metadata.size.width().saturating_mul(metadata.size.height());
         let expected_bytes = num_pixels.saturating_mul(self.num_color_components);
         if self.image_data.len() < expected_bytes {
             return Err(PdfImageError::TruncatedImageData {
@@ -71,7 +71,7 @@ impl DecodedSamples {
             return None;
         }
 
-        let num_pixels = metadata.width.saturating_mul(metadata.height);
+        let num_pixels = metadata.size.width().saturating_mul(metadata.size.height());
         let num_color_components = Self::decoded_dct_component_count(raw_data, num_pixels)
             .or_else(|| Self::decoded_single_pixel_component_count(raw_data))?;
 
@@ -104,7 +104,7 @@ impl DecodedSamples {
             return None;
         }
 
-        let num_pixels = metadata.width.saturating_mul(metadata.height);
+        let num_pixels = metadata.size.width().saturating_mul(metadata.size.height());
         let bytes_per_pixel = raw_data.len().checked_div(num_pixels)?;
         if bytes_per_pixel.saturating_mul(num_pixels) != raw_data.len() {
             return None;
@@ -203,8 +203,8 @@ impl DecodedSamples {
             raw_data,
             metadata.bits_per_component,
             SampleLayout::RowAligned {
-                width: metadata.width,
-                height: metadata.height,
+                width: metadata.size.width(),
+                height: metadata.size.height(),
                 samples_per_pixel,
             },
         )?)

--- a/crates/pdf-image/src/image_metadata.rs
+++ b/crates/pdf-image/src/image_metadata.rs
@@ -1,5 +1,6 @@
 use pdf_color_space::color_space::ColorSpace;
 use pdf_filter::filter::Filters;
+use pdf_graphics::rect::Rect;
 use pdf_object::{
     dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
 };
@@ -9,8 +10,7 @@ use crate::error::PdfImageError;
 /// Stores the normalized metadata needed to decode an image stream.
 #[derive(Debug, Clone)]
 pub(crate) struct ImageMetadata {
-    pub(crate) width: usize,
-    pub(crate) height: usize,
+    pub(crate) size: Rect<usize>,
     pub(crate) bits_per_component: usize,
     pub(crate) color_space: Option<ColorSpace>,
     pub(crate) image_mask: bool,
@@ -18,13 +18,20 @@ pub(crate) struct ImageMetadata {
 }
 
 impl ImageMetadata {
+    /// Default bit depth for an image mask when `/BitsPerComponent` is omitted.
+    const DEFAULT_IMAGE_MASK_BITS_PER_COMPONENT: usize = 1;
+
+    /// Default bit depth for a JPX image when `/BitsPerComponent` is omitted.
+    const DEFAULT_JPX_BITS_PER_COMPONENT: usize = 8;
+
     /// Reads and validates normalized image metadata from an image dictionary.
     pub(crate) fn from_dictionary(
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
     ) -> Result<Self, PdfImageError> {
-        let width = dictionary.required_number::<usize>("Width", objects)?;
-        let height = dictionary.required_number::<usize>("Height", objects)?;
+        let size = dictionary.required_size(objects)?;
+        let width = size.width();
+        let height = size.height();
 
         if width == 0 || height == 0 {
             return Err(PdfImageError::InvalidImageDimensions { width, height });
@@ -33,36 +40,52 @@ impl ImageMetadata {
         let image_mask = dictionary
             .optional_boolean("ImageMask", objects)?
             .unwrap_or(false);
-        let (bits_per_component, color_space, filters) = if image_mask {
-            let bits_per_component = dictionary
-                .optional_number::<usize>("BitsPerComponent", objects)?
-                .unwrap_or(1);
-            validate_bits_per_component(bits_per_component, image_mask, None)?;
-            let filters = Filters::from_dictionary(dictionary, objects)?;
-            (bits_per_component, None, filters)
+        let filters = Filters::from_dictionary(dictionary, objects)?;
+        let bits_per_component =
+            read_bits_per_component(dictionary, objects, image_mask, filters.as_ref())?;
+        let color_space = if image_mask {
+            None
         } else {
-            let filters = Filters::from_dictionary(dictionary, objects)?;
-            let has_jpx_filter = filters.as_ref().is_some_and(Filters::has_jpx_filter);
-            let bits_per_component = if has_jpx_filter {
-                dictionary
-                    .optional_number::<usize>("BitsPerComponent", objects)?
-                    .unwrap_or(8)
-            } else {
-                dictionary.required_number::<usize>("BitsPerComponent", objects)?
-            };
-            let color_space = ColorSpace::from_dictionary(dictionary, objects)?;
-            validate_bits_per_component(bits_per_component, image_mask, color_space.as_ref())?;
-            (bits_per_component, color_space, filters)
+            ColorSpace::from_dictionary(dictionary, objects)?
         };
+        validate_bits_per_component(bits_per_component, image_mask, color_space.as_ref())?;
 
         Ok(Self {
-            width,
-            height,
+            size,
             bits_per_component,
             color_space,
             image_mask,
             filters,
         })
+    }
+}
+
+/// Reads the image bit depth, applying the defaults allowed for masks and JPX images.
+fn read_bits_per_component(
+    dictionary: &Dictionary,
+    objects: &dyn ObjectResolver,
+    image_mask: bool,
+    filters: Option<&Filters>,
+) -> Result<usize, PdfImageError> {
+    const BITS_PER_COMPONENT_KEY: &str = "BitsPerComponent";
+
+    // Image masks and JPX images may omit BitsPerComponent, with different
+    // defaults. Every other image must provide the value explicitly.
+    let default = if image_mask {
+        Some(ImageMetadata::DEFAULT_IMAGE_MASK_BITS_PER_COMPONENT)
+    } else if filters.is_some_and(Filters::has_jpx_filter) {
+        Some(ImageMetadata::DEFAULT_JPX_BITS_PER_COMPONENT)
+    } else {
+        None
+    };
+
+    // Use the optional dictionary reader only when a default is available.
+    // The required reader preserves the missing-key error for all other images.
+    match default {
+        Some(default) => Ok(dictionary
+            .optional_number::<usize>(BITS_PER_COMPONENT_KEY, objects)?
+            .unwrap_or(default)),
+        None => Ok(dictionary.required_number::<usize>(BITS_PER_COMPONENT_KEY, objects)?),
     }
 }
 
@@ -157,6 +180,27 @@ mod tests {
                 bits_per_component: 8
             }
         ));
+    }
+
+    #[test]
+    fn image_mask_stores_filter_chain() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            (
+                "Filter".to_string(),
+                ObjectVariant::Name(b"ASCIIHexDecode".to_vec()),
+            ),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("ImageMask".to_string(), ObjectVariant::Boolean(true)),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
+        ]));
+
+        let metadata = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect("image mask filter should parse");
+
+        assert_eq!(
+            metadata.filters,
+            Some(Filters::from(vec![Filter::ASCIIHexDecode]))
+        );
     }
 
     #[test]

--- a/crates/pdf-image/src/image_xobject.rs
+++ b/crates/pdf-image/src/image_xobject.rs
@@ -98,8 +98,8 @@ impl ImageXObject {
         let (data, pixel_format) = Self::assemble_pixel_data(metadata, &decoded_samples, soft_mask);
 
         Ok(Self {
-            width: metadata.width,
-            height: metadata.height,
+            width: metadata.size.width(),
+            height: metadata.size.height(),
             bits_per_component: decoded_samples.bits_per_component,
             data: data.into(),
             pixel_format,
@@ -117,8 +117,8 @@ impl ImageXObject {
             return (
                 Self::to_rgba(
                     &decoded_samples.image_data,
-                    metadata.width,
-                    metadata.height,
+                    metadata.size.width(),
+                    metadata.size.height(),
                     decoded_samples.num_color_components,
                     smask.as_ref(),
                 ),

--- a/crates/pdf-object/src/dictionary.rs
+++ b/crates/pdf-object/src/dictionary.rs
@@ -14,6 +14,9 @@ pub struct Dictionary {
 }
 
 impl Dictionary {
+    const HEIGHT_KEY: &'static str = "Height";
+    const WIDTH_KEY: &'static str = "Width";
+
     pub fn new(dictionary: BTreeMap<String, ObjectVariant>) -> Self {
         Dictionary {
             dictionary,
@@ -101,6 +104,39 @@ impl Dictionary {
             .map(Rect::from)
     }
 
+    /// Reads optional `/Width` and `/Height` entries as an origin-based integer rectangle.
+    ///
+    /// Returns `None` when both entries are missing or `null`. If only one dimension is
+    /// available, the missing counterpart is reported as a required-key error.
+    pub fn optional_size(
+        &self,
+        objects: &dyn ObjectResolver,
+    ) -> Result<Option<Rect<usize>>, ObjectError> {
+        let width = self.optional_number::<usize>(Self::WIDTH_KEY, objects)?;
+        let height = self.optional_number::<usize>(Self::HEIGHT_KEY, objects)?;
+
+        if width.is_none() && height.is_none() {
+            return Ok(None);
+        }
+
+        let width = width.ok_or_else(|| ObjectError::MissingRequiredKey {
+            key: Self::WIDTH_KEY.to_owned(),
+        })?;
+        let height = height.ok_or_else(|| ObjectError::MissingRequiredKey {
+            key: Self::HEIGHT_KEY.to_owned(),
+        })?;
+
+        Ok(Some(Rect::<usize>::from_size(width, height)))
+    }
+
+    /// Reads required `/Width` and `/Height` entries as an origin-based integer rectangle.
+    pub fn required_size(&self, objects: &dyn ObjectResolver) -> Result<Rect<usize>, ObjectError> {
+        let width = self.required_number::<usize>(Self::WIDTH_KEY, objects)?;
+        let height = self.required_number::<usize>(Self::HEIGHT_KEY, objects)?;
+
+        Ok(Rect::<usize>::from_size(width, height))
+    }
+
     /// Reads the optional `/MediaBox` entry as a rectangle.
     ///
     /// Missing entries and explicit PDF `null` values are treated as absent.
@@ -160,6 +196,13 @@ mod tests {
         let mut values = BTreeMap::new();
         values.insert(key.to_owned(), value);
         Dictionary::new(values)
+    }
+
+    fn size_dictionary(width: ObjectVariant, height: ObjectVariant) -> Dictionary {
+        Dictionary::new(BTreeMap::from([
+            ("Height".to_owned(), height),
+            ("Width".to_owned(), width),
+        ]))
     }
 
     #[test]
@@ -288,6 +331,91 @@ mod tests {
                 expected: 4,
                 found: 3,
             }
+        );
+    }
+
+    #[test]
+    fn optional_size_parses_width_and_height() {
+        let dictionary = size_dictionary(ObjectVariant::Integer(40), ObjectVariant::Integer(15));
+
+        let size = dictionary
+            .optional_size(&PassthroughResolver)
+            .expect("size parses");
+
+        assert_eq!(size, Some(Rect::<usize>::from_size(40, 15)));
+    }
+
+    #[test]
+    fn optional_size_returns_none_when_both_dimensions_are_absent() {
+        let missing = Dictionary::new(BTreeMap::new());
+        let null = size_dictionary(ObjectVariant::Null, ObjectVariant::Null);
+
+        assert_eq!(
+            missing
+                .optional_size(&PassthroughResolver)
+                .expect("missing dimensions are optional"),
+            None
+        );
+        assert_eq!(
+            null.optional_size(&PassthroughResolver)
+                .expect("null dimensions are optional"),
+            None
+        );
+    }
+
+    #[test]
+    fn optional_size_rejects_partial_dimensions() {
+        let width_only = dictionary_with("Width", ObjectVariant::Integer(40));
+        let height_only = dictionary_with("Height", ObjectVariant::Integer(15));
+
+        assert_eq!(
+            width_only
+                .optional_size(&PassthroughResolver)
+                .expect_err("height is required when width is present"),
+            ObjectError::MissingRequiredKey {
+                key: "Height".to_owned(),
+            }
+        );
+        assert_eq!(
+            height_only
+                .optional_size(&PassthroughResolver)
+                .expect_err("width is required when height is present"),
+            ObjectError::MissingRequiredKey {
+                key: "Width".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn required_size_parses_width_and_height() {
+        let dictionary = size_dictionary(ObjectVariant::Integer(40), ObjectVariant::Integer(15));
+
+        let size = dictionary
+            .required_size(&PassthroughResolver)
+            .expect("required size parses");
+
+        assert_eq!(size, Rect::<usize>::from_size(40, 15));
+    }
+
+    #[test]
+    fn required_size_rejects_missing_or_invalid_dimensions() {
+        let missing_height = dictionary_with("Width", ObjectVariant::Integer(40));
+        let negative_width =
+            size_dictionary(ObjectVariant::Integer(-1), ObjectVariant::Integer(15));
+
+        assert_eq!(
+            missing_height
+                .required_size(&PassthroughResolver)
+                .expect_err("height is required"),
+            ObjectError::MissingRequiredKey {
+                key: "Height".to_owned(),
+            }
+        );
+        assert_eq!(
+            negative_width
+                .required_size(&PassthroughResolver)
+                .expect_err("negative width cannot convert to usize"),
+            ObjectError::NumberConversionError
         );
     }
 

--- a/crates/pdf-resources/src/xobject.rs
+++ b/crates/pdf-resources/src/xobject.rs
@@ -48,7 +48,12 @@ fn read_xobject_inner(
 ) -> Result<Resource, PdfPagesError> {
     match dictionary.required_str("Subtype", objects)? {
         "Image" => {
-            if !has_valid_image_dimensions(dictionary, objects) {
+            // Malformed dimensions make the image impossible to decode, but should not
+            // prevent otherwise valid page content from being loaded and rendered.
+            if !dictionary
+                .required_size(objects)
+                .is_ok_and(|size| size.is_valid())
+            {
                 return Ok(Resource::UnavailableImage);
             }
 
@@ -74,20 +79,6 @@ fn read_xobject_inner(
             subtype: other.to_string(),
         }),
     }
-}
-
-/// Returns whether an image dictionary contains usable dimensions.
-///
-/// Malformed dimensions make the image impossible to decode, but should not
-/// prevent otherwise valid page content from being loaded and rendered.
-fn has_valid_image_dimensions(dictionary: &Dictionary, objects: &dyn ObjectResolver) -> bool {
-    matches!(
-        (
-            dictionary.required_number::<usize>("Width", objects),
-            dictionary.required_number::<usize>("Height", objects),
-        ),
-        (Ok(width), Ok(height)) if width > 0 && height > 0
-    )
 }
 
 /// Resolves an image XObject `/SMask` entry through the page-level XObject reader.
@@ -153,7 +144,7 @@ mod tests {
         object_reader::ReadCycleTracker, resource::Resource, resource_cache::DefaultResourceCache,
     };
 
-    use super::{has_valid_image_dimensions, read_xobject};
+    use super::read_xobject;
 
     struct MapResolver {
         objects: BTreeMap<usize, ObjectVariant>,
@@ -335,36 +326,5 @@ mod tests {
         .expect("the unavailable image resource should be preserved");
 
         assert!(matches!(xobject, Resource::UnavailableImage));
-    }
-
-    #[test]
-    fn image_dimensions_must_be_positive_numbers() {
-        let valid = Dictionary::new(BTreeMap::from([
-            ("Width".to_string(), ObjectVariant::Integer(2)),
-            ("Height".to_string(), ObjectVariant::Integer(3)),
-        ]));
-        let named_width = Dictionary::new(BTreeMap::from([
-            ("Width".to_string(), ObjectVariant::Name(b"Height".to_vec())),
-            ("Height".to_string(), ObjectVariant::Integer(3)),
-        ]));
-        let missing_height = Dictionary::new(BTreeMap::from([(
-            "Width".to_string(),
-            ObjectVariant::Integer(2),
-        )]));
-        let zero_width = Dictionary::new(BTreeMap::from([
-            ("Width".to_string(), ObjectVariant::Integer(0)),
-            ("Height".to_string(), ObjectVariant::Integer(3)),
-        ]));
-        let negative_height = Dictionary::new(BTreeMap::from([
-            ("Width".to_string(), ObjectVariant::Integer(2)),
-            ("Height".to_string(), ObjectVariant::Integer(-1)),
-        ]));
-
-        let resolver = pdf_object::object_resolver::PassthroughResolver;
-        assert!(has_valid_image_dimensions(&valid, &resolver));
-        assert!(!has_valid_image_dimensions(&named_width, &resolver));
-        assert!(!has_valid_image_dimensions(&missing_height, &resolver));
-        assert!(!has_valid_image_dimensions(&zero_width, &resolver));
-        assert!(!has_valid_image_dimensions(&negative_height, &resolver));
     }
 }


### PR DESCRIPTION
Generalize Rect over its coordinate type and add usize helpers for origin-based image sizes. Teach Dictionary to read optional and required Width and Height pairs.

Store normalized dimensions in ImageMetadata as Rect<usize>, reuse its validity check during XObject loading, and keep existing image decoding behavior unchanged.