### PR TITLE
pdf-image: avoid implicit decode allocations

### DIFF
--- a/crates/pdf-decode/src/map.rs
+++ b/crates/pdf-decode/src/map.rs
@@ -14,24 +14,19 @@ pub struct DecodeMap {
 
 impl DecodeMap {
     /// Builds a decode map from a PDF dictionary and object resolver.
+    ///
+    /// Returns `None` when the dictionary does not contain a `/Decode` entry.
     pub fn from_dictionary(
         dictionary: &Dictionary,
         objects: &dyn ObjectResolver,
         component_count: usize,
-        default_inverted: bool,
-    ) -> Result<Self, DecodeError> {
-        let default_range = if default_inverted {
-            DecodeRange::inverted_identity()
-        } else {
-            DecodeRange::identity()
+    ) -> Result<Option<Self>, DecodeError> {
+        let Some(value) = dictionary.get("Decode") else {
+            return Ok(None);
         };
+        let ranges = Self::parse_object(value, objects, component_count)?;
 
-        let ranges = match dictionary.get("Decode") {
-            Some(value) => Self::parse_object(value, objects, component_count)?,
-            None => vec![default_range; component_count],
-        };
-
-        Ok(Self { ranges })
+        Ok(Some(Self { ranges }))
     }
 
     /// Parses a `/Decode` array into per-component ranges.
@@ -92,21 +87,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn decode_map_defaults_to_identity() {
+    fn decode_map_is_absent_without_decode_entry() {
         let dictionary = Dictionary::new(BTreeMap::new());
-        let map = DecodeMap::from_dictionary(&dictionary, &PassthroughResolver, 2, false).unwrap();
-        let out = map.apply_to_bytes(&[0, 255, 128, 64], 255, 255);
+        let map = DecodeMap::from_dictionary(&dictionary, &PassthroughResolver, 2).unwrap();
 
-        assert_eq!(out, vec![0, 255, 128, 64]);
-    }
-
-    #[test]
-    fn decode_map_supports_inverted_default() {
-        let dictionary = Dictionary::new(BTreeMap::new());
-        let map = DecodeMap::from_dictionary(&dictionary, &PassthroughResolver, 1, true).unwrap();
-        let out = map.apply_to_bytes(&[0, 1], 1, 255);
-
-        assert_eq!(out, vec![255, 0]);
+        assert!(map.is_none());
     }
 
     #[test]
@@ -118,7 +103,6 @@ mod tests {
             )])),
             &PassthroughResolver,
             1,
-            false,
         )
         .expect_err("invalid decode length should fail");
 
@@ -143,7 +127,6 @@ mod tests {
             )])),
             &PassthroughResolver,
             1,
-            false,
         )
         .expect_err("nan decode values should fail");
 
@@ -161,7 +144,9 @@ mod tests {
                 ObjectVariant::Integer(0),
             ]),
         )]));
-        let map = DecodeMap::from_dictionary(&dictionary, &PassthroughResolver, 2, false).unwrap();
+        let map = DecodeMap::from_dictionary(&dictionary, &PassthroughResolver, 2)
+            .unwrap()
+            .expect("explicit /Decode should create a map");
         let out = map.apply_to_bytes(&[255, 0, 0, 255], 255, 255);
 
         assert_eq!(out, vec![128, 255, 0, 0]);

--- a/crates/pdf-image/src/decoded_samples.rs
+++ b/crates/pdf-image/src/decoded_samples.rs
@@ -1,7 +1,9 @@
 use std::borrow::Cow;
 
 use pdf_color_space::{color_space::ColorSpace, indexed_color_space::IndexedColorSpace};
-use pdf_decode::{DecodeMap, SampleLayout, decode_sample_bytes, expand_indexed_values};
+use pdf_decode::{
+    DecodeMap, DecodeRange, SampleLayout, decode_sample_bytes, expand_indexed_values,
+};
 use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 
 use crate::error::PdfImageError;
@@ -148,12 +150,18 @@ impl DecodedSamples {
     ) -> Result<Self, PdfImageError> {
         let sample_codes = Self::decode_image_sample_codes(raw_data, 1, metadata)?;
         let sample_max = Self::sample_max(metadata.bits_per_component)?;
-        let decode = DecodeMap::from_dictionary(dictionary, objects, 1, metadata.image_mask)?;
-        let decoded_indices = decode.apply_to_bytes(sample_codes.as_ref(), sample_max, sample_max);
+        let decode = DecodeMap::from_dictionary(dictionary, objects, 1)?;
+        let decoded_indices = Self::apply_decode(
+            sample_codes,
+            decode.as_ref(),
+            sample_max,
+            sample_max,
+            metadata.image_mask,
+        );
         let base_components = indexed.base.num_color_components();
 
         let image_data = expand_indexed_values(
-            &decoded_indices,
+            decoded_indices.as_ref(),
             &indexed.lookup,
             indexed.hival,
             base_components,
@@ -179,19 +187,54 @@ impl DecodedSamples {
             .as_ref()
             .map_or(1, ColorSpace::num_color_components);
         let sample_codes = Self::decode_image_sample_codes(raw_data, num_components, metadata)?;
-        let decode =
-            DecodeMap::from_dictionary(dictionary, objects, num_components, metadata.image_mask)?;
+        let decode = DecodeMap::from_dictionary(dictionary, objects, num_components)?;
+        let sample_max = Self::sample_max(metadata.bits_per_component)?;
 
         Ok(Self {
             bits_per_component: metadata.bits_per_component,
             stored_color_space: metadata.color_space.clone(),
             num_color_components: num_components,
-            image_data: decode.apply_to_bytes(
-                sample_codes.as_ref(),
-                Self::sample_max(metadata.bits_per_component)?,
+            image_data: Self::apply_decode(
+                sample_codes,
+                decode.as_ref(),
+                sample_max,
                 255,
-            ),
+                metadata.image_mask,
+            )
+            .into_owned(),
         })
+    }
+
+    /// Applies an explicit decode map or the implicit PDF identity/inverted default.
+    fn apply_decode<'a>(
+        sample_codes: Cow<'a, [u8]>,
+        decode: Option<&DecodeMap>,
+        sample_max: u8,
+        output_max: u8,
+        default_inverted: bool,
+    ) -> Cow<'a, [u8]> {
+        if let Some(decode) = decode {
+            return Cow::Owned(decode.apply_to_bytes(
+                sample_codes.as_ref(),
+                sample_max,
+                output_max,
+            ));
+        }
+
+        if sample_max == output_max && !default_inverted {
+            return sample_codes;
+        }
+
+        let mut decoded = sample_codes.into_owned();
+        let default_range = if default_inverted {
+            DecodeRange::inverted_identity()
+        } else {
+            DecodeRange::identity()
+        };
+        for sample in &mut decoded {
+            *sample = default_range.map_byte(*sample, sample_max, output_max);
+        }
+        Cow::Owned(decoded)
     }
 
     fn decode_image_sample_codes<'a>(
@@ -219,5 +262,21 @@ impl DecodedSamples {
             8 => Ok(255),
             _ => Err(PdfImageError::UnsupportedImageBitsPerComponent { bits_per_component }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_decode_preserves_borrowed_identity_samples() {
+        let samples = [12, 34];
+        let decoded = DecodedSamples::apply_decode(Cow::Borrowed(&samples), None, 255, 255, false);
+
+        assert!(matches!(
+            decoded,
+            Cow::Borrowed(values) if std::ptr::eq(values, samples.as_slice())
+        ));
     }
 }

--- a/crates/pdf-image/src/image_xobject.rs
+++ b/crates/pdf-image/src/image_xobject.rs
@@ -95,38 +95,46 @@ impl ImageXObject {
         metadata: &ImageMetadata,
     ) -> Result<Self, PdfImageError> {
         let decoded_samples = DecodedSamples::decode(dictionary, raw_data, objects, metadata)?;
-        let (data, pixel_format) = Self::assemble_pixel_data(metadata, &decoded_samples, soft_mask);
+        let DecodedSamples {
+            bits_per_component,
+            stored_color_space,
+            num_color_components,
+            image_data,
+        } = decoded_samples;
+        let (data, pixel_format) =
+            Self::assemble_pixel_data(metadata, image_data, num_color_components, soft_mask);
 
         Ok(Self {
             width: metadata.size.width(),
             height: metadata.size.height(),
-            bits_per_component: decoded_samples.bits_per_component,
+            bits_per_component,
             data: data.into(),
             pixel_format,
-            color_space: decoded_samples.stored_color_space,
+            color_space: stored_color_space,
         })
     }
 
     /// Builds the final pixel buffer and pixel format after optional soft-mask application.
     fn assemble_pixel_data(
         metadata: &ImageMetadata,
-        decoded_samples: &DecodedSamples,
+        image_data: Vec<u8>,
+        num_color_components: usize,
         smask: Option<ImageXObject>,
     ) -> (Vec<u8>, PixelFormat) {
-        if smask.is_some() || decoded_samples.num_color_components != 1 {
+        if smask.is_some() || num_color_components != 1 {
             return (
                 Self::to_rgba(
-                    &decoded_samples.image_data,
+                    &image_data,
                     metadata.size.width(),
                     metadata.size.height(),
-                    decoded_samples.num_color_components,
+                    num_color_components,
                     smask.as_ref(),
                 ),
                 PixelFormat::RGBA8888,
             );
         }
 
-        (decoded_samples.image_data.clone(), PixelFormat::Gray8)
+        (image_data, PixelFormat::Gray8)
     }
 
     /// Converts decoded image samples into RGBA pixels with an optional soft-mask alpha channel.


### PR DESCRIPTION
Return no DecodeMap when /Decode is absent and handle implicit identity or inverted ranges while decoding image samples. Preserve borrowed identity samples and reuse owned unpacked buffers for default mapping.

Move grayscale sample buffers into final image assembly instead of cloning them. Keep explicit decode validation and image-mask behavior unchanged.