### PR TITLE
pdf-image: avoid repeated XObject sample decoding

### DIFF
--- a/crates/pdf-document/src/decryption.rs
+++ b/crates/pdf-document/src/decryption.rs
@@ -299,7 +299,7 @@ impl DocumentDecryptor {
             stream.raw_data(),
         )?;
 
-        Ok(StreamObject::new(
+        Ok(StreamObject::new_encoded(
             stream.object_number,
             stream.generation_number,
             stream.dictionary,
@@ -455,7 +455,7 @@ impl DocumentDecryptor {
         let stream = self.decrypt_stream_object(stream)?;
         let dictionary =
             self.decrypt_dictionary(*stream.dictionary, object_number, generation_number)?;
-        Ok(ObjectVariant::Stream(StreamObject::new(
+        Ok(ObjectVariant::Stream(StreamObject::new_encoded(
             object_number,
             generation_number,
             Box::new(dictionary),

--- a/crates/pdf-image/src/image_xobject.rs
+++ b/crates/pdf-image/src/image_xobject.rs
@@ -36,27 +36,19 @@ impl ImageXObject {
         soft_mask: Option<ImageXObject>,
     ) -> Result<Self, PdfImageError> {
         let metadata = ImageMetadata::from_dictionary(dictionary, objects)?;
-        match Self::decode_normalized_image_with_metadata(
+        let decoded = if stream_data.filters_applied() {
+            stream_data.shared_data()
+        } else {
+            decode_with_resolver(stream_data, objects)?
+        };
+
+        Self::decode_normalized_image_with_metadata(
             dictionary,
-            stream_data.raw_data(),
+            decoded.as_ref(),
             objects,
             &soft_mask,
             &metadata,
-        ) {
-            Ok(image) => Ok(image),
-            Err(original_error) if metadata.filters.is_some() => {
-                let decoded = decode_with_resolver(stream_data, objects)?;
-                Self::decode_normalized_image_with_metadata(
-                    dictionary,
-                    decoded.as_ref(),
-                    objects,
-                    &soft_mask,
-                    &metadata,
-                )
-                .map_err(|_| original_error)
-            }
-            Err(error) => Err(error),
-        }
+        )
     }
 
     /// Decodes an inline image, including its filter chain and normalized sample data.
@@ -219,7 +211,7 @@ mod tests {
 
     use pdf_object::{
         dictionary::Dictionary, error::ObjectError, object_resolver::PassthroughResolver,
-        object_variant::ObjectVariant,
+        object_variant::ObjectVariant, stream::StreamObject,
     };
 
     use super::{ImageXObject, InlineImage};
@@ -240,6 +232,28 @@ mod tests {
         let cloned = image.clone();
 
         assert!(Arc::ptr_eq(&cloned.data, &data));
+    }
+
+    #[test]
+    fn read_xobject_uses_predecoded_filtered_stream_data() {
+        let dictionary = filtered_gray_dictionary();
+        let stream = StreamObject::new(1, 0, Box::new(dictionary.clone()), vec![0x2A]);
+
+        let image = ImageXObject::read_xobject(&dictionary, &stream, &PassthroughResolver, None)
+            .expect("predecoded image data should not be filtered again");
+
+        assert_eq!(image.data.as_ref(), &[0x2A]);
+    }
+
+    #[test]
+    fn read_xobject_decodes_encoded_stream_data() {
+        let dictionary = filtered_gray_dictionary();
+        let stream = StreamObject::new_encoded(1, 0, Box::new(dictionary.clone()), b"2A>".to_vec());
+
+        let image = ImageXObject::read_xobject(&dictionary, &stream, &PassthroughResolver, None)
+            .expect("encoded image data should have its filter applied");
+
+        assert_eq!(image.data.as_ref(), &[0x2A]);
     }
 
     #[test]
@@ -787,6 +801,22 @@ mod tests {
             ),
             ("Height".to_string(), ObjectVariant::Integer(1)),
             ("Width".to_string(), ObjectVariant::Integer(4)),
+        ]))
+    }
+
+    fn filtered_gray_dictionary() -> Dictionary {
+        Dictionary::new(BTreeMap::from([
+            ("BitsPerComponent".to_string(), ObjectVariant::Integer(8)),
+            (
+                "ColorSpace".to_string(),
+                ObjectVariant::Name(b"DeviceGray".to_vec()),
+            ),
+            (
+                "Filter".to_string(),
+                ObjectVariant::Name(b"ASCIIHexDecode".to_vec()),
+            ),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
         ]))
     }
 }

--- a/crates/pdf-object-collection/src/object_collection.rs
+++ b/crates/pdf-object-collection/src/object_collection.rs
@@ -1,6 +1,5 @@
 use pdf_object::indirect_object::IndirectObject;
 use pdf_object::object_resolver::ObjectResolver;
-use pdf_object::stream::StreamObject;
 use pdf_object::{error::ObjectError, object_variant::ObjectVariant};
 use std::collections::{HashMap, HashSet};
 
@@ -83,21 +82,17 @@ impl ObjectCollection {
                     return Err(ObjectError::DuplicateKeyInObjectCollection(object_number));
                 }
             }
-            ObjectVariant::Stream(stream) => {
-                let data = pdf_filter::filter::decode_with_resolver(&stream, self)
-                    .unwrap_or_else(|_| stream.shared_data());
-                let StreamObject {
-                    object_number,
-                    generation_number,
-                    dictionary,
-                    ..
-                } = stream;
+            ObjectVariant::Stream(mut stream) => {
+                if !stream.filters_applied()
+                    && let Ok(data) = pdf_filter::filter::decode_with_resolver(&stream, self)
+                {
+                    stream.set_filtered_data(data);
+                }
 
-                let obj = StreamObject::new(object_number, generation_number, dictionary, data);
-
+                let object_number = stream.object_number;
                 if self
                     .map
-                    .insert(object_number, ObjectVariant::Stream(obj))
+                    .insert(object_number, ObjectVariant::Stream(stream))
                     .is_some()
                 {
                     return Err(ObjectError::DuplicateKeyInObjectCollection(object_number));
@@ -363,7 +358,7 @@ mod tests {
             ObjectVariant::Integer(compressed.len() as i64),
         );
 
-        let stream = ObjectVariant::Stream(StreamObject::new(
+        let stream = ObjectVariant::Stream(StreamObject::new_encoded(
             1,
             0,
             Box::new(Dictionary::new(stream_dict)),
@@ -373,11 +368,62 @@ mod tests {
         collection.insert(stream).expect("stream insert failed");
 
         let decoded = collection.get(1).and_then(|obj| match obj {
-            ObjectVariant::Stream(stream) => Some(stream.raw_data()),
+            ObjectVariant::Stream(stream) => Some((stream.raw_data(), stream.filters_applied())),
             _ => None,
         });
 
-        assert_eq!(decoded, Some(b"hello".as_slice()));
+        assert_eq!(decoded, Some((b"hello".as_slice(), true)));
+    }
+
+    #[test]
+    fn insert_preserves_encoded_state_when_filter_dependencies_are_unresolved() {
+        use pdf_object::indirect_object::IndirectObject;
+
+        let stream_dictionary = Dictionary::new(BTreeMap::from([
+            ("DecodeParms".to_string(), ObjectVariant::Reference(2)),
+            (
+                "Filter".to_string(),
+                ObjectVariant::Name(b"ASCIIHexDecode".to_vec()),
+            ),
+        ]));
+        let stream = StreamObject::new_encoded(1, 0, Box::new(stream_dictionary), b"2A>".to_vec());
+        let mut collection = ObjectCollection::default();
+
+        collection
+            .insert(ObjectVariant::Stream(stream))
+            .expect("encoded stream insertion should be recoverable");
+        let stored = collection
+            .get(1)
+            .and_then(|object| match object {
+                ObjectVariant::Stream(stream) => Some(stream),
+                _ => None,
+            })
+            .expect("stream should remain in the collection");
+        assert!(!stored.filters_applied());
+        assert_eq!(stored.raw_data(), b"2A>");
+
+        collection
+            .insert(ObjectVariant::IndirectObject(Box::new(
+                IndirectObject::new(
+                    2,
+                    0,
+                    Some(ObjectVariant::Dictionary(Box::new(Dictionary::new(
+                        BTreeMap::new(),
+                    )))),
+                ),
+            )))
+            .expect("decode parameters should be inserted");
+
+        let stored = collection
+            .get(1)
+            .and_then(|object| match object {
+                ObjectVariant::Stream(stream) => Some(stream),
+                _ => None,
+            })
+            .expect("stream should remain in the collection");
+        let decoded = pdf_filter::filter::decode_with_resolver(stored, &collection)
+            .expect("filter retry should succeed after dependency insertion");
+        assert_eq!(decoded.as_slice(), &[0x2A]);
     }
 
     #[test]

--- a/crates/pdf-object/src/stream.rs
+++ b/crates/pdf-object/src/stream.rs
@@ -16,13 +16,15 @@ pub struct StreamObject {
     pub generation_number: usize,
     /// The dictionary associated with this stream.
     pub dictionary: Box<Dictionary>,
-    /// Shared decoded (decompressed) byte data of the stream.
+    /// Shared byte data of the stream.
     ///
-    /// Filter chains declared in the `/Filter` dictionary entry are applied
-    /// when the stream is first inserted into the object collection, so this
-    /// field always holds the final, usable bytes. Cloning the [`Arc`] shares
-    /// the allocation rather than copying the bytes.
+    /// The bytes may still be encoded when the stream was created directly
+    /// from PDF input and filter decoding has not yet succeeded. Cloning the
+    /// [`Arc`] shares the allocation rather than copying the bytes.
     pub data: Arc<Vec<u8>>,
+    /// Indicates whether the stream's declared filter chain has been applied to
+    /// the current bytes.
+    filters_applied: bool,
 }
 
 impl StreamObject {
@@ -38,21 +40,78 @@ impl StreamObject {
             generation_number,
             dictionary,
             data: data.into(),
+            filters_applied: true,
         }
+    }
+
+    /// Creates a new [`StreamObject`] whose declared filter chain has not been applied.
+    pub fn new_encoded(
+        object_number: usize,
+        generation_number: usize,
+        dictionary: Box<Dictionary>,
+        data: impl Into<Arc<Vec<u8>>>,
+    ) -> Self {
+        StreamObject {
+            object_number,
+            generation_number,
+            dictionary,
+            data: data.into(),
+            filters_applied: false,
+        }
+    }
+
+    /// Returns whether the stream's declared filter chain has been applied.
+    pub fn filters_applied(&self) -> bool {
+        self.filters_applied
+    }
+
+    /// Replaces the stream bytes with the result of applying its filter chain.
+    pub fn set_filtered_data(&mut self, data: impl Into<Arc<Vec<u8>>>) {
+        self.data = data.into();
+        self.filters_applied = true;
     }
 
     /// Returns a reference to the stream bytes.
     ///
-    /// Because stream data is decoded at insertion time, this always returns
-    /// the fully decompressed content.
+    /// Use [`Self::filters_applied`] when the distinction between encoded and
+    /// decoded bytes matters to the caller.
     pub fn raw_data(&self) -> &[u8] {
         self.data.as_slice()
     }
 
-    /// Returns shared ownership of the decoded stream bytes.
+    /// Returns shared ownership of the current stream bytes.
     ///
     /// Cloning the returned [`Arc`] does not copy the underlying byte buffer.
     pub fn shared_data(&self) -> Arc<Vec<u8>> {
         Arc::clone(&self.data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::StreamObject;
+    use crate::dictionary::Dictionary;
+
+    #[test]
+    fn constructors_record_filter_state() {
+        let decoded = StreamObject::new(1, 0, Box::new(Dictionary::new(BTreeMap::new())), vec![1]);
+        let encoded =
+            StreamObject::new_encoded(2, 0, Box::new(Dictionary::new(BTreeMap::new())), vec![2]);
+
+        assert!(decoded.filters_applied());
+        assert!(!encoded.filters_applied());
+    }
+
+    #[test]
+    fn setting_filtered_data_updates_bytes_and_state() {
+        let mut stream =
+            StreamObject::new_encoded(1, 0, Box::new(Dictionary::new(BTreeMap::new())), vec![1]);
+
+        stream.set_filtered_data(vec![2, 3]);
+
+        assert!(stream.filters_applied());
+        assert_eq!(stream.raw_data(), &[2, 3]);
     }
 }

--- a/crates/pdf-parser/src/indirect_object.rs
+++ b/crates/pdf-parser/src/indirect_object.rs
@@ -176,7 +176,7 @@ impl PdfParser<'_> {
             self.skip_whitespace_and_comments();
             self.read_keyword(ENDOBJ_KEYWORD)?;
 
-            return Ok(ObjectVariant::Stream(StreamObject::new(
+            return Ok(ObjectVariant::Stream(StreamObject::new_encoded(
                 header.object_number,
                 header.generation_number,
                 dictionary,
@@ -253,6 +253,7 @@ mod tests {
             assert_eq!(stream.object_number, 1);
             assert_eq!(stream.generation_number, 0);
             assert_eq!(stream.raw_data(), b"Hello");
+            assert!(!stream.filters_applied());
         } else {
             panic!("Expected Stream variant");
         }

--- a/crates/pdf-resources/src/xobject.rs
+++ b/crates/pdf-resources/src/xobject.rs
@@ -130,9 +130,10 @@ fn resolve_image_soft_mask(
 mod tests {
     use pdf_content_stream::ContentStreamIdAllocator;
     use pdf_object::{
-        dictionary::Dictionary, error::ObjectError, object_resolver::ObjectResolver,
-        object_variant::ObjectVariant, stream::StreamObject,
+        dictionary::Dictionary, error::ObjectError, indirect_object::IndirectObject,
+        object_resolver::ObjectResolver, object_variant::ObjectVariant, stream::StreamObject,
     };
+    use pdf_object_collection::object_collection::ObjectCollection;
     use std::collections::BTreeMap;
 
     use crate::{
@@ -317,6 +318,71 @@ mod tests {
             Err(PdfPagesError::UnsupportedXObjectSubtype { subtype })
                 if subtype == "Unsupported"
         ));
+    }
+
+    #[test]
+    fn encoded_image_retries_filters_after_dependencies_are_resolved() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            ("BitsPerComponent".to_string(), ObjectVariant::Integer(8)),
+            (
+                "ColorSpace".to_string(),
+                ObjectVariant::Name(b"DeviceGray".to_vec()),
+            ),
+            ("DecodeParms".to_string(), ObjectVariant::Reference(2)),
+            (
+                "Filter".to_string(),
+                ObjectVariant::Name(b"ASCIIHexDecode".to_vec()),
+            ),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            (
+                "Subtype".to_string(),
+                ObjectVariant::Name(b"Image".to_vec()),
+            ),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
+        ]));
+        let stream = StreamObject::new_encoded(1, 0, Box::new(dictionary), b"2A>".to_vec());
+        let mut objects = ObjectCollection::default();
+
+        objects
+            .insert(ObjectVariant::Stream(stream))
+            .expect("unresolved filter parameters should preserve the image stream");
+        objects
+            .insert(ObjectVariant::IndirectObject(Box::new(
+                IndirectObject::new(
+                    2,
+                    0,
+                    Some(ObjectVariant::Dictionary(Box::new(Dictionary::new(
+                        BTreeMap::new(),
+                    )))),
+                ),
+            )))
+            .expect("decode parameters should be inserted");
+
+        let content = objects.get(1).expect("image stream should be retained");
+        let ObjectVariant::Stream(stream) = content else {
+            panic!("expected an image stream");
+        };
+        assert!(!stream.filters_applied());
+
+        let mut cache = DefaultResourceCache::default();
+        let mut cycle_tracker = ReadCycleTracker::default();
+        let mut id_allocator = ContentStreamIdAllocator::new();
+        let xobject = read_xobject(
+            content,
+            &stream.dictionary,
+            stream,
+            &objects,
+            &mut cache,
+            &mut cycle_tracker,
+            &mut id_allocator,
+        )
+        .expect("image decoding should retry the filter chain")
+        .expect("image should remain available");
+
+        let Resource::Image(image) = xobject else {
+            panic!("expected a decoded image xobject");
+        };
+        assert_eq!(image.data.as_ref(), &[0x2A]);
     }
 
     #[test]


### PR DESCRIPTION
Track whether stream filters have already been applied so image XObjects can choose encoded or decoded data before normalizing samples.

Preserve deferred filter recovery when object dependencies are not yet available, while avoiding speculative image decoding on normal streams.