### PR TITLE
pdf-image: preserve borrowed decoded samples

### DIFF
--- a/crates/pdf-canvas/tests/pdf_canvas.rs
+++ b/crates/pdf-canvas/tests/pdf_canvas.rs
@@ -162,7 +162,7 @@ fn inline_image_render_path_matches_image_xobject_path() {
         &image_dictionary(),
         &[0b1010_0000],
         &pdf_object::object_resolver::PassthroughResolver,
-        None,
+        &None,
     )
     .expect("image XObject should decode");
     let graphics_state = Resource::ExternalGraphicsState(Rc::new(ExternalGraphicsState {

--- a/crates/pdf-image/src/decoded_samples.rs
+++ b/crates/pdf-image/src/decoded_samples.rs
@@ -11,18 +11,18 @@ use crate::image_metadata::ImageMetadata;
 
 /// Stores decoded sample bytes before the final pixel format conversion.
 #[derive(Debug, Clone)]
-pub(crate) struct DecodedSamples {
+pub(crate) struct DecodedSamples<'data> {
     pub(crate) bits_per_component: usize,
     pub(crate) stored_color_space: Option<ColorSpace>,
     pub(crate) num_color_components: usize,
-    pub(crate) image_data: Vec<u8>,
+    pub(crate) image_data: Cow<'data, [u8]>,
 }
 
-impl DecodedSamples {
+impl<'data> DecodedSamples<'data> {
     /// Decodes raw image bytes into component samples based on the configured color space.
     pub(crate) fn decode(
         dictionary: &Dictionary,
-        raw_data: &[u8],
+        raw_data: &'data [u8],
         objects: &dyn ObjectResolver,
         metadata: &ImageMetadata,
     ) -> Result<Self, PdfImageError> {
@@ -64,7 +64,7 @@ impl DecodedSamples {
     }
 
     /// Uses DCT decoder output as display samples when the JPEG decoder already converted color.
-    fn decode_preconverted_dct(raw_data: &[u8], metadata: &ImageMetadata) -> Option<Self> {
+    fn decode_preconverted_dct(raw_data: &'data [u8], metadata: &ImageMetadata) -> Option<Self> {
         let has_dct_filter = metadata
             .filters
             .as_ref()
@@ -83,9 +83,9 @@ impl DecodedSamples {
             _ => metadata.color_space.clone(),
         };
         let image_data = if raw_data.len() == num_color_components && num_pixels > 1 {
-            raw_data.repeat(num_pixels)
+            Cow::Owned(raw_data.repeat(num_pixels))
         } else {
-            raw_data.to_vec()
+            Cow::Borrowed(raw_data)
         };
 
         Some(Self {
@@ -97,7 +97,7 @@ impl DecodedSamples {
     }
 
     /// Uses JPX decoder output as display samples when the decoder already expanded pixels.
-    fn decode_preconverted_jpx(raw_data: &[u8], metadata: &ImageMetadata) -> Option<Self> {
+    fn decode_preconverted_jpx(raw_data: &'data [u8], metadata: &ImageMetadata) -> Option<Self> {
         let has_jpx_filter = metadata
             .filters
             .as_ref()
@@ -124,7 +124,7 @@ impl DecodedSamples {
             bits_per_component,
             stored_color_space,
             num_color_components,
-            image_data: raw_data.to_vec(),
+            image_data: Cow::Borrowed(raw_data),
         })
     }
 
@@ -143,7 +143,7 @@ impl DecodedSamples {
     /// Decodes indexed image samples, applies `/Decode`, and expands palette entries.
     fn decode_indexed(
         dictionary: &Dictionary,
-        raw_data: &[u8],
+        raw_data: &'data [u8],
         objects: &dyn ObjectResolver,
         metadata: &ImageMetadata,
         indexed: &IndexedColorSpace,
@@ -171,14 +171,14 @@ impl DecodedSamples {
             bits_per_component: metadata.bits_per_component,
             stored_color_space: Some(*indexed.base.clone()),
             num_color_components: base_components,
-            image_data,
+            image_data: Cow::Owned(image_data),
         })
     }
 
     /// Decodes non-indexed image samples and applies the `/Decode` transform.
     fn decode_direct(
         dictionary: &Dictionary,
-        raw_data: &[u8],
+        raw_data: &'data [u8],
         objects: &dyn ObjectResolver,
         metadata: &ImageMetadata,
     ) -> Result<Self, PdfImageError> {
@@ -200,8 +200,7 @@ impl DecodedSamples {
                 sample_max,
                 255,
                 metadata.image_mask,
-            )
-            .into_owned(),
+            ),
         })
     }
 
@@ -267,6 +266,10 @@ impl DecodedSamples {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use pdf_object::{object_resolver::PassthroughResolver, object_variant::ObjectVariant};
+
     use super::*;
 
     #[test]
@@ -276,6 +279,31 @@ mod tests {
 
         assert!(matches!(
             decoded,
+            Cow::Borrowed(values) if std::ptr::eq(values, samples.as_slice())
+        ));
+    }
+
+    #[test]
+    fn decode_direct_preserves_borrowed_identity_samples() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            ("BitsPerComponent".to_string(), ObjectVariant::Integer(8)),
+            (
+                "ColorSpace".to_string(),
+                ObjectVariant::Name(b"DeviceGray".to_vec()),
+            ),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("Width".to_string(), ObjectVariant::Integer(2)),
+        ]));
+        let metadata = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
+            .expect("direct image metadata should be valid");
+        let samples = [12, 34];
+
+        let decoded =
+            DecodedSamples::decode_direct(&dictionary, &samples, &PassthroughResolver, &metadata)
+                .expect("identity samples should decode");
+
+        assert!(matches!(
+            decoded.image_data,
             Cow::Borrowed(values) if std::ptr::eq(values, samples.as_slice())
         ));
     }

--- a/crates/pdf-image/src/image_xobject.rs
+++ b/crates/pdf-image/src/image_xobject.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use pdf_color_space::color_space::ColorSpace;
 use pdf_filter::filter::{decode_data_with_resolver, decode_with_resolver};
@@ -40,7 +40,7 @@ impl ImageXObject {
             dictionary,
             stream_data.raw_data(),
             objects,
-            soft_mask.clone(),
+            &soft_mask,
             &metadata,
         ) {
             Ok(image) => Ok(image),
@@ -50,7 +50,7 @@ impl ImageXObject {
                     dictionary,
                     decoded.as_ref(),
                     objects,
-                    soft_mask,
+                    &soft_mask,
                     &metadata,
                 )
                 .map_err(|_| original_error)
@@ -68,7 +68,7 @@ impl ImageXObject {
         let dictionary = image.normalized_dictionary();
         let decoded = decode_data_with_resolver(&dictionary, image.shared_data(), objects)?;
 
-        Self::decode_normalized_image(&dictionary, decoded.as_ref(), objects, soft_mask)
+        Self::decode_normalized_image(&dictionary, decoded.as_ref(), objects, &soft_mask)
     }
 
     /// Decodes a normalized image dictionary and raw bytes into a raster image.
@@ -79,7 +79,7 @@ impl ImageXObject {
         dictionary: &Dictionary,
         raw_data: &[u8],
         objects: &dyn ObjectResolver,
-        soft_mask: Option<ImageXObject>,
+        soft_mask: &Option<ImageXObject>,
     ) -> Result<Self, PdfImageError> {
         let metadata = ImageMetadata::from_dictionary(dictionary, objects)?;
         Self::decode_normalized_image_with_metadata(
@@ -91,7 +91,7 @@ impl ImageXObject {
         dictionary: &Dictionary,
         raw_data: &[u8],
         objects: &dyn ObjectResolver,
-        soft_mask: Option<ImageXObject>,
+        soft_mask: &Option<ImageXObject>,
         metadata: &ImageMetadata,
     ) -> Result<Self, PdfImageError> {
         let decoded_samples = DecodedSamples::decode(dictionary, raw_data, objects, metadata)?;
@@ -117,14 +117,14 @@ impl ImageXObject {
     /// Builds the final pixel buffer and pixel format after optional soft-mask application.
     fn assemble_pixel_data(
         metadata: &ImageMetadata,
-        image_data: Vec<u8>,
+        image_data: Cow<'_, [u8]>,
         num_color_components: usize,
-        smask: Option<ImageXObject>,
+        smask: &Option<ImageXObject>,
     ) -> (Vec<u8>, PixelFormat) {
         if smask.is_some() || num_color_components != 1 {
             return (
                 Self::to_rgba(
-                    &image_data,
+                    image_data.as_ref(),
                     metadata.size.width(),
                     metadata.size.height(),
                     num_color_components,
@@ -134,7 +134,7 @@ impl ImageXObject {
             );
         }
 
-        (image_data, PixelFormat::Gray8)
+        (image_data.into_owned(), PixelFormat::Gray8)
     }
 
     /// Converts decoded image samples into RGBA pixels with an optional soft-mask alpha channel.
@@ -262,7 +262,7 @@ mod tests {
             &dictionary,
             &[0b1010_0000],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("1-bpc decoded grayscale image should decode");
 
@@ -290,7 +290,7 @@ mod tests {
             &dictionary,
             &[0, 255],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("8-bpc decoded grayscale image should decode");
 
@@ -323,7 +323,7 @@ mod tests {
             &dictionary,
             &[0b1000_0000],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("decoded indexed image should decode");
 
@@ -348,7 +348,7 @@ mod tests {
         ]));
 
         let err =
-            ImageXObject::decode_normalized_image(&dictionary, &[0], &PassthroughResolver, None)
+            ImageXObject::decode_normalized_image(&dictionary, &[0], &PassthroughResolver, &None)
                 .expect_err("invalid /Decode length should fail");
 
         assert!(matches!(
@@ -376,7 +376,7 @@ mod tests {
             &dictionary,
             &[12, 34],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("grayscale image without /Decode should decode");
 
@@ -396,7 +396,7 @@ mod tests {
             &dictionary,
             &[0b1010_0000],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("image masks should default missing BitsPerComponent to 1");
 
@@ -421,7 +421,7 @@ mod tests {
             &dictionary,
             &[1, 2, 3, 4, 5, 6],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("JPX images should decode without BitsPerComponent when already expanded");
 
@@ -446,7 +446,7 @@ mod tests {
         ]));
 
         let err =
-            ImageXObject::decode_normalized_image(&dictionary, &[0], &PassthroughResolver, None)
+            ImageXObject::decode_normalized_image(&dictionary, &[0], &PassthroughResolver, &None)
                 .expect_err("non-mask images should still require BitsPerComponent");
 
         assert!(matches!(
@@ -475,7 +475,7 @@ mod tests {
             &dictionary,
             &[10, 20, 30, 40, 50, 60],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("DCT-decoded RGB bytes should not be validated as CMYK samples");
 
@@ -503,7 +503,7 @@ mod tests {
             &dictionary,
             &[10, 20, 30, 40, 50, 60],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect_err("non-DCT CMYK image data should still require four components");
 
@@ -536,7 +536,7 @@ mod tests {
             &dictionary,
             &[0xAA, 0x10, 0x20],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("single decoded DCT pixel should expand to the declared image size");
 
@@ -575,7 +575,7 @@ mod tests {
             &dictionary,
             &[0x20, 0xC0],
             &PassthroughResolver,
-            Some(soft_mask),
+            &Some(soft_mask),
         )
         .expect("resolved soft mask should be applied");
 
@@ -679,7 +679,7 @@ mod tests {
             &dictionary,
             &[0b1011_0010],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("1-bpc image should decode");
 
@@ -697,7 +697,7 @@ mod tests {
             &dictionary,
             &[0b1010_0000],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("1-bpc indexed image should decode");
 
@@ -713,9 +713,13 @@ mod tests {
     #[test]
     fn decode_normalized_indexed_image_2bpc_expands_samples() {
         let dictionary = indexed_dictionary(2);
-        let image =
-            ImageXObject::decode_normalized_image(&dictionary, &[0x1B], &PassthroughResolver, None)
-                .expect("2-bpc indexed image should decode");
+        let image = ImageXObject::decode_normalized_image(
+            &dictionary,
+            &[0x1B],
+            &PassthroughResolver,
+            &None,
+        )
+        .expect("2-bpc indexed image should decode");
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
         assert_eq!(
@@ -733,7 +737,7 @@ mod tests {
             &dictionary,
             &[0x01, 0x23],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("4-bpc indexed image should decode");
 
@@ -753,7 +757,7 @@ mod tests {
             &dictionary,
             &[0, 1, 2, 3],
             &PassthroughResolver,
-            None,
+            &None,
         )
         .expect("8-bpc indexed image should decode");
 

--- a/crates/pdf-resources/src/xobject.rs
+++ b/crates/pdf-resources/src/xobject.rs
@@ -93,7 +93,7 @@ fn resolve_image_soft_mask(
     cache: &mut dyn ResourceCache,
     cycle_tracker: &mut ReadCycleTracker,
     id_allocator: &mut ContentStreamIdAllocator,
-) -> Result<Option<ImageXObject>, PdfImageError> {
+) -> Result<Option<ImageXObject>, PdfPagesError> {
     let Some(smask_obj) = dictionary.get("SMask") else {
         return Ok(None);
     };
@@ -116,17 +116,12 @@ fn resolve_image_soft_mask(
         cache,
         cycle_tracker,
         id_allocator,
-    ) {
-        Ok(Some(Resource::Image(image))) => Rc::try_unwrap(image)
+    )? {
+        Some(Resource::Image(image)) => Rc::try_unwrap(image)
             .map(Some)
-            .map_err(|_| PdfImageError::InvalidSoftMaskXObject),
-        Ok(Some(Resource::UnavailableImage)) => Ok(None),
-        Ok(Some(_)) => Err(PdfImageError::InvalidSoftMaskXObject),
-        Ok(None) => Ok(None),
-        Err(PdfPagesError::Image(err)) => Err(err),
-        Err(PdfPagesError::Object(err)) => Err(err.into()),
-        Err(PdfPagesError::ColorSpace(err)) => Err(err.into()),
-        Err(_) => Err(PdfImageError::InvalidSoftMaskXObject),
+            .map_err(|_| PdfImageError::InvalidSoftMaskXObject.into()),
+        Some(Resource::UnavailableImage) | None => Ok(None),
+        Some(_) => Err(PdfImageError::InvalidSoftMaskXObject.into()),
     }
 }
 
@@ -141,7 +136,8 @@ mod tests {
     use std::collections::BTreeMap;
 
     use crate::{
-        object_reader::ReadCycleTracker, resource::Resource, resource_cache::DefaultResourceCache,
+        error::PdfPagesError, object_reader::ReadCycleTracker, resource::Resource,
+        resource_cache::DefaultResourceCache,
     };
 
     use super::read_xobject;
@@ -285,6 +281,42 @@ mod tests {
             Resource::UnavailableImage => panic!("expected a decoded image xobject"),
             _ => panic!("expected an image xobject"),
         }
+    }
+
+    #[test]
+    fn soft_mask_xobject_error_is_propagated() {
+        let image_stream = StreamObject::new(1, 0, Box::new(image_dictionary(2)), vec![0xAA]);
+        let mask_stream = StreamObject::new(
+            2,
+            0,
+            Box::new(Dictionary::new(BTreeMap::from([(
+                "Subtype".to_string(),
+                ObjectVariant::Name(b"Unsupported".to_vec()),
+            )]))),
+            vec![],
+        );
+        let resolver = MapResolver {
+            objects: BTreeMap::from([(2, ObjectVariant::Stream(mask_stream))]),
+        };
+        let mut cache = DefaultResourceCache::default();
+        let mut cycle_tracker = ReadCycleTracker::default();
+        let mut id_allocator = ContentStreamIdAllocator::new();
+
+        let result = read_xobject(
+            &ObjectVariant::Stream(image_stream.clone()),
+            &image_stream.dictionary,
+            &image_stream,
+            &resolver,
+            &mut cache,
+            &mut cycle_tracker,
+            &mut id_allocator,
+        );
+
+        assert!(matches!(
+            result,
+            Err(PdfPagesError::UnsupportedXObjectSubtype { subtype })
+                if subtype == "Unsupported"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Store decoded sample data as Cow so unchanged direct, DCT, and JPX buffers remain borrowed until final image assembly. Borrow resolved soft masks across retry paths instead of cloning them.

Propagate nested XObject errors while resolving image soft masks. Cover borrowed identity samples and unsupported soft-mask subtypes with tests.