### PR TITLE
pdf-image: share decoded image vectors without copying

### DIFF
--- a/crates/pdf-canvas/src/canvas_backend.rs
+++ b/crates/pdf-canvas/src/canvas_backend.rs
@@ -35,7 +35,7 @@ pub enum Shader {
 #[derive(Clone)]
 pub struct Image {
     /// Shared raw image data.
-    pub data: Arc<[u8]>,
+    pub data: Arc<Vec<u8>>,
     /// The width of the image in pixels.
     pub width: usize,
     /// The height of the image in pixels.

--- a/crates/pdf-canvas/src/recording_canvas.rs
+++ b/crates/pdf-canvas/src/recording_canvas.rs
@@ -317,7 +317,7 @@ mod tests {
 
     #[test]
     fn recorded_image_shares_pixel_data() {
-        let data: Arc<[u8]> = vec![1, 2, 3, 4].into();
+        let data = Arc::new(vec![1, 2, 3, 4]);
         let image = BackendImage {
             data: Arc::clone(&data),
             width: 1,

--- a/crates/pdf-canvas/tests/pdf_canvas.rs
+++ b/crates/pdf-canvas/tests/pdf_canvas.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use std::{collections::HashMap, rc::Rc};
+use std::{collections::HashMap, rc::Rc, sync::Arc};
 
 use common::{content_stream, replay};
 use pdf_canvas::{pdf_canvas::PdfCanvas, recording_canvas::RecordingCanvas};
@@ -160,7 +160,7 @@ fn unavailable_image_xobject_is_a_no_op() {
 fn inline_image_render_path_matches_image_xobject_path() {
     let image = pdf_image::ImageXObject::decode_normalized_image(
         &image_dictionary(),
-        &[0b1010_0000],
+        Arc::new(vec![0b1010_0000]),
         &pdf_object::object_resolver::PassthroughResolver,
         &None,
     )

--- a/crates/pdf-image/src/decoded_samples.rs
+++ b/crates/pdf-image/src/decoded_samples.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::Arc};
 
 use pdf_color_space::{color_space::ColorSpace, indexed_color_space::IndexedColorSpace};
 use pdf_decode::{
@@ -11,26 +11,26 @@ use crate::image_metadata::ImageMetadata;
 
 /// Stores decoded sample bytes before the final pixel format conversion.
 #[derive(Debug, Clone)]
-pub(crate) struct DecodedSamples<'data> {
+pub(crate) struct DecodedSamples {
     pub(crate) bits_per_component: usize,
     pub(crate) stored_color_space: Option<ColorSpace>,
     pub(crate) num_color_components: usize,
-    pub(crate) image_data: Cow<'data, [u8]>,
+    pub(crate) image_data: Arc<Vec<u8>>,
 }
 
-impl<'data> DecodedSamples<'data> {
+impl DecodedSamples {
     /// Decodes raw image bytes into component samples based on the configured color space.
     pub(crate) fn decode(
         dictionary: &Dictionary,
-        raw_data: &'data [u8],
+        raw_data: Arc<Vec<u8>>,
         objects: &dyn ObjectResolver,
         metadata: &ImageMetadata,
     ) -> Result<Self, PdfImageError> {
         let decoded_samples = if let Some(decoded_samples) =
-            Self::decode_preconverted_jpx(raw_data, metadata)
+            Self::decode_preconverted_jpx(&raw_data, metadata)
         {
             decoded_samples
-        } else if let Some(decoded_samples) = Self::decode_preconverted_dct(raw_data, metadata) {
+        } else if let Some(decoded_samples) = Self::decode_preconverted_dct(&raw_data, metadata) {
             decoded_samples
         } else {
             match metadata.color_space.as_ref() {
@@ -64,7 +64,7 @@ impl<'data> DecodedSamples<'data> {
     }
 
     /// Uses DCT decoder output as display samples when the JPEG decoder already converted color.
-    fn decode_preconverted_dct(raw_data: &'data [u8], metadata: &ImageMetadata) -> Option<Self> {
+    fn decode_preconverted_dct(raw_data: &Arc<Vec<u8>>, metadata: &ImageMetadata) -> Option<Self> {
         let has_dct_filter = metadata
             .filters
             .as_ref()
@@ -74,8 +74,9 @@ impl<'data> DecodedSamples<'data> {
         }
 
         let num_pixels = metadata.size.width().saturating_mul(metadata.size.height());
-        let num_color_components = Self::decoded_dct_component_count(raw_data, num_pixels)
-            .or_else(|| Self::decoded_single_pixel_component_count(raw_data))?;
+        let num_color_components =
+            Self::decoded_dct_component_count(raw_data.as_slice(), num_pixels)
+                .or_else(|| Self::decoded_single_pixel_component_count(raw_data.as_slice()))?;
 
         let stored_color_space = match num_color_components {
             1 => Some(ColorSpace::DeviceGray),
@@ -83,9 +84,9 @@ impl<'data> DecodedSamples<'data> {
             _ => metadata.color_space.clone(),
         };
         let image_data = if raw_data.len() == num_color_components && num_pixels > 1 {
-            Cow::Owned(raw_data.repeat(num_pixels))
+            Arc::new(raw_data.repeat(num_pixels))
         } else {
-            Cow::Borrowed(raw_data)
+            Arc::clone(raw_data)
         };
 
         Some(Self {
@@ -97,7 +98,7 @@ impl<'data> DecodedSamples<'data> {
     }
 
     /// Uses JPX decoder output as display samples when the decoder already expanded pixels.
-    fn decode_preconverted_jpx(raw_data: &'data [u8], metadata: &ImageMetadata) -> Option<Self> {
+    fn decode_preconverted_jpx(raw_data: &Arc<Vec<u8>>, metadata: &ImageMetadata) -> Option<Self> {
         let has_jpx_filter = metadata
             .filters
             .as_ref()
@@ -124,7 +125,7 @@ impl<'data> DecodedSamples<'data> {
             bits_per_component,
             stored_color_space,
             num_color_components,
-            image_data: Cow::Borrowed(raw_data),
+            image_data: Arc::clone(raw_data),
         })
     }
 
@@ -143,7 +144,7 @@ impl<'data> DecodedSamples<'data> {
     /// Decodes indexed image samples, applies `/Decode`, and expands palette entries.
     fn decode_indexed(
         dictionary: &Dictionary,
-        raw_data: &'data [u8],
+        raw_data: Arc<Vec<u8>>,
         objects: &dyn ObjectResolver,
         metadata: &ImageMetadata,
         indexed: &IndexedColorSpace,
@@ -171,14 +172,14 @@ impl<'data> DecodedSamples<'data> {
             bits_per_component: metadata.bits_per_component,
             stored_color_space: Some(*indexed.base.clone()),
             num_color_components: base_components,
-            image_data: Cow::Owned(image_data),
+            image_data: Arc::new(image_data),
         })
     }
 
     /// Decodes non-indexed image samples and applies the `/Decode` transform.
     fn decode_direct(
         dictionary: &Dictionary,
-        raw_data: &'data [u8],
+        raw_data: Arc<Vec<u8>>,
         objects: &dyn ObjectResolver,
         metadata: &ImageMetadata,
     ) -> Result<Self, PdfImageError> {
@@ -205,51 +206,53 @@ impl<'data> DecodedSamples<'data> {
     }
 
     /// Applies an explicit decode map or the implicit PDF identity/inverted default.
-    fn apply_decode<'a>(
-        sample_codes: Cow<'a, [u8]>,
+    fn apply_decode(
+        sample_codes: Arc<Vec<u8>>,
         decode: Option<&DecodeMap>,
         sample_max: u8,
         output_max: u8,
         default_inverted: bool,
-    ) -> Cow<'a, [u8]> {
+    ) -> Arc<Vec<u8>> {
         if let Some(decode) = decode {
-            return Cow::Owned(decode.apply_to_bytes(
-                sample_codes.as_ref(),
-                sample_max,
-                output_max,
-            ));
+            return Arc::new(decode.apply_to_bytes(sample_codes.as_ref(), sample_max, output_max));
         }
 
         if sample_max == output_max && !default_inverted {
             return sample_codes;
         }
 
-        let mut decoded = sample_codes.into_owned();
+        let mut decoded = sample_codes;
         let default_range = if default_inverted {
             DecodeRange::inverted_identity()
         } else {
             DecodeRange::identity()
         };
-        for sample in &mut decoded {
+        for sample in Arc::make_mut(&mut decoded) {
             *sample = default_range.map_byte(*sample, sample_max, output_max);
         }
-        Cow::Owned(decoded)
+        decoded
     }
 
-    fn decode_image_sample_codes<'a>(
-        raw_data: &'a [u8],
+    fn decode_image_sample_codes(
+        raw_data: Arc<Vec<u8>>,
         samples_per_pixel: usize,
         metadata: &ImageMetadata,
-    ) -> Result<Cow<'a, [u8]>, PdfImageError> {
-        Ok(decode_sample_bytes(
-            raw_data,
+    ) -> Result<Arc<Vec<u8>>, PdfImageError> {
+        let sample_codes = decode_sample_bytes(
+            raw_data.as_slice(),
             metadata.bits_per_component,
             SampleLayout::RowAligned {
                 width: metadata.size.width(),
                 height: metadata.size.height(),
                 samples_per_pixel,
             },
-        )?)
+        )?;
+
+        Ok(match sample_codes {
+            Cow::Borrowed(samples) if samples.len() == raw_data.len() => raw_data,
+            Cow::Borrowed(samples) => Arc::new(samples.to_vec()),
+            Cow::Owned(samples) => Arc::new(samples),
+        })
     }
 
     /// Returns the maximum encoded sample value for a supported bit depth.
@@ -273,18 +276,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn apply_decode_preserves_borrowed_identity_samples() {
-        let samples = [12, 34];
-        let decoded = DecodedSamples::apply_decode(Cow::Borrowed(&samples), None, 255, 255, false);
+    fn apply_decode_preserves_shared_identity_samples() {
+        let samples = Arc::new(vec![12, 34]);
+        let decoded = DecodedSamples::apply_decode(Arc::clone(&samples), None, 255, 255, false);
 
-        assert!(matches!(
-            decoded,
-            Cow::Borrowed(values) if std::ptr::eq(values, samples.as_slice())
-        ));
+        assert!(Arc::ptr_eq(&decoded, &samples));
     }
 
     #[test]
-    fn decode_direct_preserves_borrowed_identity_samples() {
+    fn decode_direct_preserves_shared_identity_samples() {
         let dictionary = Dictionary::new(BTreeMap::from([
             ("BitsPerComponent".to_string(), ObjectVariant::Integer(8)),
             (
@@ -296,15 +296,16 @@ mod tests {
         ]));
         let metadata = ImageMetadata::from_dictionary(&dictionary, &PassthroughResolver)
             .expect("direct image metadata should be valid");
-        let samples = [12, 34];
+        let samples = Arc::new(vec![12, 34]);
 
-        let decoded =
-            DecodedSamples::decode_direct(&dictionary, &samples, &PassthroughResolver, &metadata)
-                .expect("identity samples should decode");
+        let decoded = DecodedSamples::decode_direct(
+            &dictionary,
+            Arc::clone(&samples),
+            &PassthroughResolver,
+            &metadata,
+        )
+        .expect("identity samples should decode");
 
-        assert!(matches!(
-            decoded.image_data,
-            Cow::Borrowed(values) if std::ptr::eq(values, samples.as_slice())
-        ));
+        assert!(Arc::ptr_eq(&decoded.image_data, &samples));
     }
 }

--- a/crates/pdf-image/src/image_xobject.rs
+++ b/crates/pdf-image/src/image_xobject.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::sync::Arc;
 
 use pdf_color_space::color_space::ColorSpace;
 use pdf_filter::filter::{decode_data_with_resolver, decode_with_resolver};
@@ -20,7 +20,7 @@ pub struct ImageXObject {
     /// The number of bits used to represent each color component.
     pub bits_per_component: usize,
     /// The shared image stream data (with soft mask alpha applied if present).
-    pub data: Arc<[u8]>,
+    pub data: Arc<Vec<u8>>,
     /// The pixel format of the image data.
     pub pixel_format: PixelFormat,
     /// The color space of the image samples.
@@ -43,11 +43,7 @@ impl ImageXObject {
         };
 
         Self::decode_normalized_image_with_metadata(
-            dictionary,
-            decoded.as_ref(),
-            objects,
-            &soft_mask,
-            &metadata,
+            dictionary, decoded, objects, &soft_mask, &metadata,
         )
     }
 
@@ -60,16 +56,16 @@ impl ImageXObject {
         let dictionary = image.normalized_dictionary();
         let decoded = decode_data_with_resolver(&dictionary, image.shared_data(), objects)?;
 
-        Self::decode_normalized_image(&dictionary, decoded.as_ref(), objects, &soft_mask)
+        Self::decode_normalized_image(&dictionary, decoded, objects, &soft_mask)
     }
 
-    /// Decodes a normalized image dictionary and raw bytes into a raster image.
+    /// Decodes a normalized image dictionary and shared raw bytes into a raster image.
     ///
     /// The dictionary must already use canonical image keys such as `Width`,
     /// `Height`, `BitsPerComponent`, and `ColorSpace`.
     pub fn decode_normalized_image(
         dictionary: &Dictionary,
-        raw_data: &[u8],
+        raw_data: Arc<Vec<u8>>,
         objects: &dyn ObjectResolver,
         soft_mask: &Option<ImageXObject>,
     ) -> Result<Self, PdfImageError> {
@@ -81,7 +77,7 @@ impl ImageXObject {
 
     fn decode_normalized_image_with_metadata(
         dictionary: &Dictionary,
-        raw_data: &[u8],
+        raw_data: Arc<Vec<u8>>,
         objects: &dyn ObjectResolver,
         soft_mask: &Option<ImageXObject>,
         metadata: &ImageMetadata,
@@ -93,40 +89,32 @@ impl ImageXObject {
             num_color_components,
             image_data,
         } = decoded_samples;
-        let (data, pixel_format) =
-            Self::assemble_pixel_data(metadata, image_data, num_color_components, soft_mask);
+        let convert_to_rgba = soft_mask.is_some() || num_color_components != 1;
+        let pixel_format = if convert_to_rgba {
+            PixelFormat::RGBA8888
+        } else {
+            PixelFormat::Gray8
+        };
+        let data = if convert_to_rgba {
+            Arc::new(Self::to_rgba(
+                image_data.as_ref(),
+                metadata.size.width(),
+                metadata.size.height(),
+                num_color_components,
+                soft_mask.as_ref(),
+            ))
+        } else {
+            image_data
+        };
 
         Ok(Self {
             width: metadata.size.width(),
             height: metadata.size.height(),
             bits_per_component,
-            data: data.into(),
+            data,
             pixel_format,
             color_space: stored_color_space,
         })
-    }
-
-    /// Builds the final pixel buffer and pixel format after optional soft-mask application.
-    fn assemble_pixel_data(
-        metadata: &ImageMetadata,
-        image_data: Cow<'_, [u8]>,
-        num_color_components: usize,
-        smask: &Option<ImageXObject>,
-    ) -> (Vec<u8>, PixelFormat) {
-        if smask.is_some() || num_color_components != 1 {
-            return (
-                Self::to_rgba(
-                    image_data.as_ref(),
-                    metadata.size.width(),
-                    metadata.size.height(),
-                    num_color_components,
-                    smask.as_ref(),
-                ),
-                PixelFormat::RGBA8888,
-            );
-        }
-
-        (image_data.into_owned(), PixelFormat::Gray8)
     }
 
     /// Converts decoded image samples into RGBA pixels with an optional soft-mask alpha channel.
@@ -219,7 +207,7 @@ mod tests {
 
     #[test]
     fn cloned_image_xobject_shares_data() {
-        let data: Arc<[u8]> = vec![1, 2, 3, 4].into();
+        let data = Arc::new(vec![1, 2, 3, 4]);
         let image = ImageXObject {
             width: 1,
             height: 1,
@@ -242,6 +230,7 @@ mod tests {
         let image = ImageXObject::read_xobject(&dictionary, &stream, &PassthroughResolver, None)
             .expect("predecoded image data should not be filtered again");
 
+        assert!(Arc::ptr_eq(&image.data, &stream.data));
         assert_eq!(image.data.as_ref(), &[0x2A]);
     }
 
@@ -274,7 +263,7 @@ mod tests {
 
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[0b1010_0000],
+            Arc::new(vec![0b1010_0000]),
             &PassthroughResolver,
             &None,
         )
@@ -302,7 +291,7 @@ mod tests {
 
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[0, 255],
+            Arc::new(vec![0, 255]),
             &PassthroughResolver,
             &None,
         )
@@ -335,7 +324,7 @@ mod tests {
 
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[0b1000_0000],
+            Arc::new(vec![0b1000_0000]),
             &PassthroughResolver,
             &None,
         )
@@ -361,9 +350,13 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(1)),
         ]));
 
-        let err =
-            ImageXObject::decode_normalized_image(&dictionary, &[0], &PassthroughResolver, &None)
-                .expect_err("invalid /Decode length should fail");
+        let err = ImageXObject::decode_normalized_image(
+            &dictionary,
+            Arc::new(vec![0]),
+            &PassthroughResolver,
+            &None,
+        )
+        .expect_err("invalid /Decode length should fail");
 
         assert!(matches!(
             err,
@@ -386,15 +379,42 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(2)),
         ]));
 
+        let samples = Arc::new(vec![12, 34]);
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[12, 34],
+            Arc::clone(&samples),
             &PassthroughResolver,
             &None,
         )
         .expect("grayscale image without /Decode should decode");
 
+        assert!(Arc::ptr_eq(&image.data, &samples));
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::Gray8);
+        assert_eq!(image.data.as_ref(), &[12, 34]);
+    }
+
+    #[test]
+    fn decode_normalized_image_trims_trailing_samples() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            ("BitsPerComponent".to_string(), ObjectVariant::Integer(8)),
+            (
+                "ColorSpace".to_string(),
+                ObjectVariant::Name(b"DeviceGray".to_vec()),
+            ),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("Width".to_string(), ObjectVariant::Integer(2)),
+        ]));
+        let samples = Arc::new(vec![12, 34, 56]);
+
+        let image = ImageXObject::decode_normalized_image(
+            &dictionary,
+            Arc::clone(&samples),
+            &PassthroughResolver,
+            &None,
+        )
+        .expect("trailing samples should be ignored");
+
+        assert!(!Arc::ptr_eq(&image.data, &samples));
         assert_eq!(image.data.as_ref(), &[12, 34]);
     }
 
@@ -408,7 +428,7 @@ mod tests {
 
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[0b1010_0000],
+            Arc::new(vec![0b1010_0000]),
             &PassthroughResolver,
             &None,
         )
@@ -433,7 +453,7 @@ mod tests {
 
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[1, 2, 3, 4, 5, 6],
+            Arc::new(vec![1, 2, 3, 4, 5, 6]),
             &PassthroughResolver,
             &None,
         )
@@ -459,9 +479,13 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(1)),
         ]));
 
-        let err =
-            ImageXObject::decode_normalized_image(&dictionary, &[0], &PassthroughResolver, &None)
-                .expect_err("non-mask images should still require BitsPerComponent");
+        let err = ImageXObject::decode_normalized_image(
+            &dictionary,
+            Arc::new(vec![0]),
+            &PassthroughResolver,
+            &None,
+        )
+        .expect_err("non-mask images should still require BitsPerComponent");
 
         assert!(matches!(
             err,
@@ -487,7 +511,7 @@ mod tests {
 
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[10, 20, 30, 40, 50, 60],
+            Arc::new(vec![10, 20, 30, 40, 50, 60]),
             &PassthroughResolver,
             &None,
         )
@@ -515,7 +539,7 @@ mod tests {
 
         let err = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[10, 20, 30, 40, 50, 60],
+            Arc::new(vec![10, 20, 30, 40, 50, 60]),
             &PassthroughResolver,
             &None,
         )
@@ -548,7 +572,7 @@ mod tests {
 
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[0xAA, 0x10, 0x20],
+            Arc::new(vec![0xAA, 0x10, 0x20]),
             &PassthroughResolver,
             &None,
         )
@@ -587,7 +611,7 @@ mod tests {
 
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[0x20, 0xC0],
+            Arc::new(vec![0x20, 0xC0]),
             &PassthroughResolver,
             &Some(soft_mask),
         )
@@ -646,6 +670,26 @@ mod tests {
     }
 
     #[test]
+    fn decode_inline_image_preserves_unfiltered_shared_samples() {
+        let image = InlineImage::new(
+            Dictionary::new(BTreeMap::from([
+                ("BPC".to_string(), ObjectVariant::Integer(8)),
+                ("CS".to_string(), ObjectVariant::Name(b"G".to_vec())),
+                ("H".to_string(), ObjectVariant::Integer(1)),
+                ("W".to_string(), ObjectVariant::Integer(2)),
+            ])),
+            vec![12, 34],
+        );
+        let samples = image.shared_data();
+
+        let decoded = ImageXObject::decode_inline_image(&image, &PassthroughResolver, None)
+            .expect("unfiltered inline image should decode");
+
+        assert!(Arc::ptr_eq(&decoded.data, &samples));
+        assert_eq!(decoded.data.as_ref(), &[12, 34]);
+    }
+
+    #[test]
     fn decode_inline_image_accepts_abbreviated_indexed_color_space() {
         let image = InlineImage::new(
             Dictionary::new(BTreeMap::from([
@@ -691,7 +735,7 @@ mod tests {
 
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[0b1011_0010],
+            Arc::new(vec![0b1011_0010]),
             &PassthroughResolver,
             &None,
         )
@@ -709,7 +753,7 @@ mod tests {
         let dictionary = indexed_dictionary(1);
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[0b1010_0000],
+            Arc::new(vec![0b1010_0000]),
             &PassthroughResolver,
             &None,
         )
@@ -729,7 +773,7 @@ mod tests {
         let dictionary = indexed_dictionary(2);
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[0x1B],
+            Arc::new(vec![0x1B]),
             &PassthroughResolver,
             &None,
         )
@@ -749,7 +793,7 @@ mod tests {
         let dictionary = indexed_dictionary(4);
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[0x01, 0x23],
+            Arc::new(vec![0x01, 0x23]),
             &PassthroughResolver,
             &None,
         )
@@ -769,7 +813,7 @@ mod tests {
         let dictionary = indexed_dictionary(8);
         let image = ImageXObject::decode_normalized_image(
             &dictionary,
-            &[0, 1, 2, 3],
+            Arc::new(vec![0, 1, 2, 3]),
             &PassthroughResolver,
             &None,
         )

--- a/crates/pdf-resources/src/resources.rs
+++ b/crates/pdf-resources/src/resources.rs
@@ -58,30 +58,6 @@ pub struct Resources {
     pub lazy_reference: Option<ResourcesReference>,
 }
 
-/// Attempts to retrieve a sub-dictionary from the resources dictionary.
-///
-/// # Parameters
-///
-/// - `resources`: The main resources dictionary to search within.
-/// - `key`: The key of the sub-dictionary to retrieve (e.g., "Font", "Pattern").
-/// - `objects`: The object resolver to resolve indirect references if necessary.
-///
-/// # Returns
-///
-/// Returns `Ok(None)` if the key doesn't exist, `Ok(Some(dict))` if found,
-/// or an error if the value exists but isn't a valid dictionary.
-fn get_sub_dictionary<'a>(
-    resources: &'a Dictionary,
-    key: &str,
-    objects: &'a dyn ObjectResolver,
-) -> Result<Option<&'a Dictionary>, PdfPagesError> {
-    resources
-        .get(key)
-        .map(|entry| entry.try_dictionary(objects))
-        .transpose()
-        .map_err(Into::into)
-}
-
 pub(crate) fn read_font_resource(
     dictionary: &Dictionary,
     objects: &dyn ObjectResolver,
@@ -112,7 +88,7 @@ fn read_fonts(
     cycle_tracker: &mut ReadCycleTracker,
     id_allocator: &mut ContentStreamIdAllocator,
 ) -> Result<HashMap<String, Resource>, PdfPagesError> {
-    let Some(font_dict) = get_sub_dictionary(resources, Font::KEY, objects)? else {
+    let Some(font_dict) = resources.optional_dictionary(Font::KEY, objects)? else {
         return Ok(HashMap::new());
     };
 
@@ -135,7 +111,7 @@ fn read_external_graphics_states(
     cycle_tracker: &mut ReadCycleTracker,
     id_allocator: &mut ContentStreamIdAllocator,
 ) -> Result<HashMap<String, Resource>, PdfPagesError> {
-    let Some(ext_gstate_dict) = get_sub_dictionary(resources, "ExtGState", objects)? else {
+    let Some(ext_gstate_dict) = resources.optional_dictionary("ExtGState", objects)? else {
         return Ok(HashMap::new());
     };
 
@@ -177,7 +153,7 @@ fn read_patterns(
     cycle_tracker: &mut ReadCycleTracker,
     id_allocator: &mut ContentStreamIdAllocator,
 ) -> Result<HashMap<String, Resource>, PdfPagesError> {
-    let Some(pattern_dict) = get_sub_dictionary(resources, "Pattern", objects)? else {
+    let Some(pattern_dict) = resources.optional_dictionary("Pattern", objects)? else {
         return Ok(HashMap::new());
     };
 
@@ -294,7 +270,7 @@ fn read_xobjects(
     cycle_tracker: &mut ReadCycleTracker,
     id_allocator: &mut ContentStreamIdAllocator,
 ) -> Result<HashMap<String, Resource>, PdfPagesError> {
-    let Some(xobject_dict) = get_sub_dictionary(resources, "XObject", objects)? else {
+    let Some(xobject_dict) = resources.optional_dictionary("XObject", objects)? else {
         return Ok(HashMap::new());
     };
 
@@ -316,7 +292,7 @@ fn read_shadings(
     objects: &dyn ObjectResolver,
     cache: &mut dyn ResourceCache,
 ) -> Result<HashMap<String, Resource>, PdfPagesError> {
-    let Some(shading_dict) = get_sub_dictionary(resources, "Shading", objects)? else {
+    let Some(shading_dict) = resources.optional_dictionary("Shading", objects)? else {
         return Ok(HashMap::new());
     };
 
@@ -339,7 +315,7 @@ fn read_color_spaces(
     objects: &dyn ObjectResolver,
     cache: &mut dyn ResourceCache,
 ) -> Result<HashMap<String, Resource>, PdfPagesError> {
-    let Some(color_space_dict) = get_sub_dictionary(resources, "ColorSpace", objects)? else {
+    let Some(color_space_dict) = resources.optional_dictionary("ColorSpace", objects)? else {
         return Ok(HashMap::new());
     };
 

--- a/crates/pdf-shading/src/paint.rs
+++ b/crates/pdf-shading/src/paint.rs
@@ -57,7 +57,7 @@ pub enum ShadingPaint {
     /// A rasterized mesh shading paint.
     RasterImage {
         /// Shared RGBA8 image data for the rasterized shading.
-        pixels: Arc<[u8]>,
+        pixels: Arc<Vec<u8>>,
         /// Raster width in pixels.
         width: usize,
         /// Raster height in pixels.
@@ -125,7 +125,7 @@ pub fn build_shading_paint(
             let raster = rasterize_mesh_triangles(triangles, bounds, &mesh_transform);
 
             Ok(ShadingPaint::RasterImage {
-                pixels: raster.pixels.into(),
+                pixels: Arc::new(raster.pixels),
                 width: raster.width,
                 height: raster.height,
                 dest_rect: raster.bounds,
@@ -161,7 +161,7 @@ pub fn build_shading_paint(
             );
 
             Ok(ShadingPaint::RasterImage {
-                pixels: raster.pixels.into(),
+                pixels: Arc::new(raster.pixels),
                 width: raster.width,
                 height: raster.height,
                 dest_rect: raster.bounds,
@@ -186,7 +186,7 @@ fn has_paintable_bounds(bounds: &Rect) -> bool {
 
 fn transparent_raster_paint() -> ShadingPaint {
     ShadingPaint::RasterImage {
-        pixels: Arc::from([0_u8, 0, 0, 0]),
+        pixels: Arc::new(vec![0_u8, 0, 0, 0]),
         width: 1,
         height: 1,
         dest_rect: Rect {

--- a/crates/pdf-shading/tests/paint.rs
+++ b/crates/pdf-shading/tests/paint.rs
@@ -129,5 +129,5 @@ fn fully_degenerate_free_form_mesh_builds_transparent_paint() {
 
     assert_eq!(width, 1);
     assert_eq!(height, 1);
-    assert_eq!(pixels.as_ref(), [0, 0, 0, 0]);
+    assert_eq!(pixels.as_slice(), [0, 0, 0, 0]);
 }


### PR DESCRIPTION
Carry Arc<Vec<u8>> through image sample decoding, canvas images, and raster shadings so unchanged buffers retain their allocations. Adopt newly produced vectors directly and copy only when trimming input.

Require shared input for normalized image decoding and cover allocation reuse for XObjects, inline images, and identity samples.

Use typed optional dictionary lookups while reading page resources.