### PR TITLE
pdf-canvas: streamline selectable text recording

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,6 +2112,7 @@ dependencies = [
 name = "pdf-canvas"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "num-traits",
  "pdf-color-space",
  "pdf-content-stream",
@@ -2371,6 +2372,7 @@ dependencies = [
  "pdf-canvas",
  "pdf-content-stream",
  "pdf-document",
+ "pdf-font",
  "pdf-graphics",
  "thiserror 2.0.12",
 ]

--- a/crates/pdf-canvas/Cargo.toml
+++ b/crates/pdf-canvas/Cargo.toml
@@ -22,3 +22,10 @@ thiserror = "2.0.12"
 num-traits = "0.2.19"
 read-fonts = "0.39.2"
 skrifa =  "0.42.1"
+
+[dev-dependencies]
+criterion = "0.8"
+
+[[bench]]
+name = "text_recording"
+harness = false

--- a/crates/pdf-canvas/benches/text_recording.rs
+++ b/crates/pdf-canvas/benches/text_recording.rs
@@ -1,0 +1,119 @@
+#![allow(clippy::arithmetic_side_effects, clippy::expect_used)]
+
+use std::{collections::HashMap, hint::black_box, rc::Rc};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use pdf_canvas::{pdf_canvas::PdfCanvas, recording_canvas::RecordingCanvas};
+use pdf_content_stream::{ContentStream, ContentStreamIdAllocator};
+use pdf_document::page::PdfPage;
+use pdf_font::{
+    encoding::Encoding,
+    font::Font,
+    type1_font::{Type1Font, Type1FontProgramFormat},
+};
+use pdf_object::{
+    dictionary::Dictionary, object_resolver::PassthroughResolver, object_variant::ObjectVariant,
+    stream::StreamObject,
+};
+use pdf_resources::{resource::Resource, resources::Resources};
+
+const EEXEC_SEED: u16 = 55665;
+
+fn encrypt(bytes: &[u8]) -> Vec<u8> {
+    let mut state = EEXEC_SEED;
+    bytes
+        .iter()
+        .map(|plain| {
+            let cipher = *plain ^ u8::try_from(state >> 8).expect("shifted seed should fit");
+            state = u16::try_from(
+                (u32::from(cipher) + u32::from(state))
+                    .wrapping_mul(52845)
+                    .wrapping_add(22719)
+                    & 0xffff,
+            )
+            .expect("masked state should fit");
+            cipher
+        })
+        .collect()
+}
+
+fn font_bytes() -> Vec<u8> {
+    let mut bytes = br#"%!FontType1-1.0: Bench 1.0
+10 dict begin
+/FontName /Bench def
+/FontType 1 def
+/FontMatrix [0.001 0 0 0.001 0 0] readonly def
+/FontBBox [0 0 0 0] readonly def
+/Encoding StandardEncoding def
+currentdict end
+currentfile eexec
+"#
+    .to_vec();
+    let mut private = vec![0, 0, 0, 0];
+    private.extend_from_slice(b"/Private 1 dict dup begin\n/lenIV -1 def\n/CharStrings 1 dict dup begin\n/.notdef 1 RD \x0E ND\nend\nend\nmark currentfile closefile\n");
+    bytes.extend(encrypt(&private));
+    bytes.extend_from_slice(b"0000000000000000000000000000000000000000\ncleartomark\n");
+    bytes
+}
+
+fn content_stream(text: &[u8]) -> ContentStream {
+    let mut data = b"BT /F1 10 Tf (".to_vec();
+    data.extend_from_slice(text);
+    data.extend_from_slice(b") Tj ET");
+    let stream = StreamObject::new(1, 0, Box::new(Dictionary::new(Default::default())), data);
+    ContentStream::new(
+        &ObjectVariant::Stream(stream),
+        &PassthroughResolver,
+        &mut ContentStreamIdAllocator::new(),
+    )
+    .expect("benchmark stream should parse")
+}
+
+fn benchmark(c: &mut Criterion) {
+    let font = Font::Type1(Type1Font {
+        font_file: font_bytes().into(),
+        program_format: Type1FontProgramFormat::ClassicType1,
+        widths: Some(HashMap::from([(65, 500.0)])),
+        encoding: Encoding::default(),
+        to_unicode: None,
+    });
+    let resources = Resources {
+        fonts: HashMap::from([(
+            "F1".to_string(),
+            Resource::Font {
+                font: Rc::new(font),
+                resources: None,
+            },
+        )]),
+        ..Default::default()
+    };
+    let text = vec![b'A'; 1_024];
+    let stream = content_stream(&text);
+    let page = PdfPage::default();
+
+    c.bench_function("text/render_1024_glyphs", |bencher| {
+        bencher.iter(|| {
+            let mut recording = RecordingCanvas::new(1000.0, 1000.0);
+            let mut canvas =
+                PdfCanvas::new(&mut recording, &page, None).expect("canvas should initialize");
+            canvas
+                .render_content_stream(&stream, None, None, Some(&resources), None)
+                .expect("text should render");
+        });
+    });
+    c.bench_function("text/render_and_record_1024_glyphs", |bencher| {
+        bencher.iter(|| {
+            let mut recording = RecordingCanvas::new(1000.0, 1000.0);
+            let mut canvas = PdfCanvas::new(&mut recording, &page, None)
+                .expect("canvas should initialize")
+                .with_text_recording();
+            canvas
+                .render_content_stream(&stream, None, None, Some(&resources), None)
+                .expect("text should render");
+            black_box(canvas.take_text_glyphs());
+        });
+    });
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/crates/pdf-canvas/src/pdf_canvas.rs
+++ b/crates/pdf-canvas/src/pdf_canvas.rs
@@ -8,7 +8,7 @@ use crate::{
     pdf_path_pen::PdfPathPen,
     recording_canvas::RecordingCanvas,
     stroke_style::StrokeStyle,
-    text::{TextGlyph, TextSink, glyph_bounds, glyph_text},
+    text::{TextGlyph, TextGlyphStart, glyph_bounds, glyph_unicode},
     text_state::TextState,
 };
 use pdf_content_stream::ContentStream;
@@ -43,8 +43,8 @@ pub struct PdfCanvas<'a, B: CanvasBackend> {
     pub(crate) canvas_stack: Vec<CanvasState<'a>>,
     /// Content-stream IDs currently being rendered on this canvas stack.
     pub(crate) active_content_stream_ids: HashSet<usize>,
-    /// Optional sink for extracted text glyph positions.
-    pub(crate) text_sink: Option<&'a mut dyn TextSink>,
+    /// Optional owned buffer for extracted text glyph positions.
+    pub(crate) text_glyphs: Option<Vec<TextGlyph>>,
 }
 
 impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
@@ -117,20 +117,22 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
             page,
             canvas_stack,
             active_content_stream_ids: HashSet::new(),
-            text_sink: None,
+            text_glyphs: None,
         })
     }
 
-    /// Creates a new `PdfCanvas` and emits rendered text spans into `text_sink`.
-    pub fn new_with_text_sink(
-        backend: &'a mut B,
-        page: &'a PdfPage,
-        bb: Option<&Rect>,
-        text_sink: &'a mut dyn TextSink,
-    ) -> Result<Self, PdfCanvasError> {
-        let mut canvas = Self::new(backend, page, bb)?;
-        canvas.text_sink = Some(text_sink);
-        Ok(canvas)
+    /// Enables collection of selectable glyph metadata during rendering.
+    #[must_use]
+    pub fn with_text_recording(mut self) -> Self {
+        self.text_glyphs = Some(Vec::new());
+        self
+    }
+
+    /// Takes the glyph metadata collected by [`Self::with_text_recording`].
+    ///
+    /// Returns an empty vector when recording was not enabled.
+    pub fn take_text_glyphs(&mut self) -> Vec<TextGlyph> {
+        self.text_glyphs.take().unwrap_or_default()
     }
 
     /// Returns whether a form or pattern bbox is safe to materialize as an offscreen recording.
@@ -227,7 +229,7 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
             page: self.page,
             canvas_stack,
             active_content_stream_ids: self.active_content_stream_ids.clone(),
-            text_sink: None,
+            text_glyphs: None,
         };
 
         // Render the form's content stream into the mask canvas.
@@ -812,30 +814,38 @@ impl<'a, B: CanvasBackend> PdfCanvas<'a, B> {
         }
     }
 
+    pub(crate) fn text_glyph_start(&self) -> Result<Option<TextGlyphStart<'a>>, PdfCanvasError> {
+        if self.text_glyphs.is_none() {
+            return Ok(None);
+        }
+        let state = self.current_state()?;
+        let mut transform = state.text_state.matrix;
+        transform.concat(&state.transform);
+        Ok(Some(TextGlyphStart {
+            transform,
+            font_size: state.text_state.font_size,
+            font: state.text_state.font,
+        }))
+    }
+
     pub(crate) fn record_text_glyph(
         &mut self,
         char_code: u16,
-        text_state_before_advance: &TextState<'a>,
-        ctm: &Transform,
+        start: Option<TextGlyphStart<'a>>,
     ) -> Result<(), PdfCanvasError> {
-        if self.text_sink.is_none() {
+        let Some(start) = start else {
             return Ok(());
-        }
-
-        let text_state_after_advance = &self.current_state()?.text_state;
-        let text = glyph_text(text_state_before_advance.font, char_code);
-        if text.is_empty() {
-            return Ok(());
-        }
-
-        let bounds = glyph_bounds(text_state_before_advance, ctm, text_state_after_advance);
+        };
+        let state = self.current_state()?;
+        let mut after = state.text_state.matrix;
+        after.concat(&state.transform);
+        let bounds = glyph_bounds(&start.transform, start.font_size, &after);
         if bounds.is_valid() {
-            let Some(text_sink) = self.text_sink.as_deref_mut() else {
-                return Ok(());
-            };
-            text_sink.push_glyph(TextGlyph { text, bounds });
+            let unicode = glyph_unicode(start.font, char_code);
+            if let Some(glyphs) = &mut self.text_glyphs {
+                glyphs.push(TextGlyph { unicode, bounds });
+            }
         }
-
         Ok(())
     }
 }

--- a/crates/pdf-canvas/src/text.rs
+++ b/crates/pdf-canvas/src/text.rs
@@ -1,77 +1,39 @@
-use pdf_font::font::Font;
+use pdf_font::{char_vec::CharVec, font::Font};
 use pdf_graphics::{rect::Rect, transform::Transform};
 
-use crate::text_state::TextState;
-
-/// One extracted text glyph or character span in rendered device coordinates.
+/// One selectable glyph span in rendered device coordinates.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TextGlyph {
-    /// Unicode text represented by this glyph span.
-    pub text: String,
+    /// Unicode scalar values represented by this glyph span.
+    pub unicode: CharVec,
     /// Axis-aligned device-space bounds for hit testing and highlighting.
     pub bounds: Rect,
 }
 
-/// Receives text spans while a page content stream is rendered.
-pub trait TextSink {
-    /// Records one extracted text span.
-    fn push_glyph(&mut self, glyph: TextGlyph);
+/// Minimal state captured before advancing a glyph.
+///
+/// This stays stack-only and is produced only while text recording is enabled.
+#[derive(Clone, Copy)]
+pub(crate) struct TextGlyphStart<'a> {
+    pub(crate) transform: Transform,
+    pub(crate) font_size: f32,
+    pub(crate) font: Option<&'a Font>,
 }
 
-/// Collects text spans emitted by [`PdfCanvas`](crate::pdf_canvas::PdfCanvas).
-#[derive(Default)]
-pub struct TextCollector {
-    glyphs: Vec<TextGlyph>,
-}
-
-impl TextCollector {
-    /// Creates an empty text collector.
-    pub fn new() -> Self {
-        Self::default()
+pub(crate) fn glyph_unicode(font: Option<&Font>, char_code: u16) -> CharVec {
+    let mut unicode = font
+        .map(|current_font| current_font.chars_to_unicode(char_code))
+        .unwrap_or_default();
+    if unicode.is_empty() {
+        unicode.push(char::from_u32(u32::from(char_code)).unwrap_or('\u{fffd}'));
     }
-
-    /// Returns the collected glyph spans.
-    pub fn glyphs(&self) -> &[TextGlyph] {
-        &self.glyphs
-    }
-
-    /// Consumes the collector and returns its glyph spans.
-    pub fn into_glyphs(self) -> Vec<TextGlyph> {
-        self.glyphs
-    }
+    unicode
 }
 
-impl TextSink for TextCollector {
-    fn push_glyph(&mut self, glyph: TextGlyph) {
-        self.glyphs.push(glyph);
-    }
-}
-
-pub(crate) fn glyph_text(font: Option<&Font>, char_code: u16) -> String {
-    font.map(|current_font| current_font.chars_to_unicode(char_code))
-        .filter(|chars| !chars.is_empty())
-        .map(|chars| chars.iter().collect())
-        .unwrap_or_else(|| {
-            char::from_u32(u32::from(char_code))
-                .unwrap_or('\u{fffd}')
-                .to_string()
-        })
-}
-
-pub(crate) fn glyph_bounds(
-    text_state_before_advance: &TextState<'_>,
-    ctm: &Transform,
-    text_state_after_advance: &TextState<'_>,
-) -> Rect {
-    let mut before = text_state_before_advance.matrix;
-    before.concat(ctm);
-
-    let mut after = text_state_after_advance.matrix;
-    after.concat(ctm);
-
+pub(crate) fn glyph_bounds(before: &Transform, font_size: f32, after: &Transform) -> Rect {
     let (start_x, start_y) = before.transform_point(0.0, 0.0);
     let (end_x, end_y) = after.transform_point(0.0, 0.0);
-    let font_size = text_state_before_advance.font_size.abs().max(1.0);
+    let font_size = font_size.abs().max(1.0);
     let local_rect = Rect {
         left: 0.0,
         top: font_size * 0.8,
@@ -91,18 +53,13 @@ pub(crate) fn glyph_bounds(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::text_state::TextState;
 
     #[test]
     fn glyph_bounds_cover_advanced_text_position() {
-        let before = TextState {
-            font_size: 12.0,
-            ..Default::default()
-        };
-        let mut after = before.clone();
-        after.matrix.post_translate(24.0, 0.0);
+        let before = Transform::identity();
+        let after = Transform::from_translate(24.0, 0.0);
 
-        let bounds = glyph_bounds(&before, &Transform::identity(), &after);
+        let bounds = glyph_bounds(&before, 12.0, &after);
 
         assert!(bounds.left <= 0.0);
         assert!(bounds.right >= 24.0);
@@ -110,16 +67,11 @@ mod tests {
     }
 
     #[test]
-    fn glyph_bounds_apply_ctm() {
-        let before = TextState {
-            font_size: 10.0,
-            ..Default::default()
-        };
-        let mut after = before.clone();
-        after.matrix.post_translate(10.0, 0.0);
-        let ctm = Transform::from_translate(5.0, 7.0);
+    fn glyph_bounds_apply_device_transform() {
+        let before = Transform::from_translate(5.0, 7.0);
+        let after = Transform::from_translate(15.0, 7.0);
 
-        let bounds = glyph_bounds(&before, &ctm, &after);
+        let bounds = glyph_bounds(&before, 10.0, &after);
 
         assert!(bounds.left <= 5.0);
         assert!(bounds.right >= 15.0);
@@ -127,22 +79,23 @@ mod tests {
     }
 
     #[test]
-    fn glyph_bounds_respect_flipped_canvas_ctm() {
-        let mut before = TextState {
-            font_size: 20.0,
-            ..Default::default()
-        };
-        before.matrix.post_translate(30.0, 40.0);
-        let mut after = before.clone();
-        after.matrix.post_translate(10.0, 0.0);
-        let ctm = Transform::from_row(1.0, 0.0, 0.0, -1.0, 0.0, 100.0);
+    fn glyph_bounds_respect_flipped_canvas_transform() {
+        let before = Transform::from_row(1.0, 0.0, 0.0, -1.0, 30.0, 60.0);
+        let after = Transform::from_row(1.0, 0.0, 0.0, -1.0, 40.0, 60.0);
 
-        let bounds = glyph_bounds(&before, &ctm, &after);
+        let bounds = glyph_bounds(&before, 20.0, &after);
 
-        let (_baseline_x, baseline_y) = before.matrix.transform_point(0.0, 0.0);
-        let baseline_y = 100.0 - baseline_y;
-        assert!(bounds.top < baseline_y);
-        assert!(bounds.bottom > baseline_y);
-        assert!(bounds.bottom - baseline_y < baseline_y - bounds.top);
+        assert!(bounds.top < 60.0);
+        assert!(bounds.bottom > 60.0);
+        assert!(bounds.bottom - 60.0 < 60.0 - bounds.top);
+    }
+
+    #[test]
+    fn glyph_bounds_normalize_rotated_advance() {
+        let before = Transform::from_row(0.0, 1.0, -1.0, 0.0, 20.0, 30.0);
+        let mut after = before;
+        after.post_translate(10.0, 0.0);
+
+        assert!(glyph_bounds(&before, 12.0, &after).is_valid());
     }
 }

--- a/crates/pdf-canvas/src/truetype_font_renderer.rs
+++ b/crates/pdf-canvas/src/truetype_font_renderer.rs
@@ -98,9 +98,8 @@ impl<B: CanvasBackend> TextRenderer for TrueTypeFontRenderer<'_, '_, B> {
         text: impl Iterator<Item = u16>,
     ) -> Result<(), crate::error::PdfCanvasError> {
         for char_code in text {
+            let text_glyph_start = self.canvas.text_glyph_start()?;
             let state = self.canvas.current_state()?;
-            let text_state_before_advance = state.text_state.clone();
-            let ctm = state.transform;
             let glyph_matrix_for_char = state
                 .text_state
                 .compose_glyph_matrix(self.glyph_base_transform, &state.transform);
@@ -144,8 +143,7 @@ impl<B: CanvasBackend> TextRenderer for TrueTypeFontRenderer<'_, '_, B> {
                     resolved_glyph_id,
                     self.units_per_em,
                 )?;
-            self.canvas
-                .record_text_glyph(char_code, &text_state_before_advance, &ctm)?;
+            self.canvas.record_text_glyph(char_code, text_glyph_start)?;
         }
         Ok(())
     }

--- a/crates/pdf-canvas/src/type1_font_renderer.rs
+++ b/crates/pdf-canvas/src/type1_font_renderer.rs
@@ -163,13 +163,12 @@ impl<B: CanvasBackend> TextRenderer for Type1FontRenderer<'_, '_, B> {
         } = self;
 
         for char_code in iter {
+            let text_glyph_start = canvas.text_glyph_start()?;
             let state = canvas.current_state()?;
-            let text_state_before_advance = state.text_state.clone();
-            let ctm = state.transform;
             let glyph_matrix = state
                 .text_state
                 .compose_glyph_matrix(*glyph_base_transform, &state.transform);
-            let glyph_name = text_state_before_advance.glyph_name(char_code);
+            let glyph_name = state.text_state.glyph_name(char_code);
 
             match &*font {
                 Type1RendererFont::OpenTypeCff {
@@ -194,7 +193,8 @@ impl<B: CanvasBackend> TextRenderer for Type1FontRenderer<'_, '_, B> {
                 }
                 Type1RendererFont::ClassicType1(classic_font) => {
                     let gid = classic_gid(classic_font, *is_cid, char_code, glyph_name);
-                    let pdf_width = text_state_before_advance
+                    let pdf_width = state
+                        .text_state
                         .font
                         .and_then(|font| font.glyph_width(char_code));
                     let mut pen = PdfPathPen::default();
@@ -216,7 +216,7 @@ impl<B: CanvasBackend> TextRenderer for Type1FontRenderer<'_, '_, B> {
                 }
             }
 
-            canvas.record_text_glyph(char_code, &text_state_before_advance, &ctm)?;
+            canvas.record_text_glyph(char_code, text_glyph_start)?;
         }
         Ok(())
     }

--- a/crates/pdf-canvas/src/type3_font_renderer.rs
+++ b/crates/pdf-canvas/src/type3_font_renderer.rs
@@ -41,9 +41,8 @@ impl<B: CanvasBackend> TextRenderer for Type3FontRenderer<'_, '_, B> {
         iter: impl Iterator<Item = u16>,
     ) -> Result<(), crate::error::PdfCanvasError> {
         for char_code_byte in iter {
+            let text_glyph_start = self.canvas.text_glyph_start()?;
             let state = self.canvas.current_state()?;
-            let text_state_before_advance = state.text_state.clone();
-            let ctm = state.transform;
 
             // Compute a relative glyph matrix (Tm × S × FontMatrix) without the CTM.
             // render_content_stream will post-concatenate this onto the current CTM,
@@ -112,7 +111,7 @@ impl<B: CanvasBackend> TextRenderer for Type3FontRenderer<'_, '_, B> {
 
                 text_state.advance_text_cursor(char_code_byte, glyph_width_x, glyph_width_y);
                 self.canvas
-                    .record_text_glyph(char_code_byte, &text_state_before_advance, &ctm)?;
+                    .record_text_glyph(char_code_byte, text_glyph_start)?;
             }
         }
 

--- a/crates/pdf-canvas/tests/type1_font_renderer.rs
+++ b/crates/pdf-canvas/tests/type1_font_renderer.rs
@@ -9,13 +9,15 @@ mod common;
 use std::{collections::HashMap, rc::Rc};
 
 use common::{content_stream, replay};
-use pdf_canvas::{pdf_canvas::PdfCanvas, recording_canvas::RecordingCanvas, text::TextCollector};
+use pdf_canvas::{pdf_canvas::PdfCanvas, recording_canvas::RecordingCanvas};
 use pdf_document::page::PdfPage;
 use pdf_font::{
     encoding::Encoding,
     font::Font,
     type1_font::{Type1Font, Type1FontProgramFormat},
 };
+use pdf_graphics::rect::Rect;
+use pdf_resources::form::FormXObject;
 use pdf_resources::{resource::Resource, resources::Resources};
 
 const EEXEC_SEED: u16 = 55665;
@@ -81,25 +83,101 @@ fn classic_type1_renderer_uses_pdf_widths_for_advance() {
     let stream = content_stream(1, b"BT /F1 10 Tf (AA) Tj ET");
     let page = PdfPage::default();
     let mut recording = RecordingCanvas::new(100.0, 100.0);
-    let mut text = TextCollector::new();
-
-    {
-        let mut canvas = PdfCanvas::new_with_text_sink(&mut recording, &page, None, &mut text)
-            .expect("canvas should build");
+    let glyphs = {
+        let mut canvas = PdfCanvas::new(&mut recording, &page, None)
+            .expect("canvas should build")
+            .with_text_recording();
         canvas
             .render_content_stream(&stream, None, None, Some(&resources), None)
             .expect("Type 1 text should render");
-    }
+        canvas.take_text_glyphs()
+    };
 
     let observer = replay(&recording);
     assert_eq!(observer.fill_colors.len(), 2);
 
-    let glyphs = text.glyphs();
     assert_eq!(glyphs.len(), 2);
     let first = glyphs.first().expect("first glyph should be collected");
     let second = glyphs.get(1).expect("second glyph should be collected");
+    assert_eq!(&*first.unicode, ['A'].as_slice());
     assert_eq!(first.bounds.left, 0.0);
     assert_eq!(first.bounds.right, 5.0);
     assert_eq!(second.bounds.left, 5.0);
     assert_eq!(second.bounds.right, 10.0);
+}
+
+#[test]
+fn classic_type1_renderer_does_not_collect_text_by_default() {
+    let font = Font::Type1(Type1Font {
+        font_file: minimal_classic_type1_font().into(),
+        program_format: Type1FontProgramFormat::ClassicType1,
+        widths: Some(HashMap::from([(65, 500.0)])),
+        encoding: Encoding::default(),
+        to_unicode: None,
+    });
+    let resources = Resources {
+        fonts: HashMap::from([(
+            "F1".to_string(),
+            Resource::Font {
+                font: Rc::new(font),
+                resources: None,
+            },
+        )]),
+        ..Default::default()
+    };
+    let stream = content_stream(1, b"BT /F1 10 Tf (A) Tj ET");
+    let page = PdfPage::default();
+    let mut recording = RecordingCanvas::new(100.0, 100.0);
+    let mut canvas = PdfCanvas::new(&mut recording, &page, None).expect("canvas should build");
+
+    canvas
+        .render_content_stream(&stream, None, None, Some(&resources), None)
+        .expect("Type 1 text should render");
+
+    assert!(canvas.take_text_glyphs().is_empty());
+}
+
+#[test]
+fn text_recording_includes_nested_form_xobjects() {
+    let font = Font::Type1(Type1Font {
+        font_file: minimal_classic_type1_font().into(),
+        program_format: Type1FontProgramFormat::ClassicType1,
+        widths: Some(HashMap::from([(65, 500.0)])),
+        encoding: Encoding::default(),
+        to_unicode: None,
+    });
+    let form_resources = Rc::new(Resources {
+        fonts: HashMap::from([(
+            "F1".to_string(),
+            Resource::Font {
+                font: Rc::new(font),
+                resources: None,
+            },
+        )]),
+        ..Default::default()
+    });
+    let form = FormXObject {
+        bbox: Rect::new(20.0, 20.0),
+        matrix: None,
+        resources: Some(form_resources),
+        content_stream: content_stream(2, b"BT /F1 10 Tf (A) Tj ET"),
+    };
+    let resources = Resources {
+        xobjects: HashMap::from([("Form".to_string(), Resource::from(form))]),
+        ..Default::default()
+    };
+    let stream = content_stream(1, b"/Form Do");
+    let page = PdfPage::default();
+    let mut recording = RecordingCanvas::new(100.0, 100.0);
+    let mut canvas = PdfCanvas::new(&mut recording, &page, None)
+        .expect("canvas should build")
+        .with_text_recording();
+
+    canvas
+        .render_content_stream(&stream, None, None, Some(&resources), None)
+        .expect("nested form text should render");
+
+    let glyphs = canvas.take_text_glyphs();
+    assert_eq!(glyphs.len(), 1);
+    assert_eq!(&*glyphs.first().expect("glyph should exist").unicode, ['A']);
 }

--- a/crates/pdf-renderer/Cargo.toml
+++ b/crates/pdf-renderer/Cargo.toml
@@ -10,3 +10,6 @@ pdf-document = { path = "../pdf-document" }
 pdf-canvas = { path = "../pdf-canvas" }
 pdf-graphics = { path = "../pdf-graphics" }
 thiserror = "2.0.12"
+
+[dev-dependencies]
+pdf-font = { path = "../pdf-font" }

--- a/crates/pdf-renderer/src/lib.rs
+++ b/crates/pdf-renderer/src/lib.rs
@@ -1,23 +1,45 @@
 use pdf_annotations::{AnnotationRenderError, AnnotationRenderer};
 use pdf_canvas::{
-    canvas_backend::{CanvasBackend, Image, Shader},
-    error::PdfCanvasError,
-    pdf_canvas::PdfCanvas,
+    canvas_backend::CanvasBackend, error::PdfCanvasError, pdf_canvas::PdfCanvas,
     recording_canvas::RecordingCanvas,
-    stroke_style::StrokeStyle,
 };
 use pdf_document::document::PdfDocument;
-use pdf_graphics::{
-    BlendMode, MaskMode, PathFillType, color::Color, pdf_path::PdfPath, rect::Rect,
-    transform::Transform,
-};
 use thiserror::Error;
 
 pub mod page_cache;
 pub mod text_selection;
 
 pub use page_cache::PageRecordingCache;
-pub use text_selection::PageTextLayout;
+pub use text_selection::{PageTextLayout, TextGlyph};
+
+/// A page's drawing commands and selectable text captured in one render pass.
+#[derive(Clone)]
+pub struct RecordedPage {
+    recording: RecordingCanvas,
+    text_layout: PageTextLayout,
+}
+
+impl RecordedPage {
+    /// Returns the recorded drawing commands.
+    pub fn recording(&self) -> &RecordingCanvas {
+        &self.recording
+    }
+
+    /// Returns the selectable text layout captured with the drawing commands.
+    pub fn text_layout(&self) -> &PageTextLayout {
+        &self.text_layout
+    }
+
+    /// Replays this page onto a concrete backend.
+    pub fn replay<B: CanvasBackend>(&self, backend: &mut B) -> Result<(), PdfCanvasError> {
+        self.recording.replay(backend)
+    }
+
+    /// Consumes this page and returns its drawing commands and text layout.
+    pub fn into_parts(self) -> (RecordingCanvas, PageTextLayout) {
+        (self.recording, self.text_layout)
+    }
+}
 
 /// Errors that can occur while rendering a PDF document onto a canvas backend.
 #[derive(Debug, Error)]
@@ -94,20 +116,45 @@ impl PdfRenderer {
         Ok(())
     }
 
-    /// Renders a PDF page into a [`RecordingCanvas`] for caching.
+    /// Renders a page and returns selectable text captured during the same pass.
+    pub fn render_with_text_layout<B: CanvasBackend>(
+        &self,
+        canvas_backend: &mut B,
+        page_index: usize,
+    ) -> Result<PageTextLayout, PdfRendererError> {
+        let page = self.page(page_index)?;
+        let canvas = PdfCanvas::new(canvas_backend, page, None)?.with_text_recording();
+        let mut annotation_renderer = AnnotationRenderer::new(canvas);
+        if let Some(cs) = &page.contents {
+            annotation_renderer.canvas_mut().render_content_stream(
+                cs,
+                None,
+                None,
+                page.resources.as_deref(),
+                None,
+            )?;
+        }
+        let glyphs = annotation_renderer.canvas_mut().take_text_glyphs();
+        if let Some(annotations) = &page.annotations {
+            annotation_renderer.render_all(annotations)?;
+        }
+        Ok(PageTextLayout::new(glyphs))
+    }
+
+    /// Renders a PDF page into combined drawing and text recordings for caching.
     ///
-    /// This records all drawing commands for a page into a resolution-independent
-    /// `RecordingCanvas` that can be replayed to any backend at any size.
+    /// Drawing commands and glyph bounds use the requested device dimensions;
+    /// replay the result only onto a backend with the same dimensions.
     pub fn render_page_to_recording(
         &self,
         page_index: usize,
         width: f32,
         height: f32,
-    ) -> Result<RecordingCanvas, PdfRendererError> {
+    ) -> Result<RecordedPage, PdfRendererError> {
         let page = self.page(page_index)?;
         let mut recording = RecordingCanvas::new(width, height);
-        {
-            let canvas = PdfCanvas::new(&mut recording, page, None)?;
+        let glyphs = {
+            let canvas = PdfCanvas::new(&mut recording, page, None)?.with_text_recording();
             let mut annotation_renderer = AnnotationRenderer::new(canvas);
             if let Some(cs) = &page.contents {
                 annotation_renderer.canvas_mut().render_content_stream(
@@ -118,38 +165,16 @@ impl PdfRenderer {
                     None,
                 )?;
             }
+            let glyphs = annotation_renderer.canvas_mut().take_text_glyphs();
             if let Some(annotations) = &page.annotations {
                 annotation_renderer.render_all(annotations)?;
             }
-        }
-        Ok(recording)
-    }
-
-    /// Extracts selectable page text for a specific rendered page size.
-    pub fn text_layout(
-        &self,
-        page_index: usize,
-        width: f32,
-        height: f32,
-    ) -> Result<PageTextLayout, PdfRendererError> {
-        let page = self.page(page_index)?;
-        let mut backend = NoopCanvasBackend { width, height };
-        let mut collector = pdf_canvas::text::TextCollector::new();
-        {
-            let mut canvas =
-                PdfCanvas::new_with_text_sink(&mut backend, page, None, &mut collector)?;
-            if let Some(cs) = &page.contents {
-                canvas.render_content_stream(cs, None, None, page.resources.as_deref(), None)?;
-            }
-        }
-
-        Ok(PageTextLayout::new(
-            collector
-                .into_glyphs()
-                .into_iter()
-                .map(Into::into)
-                .collect(),
-        ))
+            glyphs
+        };
+        Ok(RecordedPage {
+            recording,
+            text_layout: PageTextLayout::new(glyphs),
+        })
     }
 
     fn page(&self, page_index: usize) -> Result<&pdf_document::page::PdfPage, PdfRendererError> {
@@ -160,89 +185,7 @@ impl PdfRenderer {
     }
 }
 
-struct NoopCanvasBackend {
-    width: f32,
-    height: f32,
-}
-
-impl CanvasBackend for NoopCanvasBackend {
-    fn fill_path(
-        &mut self,
-        _path: &PdfPath,
-        _fill_type: PathFillType,
-        _color: Color,
-        _shader: &Option<Shader>,
-        _blend_mode: Option<BlendMode>,
-    ) -> Result<(), PdfCanvasError> {
-        Ok(())
-    }
-
-    fn stroke_path(
-        &mut self,
-        _path: &PdfPath,
-        _color: Color,
-        _line_width: f32,
-        _stroke_style: &StrokeStyle,
-        _shader: &Option<Shader>,
-        _blend_mode: Option<BlendMode>,
-    ) -> Result<(), PdfCanvasError> {
-        Ok(())
-    }
-
-    fn set_clip_region(
-        &mut self,
-        _path: &PdfPath,
-        _mode: PathFillType,
-    ) -> Result<(), PdfCanvasError> {
-        Ok(())
-    }
-
-    fn width(&self) -> f32 {
-        self.width
-    }
-
-    fn height(&self) -> f32 {
-        self.height
-    }
-
-    fn save(&mut self) -> Result<(), PdfCanvasError> {
-        Ok(())
-    }
-
-    fn restore(&mut self) -> Result<(), PdfCanvasError> {
-        Ok(())
-    }
-
-    fn draw_image_rect(
-        &mut self,
-        _image: &Image,
-        _blend_mode: Option<BlendMode>,
-        _dest_rect: Rect,
-        _image_rotation: Option<f32>,
-    ) -> Result<(), PdfCanvasError> {
-        Ok(())
-    }
-
-    fn begin_mask_layer(
-        &mut self,
-        _mask: &std::sync::Arc<RecordingCanvas>,
-        _transform: &Transform,
-        _mask_mode: MaskMode,
-    ) -> Result<(), PdfCanvasError> {
-        Ok(())
-    }
-
-    fn end_mask_layer(
-        &mut self,
-        _mask: &std::sync::Arc<RecordingCanvas>,
-        _transform: &Transform,
-        _mask_mode: MaskMode,
-    ) -> Result<(), PdfCanvasError> {
-        Ok(())
-    }
-}
-
-/// Renders a cached [`RecordingCanvas`] to a backend, or renders the page
+/// Renders a cached [`RecordedPage`] to a backend, or records the page
 /// directly if not cached.
 ///
 /// This is a convenience function that handles the cache lookup and fallback
@@ -272,7 +215,7 @@ pub fn render_page_cached<B: CanvasBackend>(
     let height = backend.height();
 
     // Check cache first
-    if let Some(recording) = cache.get(page_index) {
+    if let Some(recording) = cache.get(page_index, width, height) {
         // Replay directly from the cached recording.
         recording.replay(backend)?;
         return Ok(());

--- a/crates/pdf-renderer/src/page_cache.rs
+++ b/crates/pdf-renderer/src/page_cache.rs
@@ -1,199 +1,141 @@
-//! Page caching using [`RecordingCanvas`] for efficient re-rendering.
-//!
-//! This module provides an LRU cache for storing pre-recorded PDF page drawing
-//! commands. Since [`RecordingCanvas`] stores resolution-independent vector
-//! commands, cached pages can be replayed to any backend at any size without
-//! re-parsing the PDF content stream.
-//!
-//! # Example
-//!
-//! ```ignore
-//! use pdf_renderer::{page_cache::PageRecordingCache, PdfRenderer};
-//!
-//! let mut cache = PageRecordingCache::new(5); // Cache up to 5 pages
-//! let renderer = PdfRenderer::new(document);
-//!
-//! // Check if page is cached
-//! if let Some(recording) = cache.get(page_index) {
-//!     recording.replay(&mut backend)?;
-//! } else {
-//!     // Render to RecordingCanvas and cache it
-//!     let recording = renderer.render_page_to_recording(page_index, width, height)?;
-//!     cache.insert(page_index, recording.clone());
-//!     recording.replay(&mut backend)?;
-//! }
-//! ```
+//! Dimension-aware LRU caching for recorded pages and their text layouts.
 
-use pdf_canvas::recording_canvas::RecordingCanvas;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
-/// LRU cache for storing pre-recorded PDF page drawing commands.
+use crate::RecordedPage;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct CacheKey {
+    page_index: usize,
+    width_bits: u32,
+    height_bits: u32,
+}
+
+impl CacheKey {
+    fn new(page_index: usize, width: f32, height: f32) -> Self {
+        Self {
+            page_index,
+            width_bits: width.to_bits(),
+            height_bits: height.to_bits(),
+        }
+    }
+}
+
+/// LRU cache of combined drawing recordings and selectable text layouts.
 ///
-/// `PageRecordingCache` stores [`RecordingCanvas`] instances keyed by page index.
-/// When the cache reaches its capacity, the least recently accessed page is evicted.
-///
-/// # Benefits
-///
-/// - **Resolution-independent**: Cached commands can be replayed at any zoom level.
-/// - **Memory efficient**: Stores vector commands instead of pixel data.
-/// - **Backend agnostic**: Same cache works for Skia, FemtoVG, or any `CanvasBackend`.
+/// Entries are keyed by page index and exact canvas dimensions because both
+/// drawing commands and glyph bounds are stored in device coordinates.
 pub struct PageRecordingCache {
-    /// Maps page_index -> recorded drawing commands.
-    recordings: HashMap<usize, RecordingCanvas>,
-    /// Maximum number of pages to cache.
+    recordings: HashMap<CacheKey, RecordedPage>,
     max_entries: usize,
-    /// Access order for LRU eviction (most recent at back).
-    access_order: Vec<usize>,
+    access_order: VecDeque<CacheKey>,
 }
 
 impl PageRecordingCache {
-    /// Creates a new page cache with the specified capacity.
-    ///
-    /// # Parameters
-    ///
-    /// - `max_entries`: Maximum number of pages to keep in the cache.
-    ///   When this limit is reached, the least recently accessed page is evicted.
+    /// Creates a cache retaining at most `max_entries` page/size combinations.
     pub fn new(max_entries: usize) -> Self {
         Self {
             recordings: HashMap::with_capacity(max_entries),
             max_entries,
-            access_order: Vec::with_capacity(max_entries),
+            access_order: VecDeque::with_capacity(max_entries),
         }
     }
 
-    /// Gets a cached page recording, updating LRU order.
-    ///
-    /// # Parameters
-    ///
-    /// - `page_index`: Zero-based index of the page to retrieve.
-    ///
-    /// # Returns
-    ///
-    /// `Some(&RecordingCanvas)` if the page is cached, `None` otherwise.
-    pub fn get(&mut self, page_index: usize) -> Option<&RecordingCanvas> {
-        if self.recordings.contains_key(&page_index) {
-            // Move to end of access order (most recently used)
-            self.access_order.retain(|&i| i != page_index);
-            self.access_order.push(page_index);
-            self.recordings.get(&page_index)
-        } else {
-            None
+    /// Returns the recorded page for an exact page/size combination.
+    pub fn get(&mut self, page_index: usize, width: f32, height: f32) -> Option<&RecordedPage> {
+        let key = CacheKey::new(page_index, width, height);
+        if !self.recordings.contains_key(&key) {
+            return None;
         }
+        self.access_order.retain(|candidate| *candidate != key);
+        self.access_order.push_back(key);
+        self.recordings.get(&key)
     }
 
-    /// Inserts a recorded page into the cache.
-    ///
-    /// If the cache is at capacity, the least recently accessed page is evicted
-    /// before inserting the new one.
-    ///
-    /// # Parameters
-    ///
-    /// - `page_index`: Zero-based index of the page.
-    /// - `recording`: The recorded drawing commands for the page.
-    pub fn insert(&mut self, page_index: usize, recording: RecordingCanvas) {
-        // A zero-capacity cache never stores anything.
+    /// Inserts a recorded page, deriving its cache dimensions from the recording.
+    pub fn insert(&mut self, page_index: usize, recorded_page: RecordedPage) {
         if self.max_entries == 0 {
             return;
         }
-
-        // If already present, just update the recording and access order
-        if self.recordings.contains_key(&page_index) {
-            self.access_order.retain(|&i| i != page_index);
-            self.access_order.push(page_index);
-            self.recordings.insert(page_index, recording);
-            return;
+        let key = CacheKey::new(
+            page_index,
+            recorded_page.recording().width,
+            recorded_page.recording().height,
+        );
+        self.access_order.retain(|candidate| *candidate != key);
+        while self.recordings.len() >= self.max_entries && !self.recordings.contains_key(&key) {
+            let Some(oldest) = self.access_order.pop_front() else {
+                break;
+            };
+            self.recordings.remove(&oldest);
         }
-
-        // Evict oldest entries if at capacity
-        while self.recordings.len() >= self.max_entries && !self.access_order.is_empty() {
-            if let Some(oldest) = self.access_order.first().copied() {
-                self.recordings.remove(&oldest);
-                self.access_order.remove(0);
-            }
-        }
-
-        self.recordings.insert(page_index, recording);
-        self.access_order.push(page_index);
+        self.access_order.push_back(key);
+        self.recordings.insert(key, recorded_page);
     }
 
-    /// Removes a specific page from the cache.
-    ///
-    /// # Parameters
-    ///
-    /// - `page_index`: Zero-based index of the page to remove.
-    ///
-    /// # Returns
-    ///
-    /// The removed `RecordingCanvas` if it was cached, `None` otherwise.
-    pub fn remove(&mut self, page_index: usize) -> Option<RecordingCanvas> {
-        self.access_order.retain(|&i| i != page_index);
-        self.recordings.remove(&page_index)
+    /// Removes every cached size for `page_index`.
+    pub fn remove(&mut self, page_index: usize) -> Vec<RecordedPage> {
+        let keys: Vec<CacheKey> = self
+            .recordings
+            .keys()
+            .filter(|key| key.page_index == page_index)
+            .copied()
+            .collect();
+        self.access_order.retain(|key| key.page_index != page_index);
+        keys.into_iter()
+            .filter_map(|key| self.recordings.remove(&key))
+            .collect()
     }
 
     /// Clears all cached pages.
-    ///
-    /// Call this when loading a new document or when memory needs to be freed.
     pub fn clear(&mut self) {
         self.recordings.clear();
         self.access_order.clear();
     }
 
-    /// Returns the number of pages currently in the cache.
+    /// Returns the number of cached page/size combinations.
     pub fn len(&self) -> usize {
         self.recordings.len()
     }
 
-    /// Returns `true` if the cache is empty.
+    /// Returns whether the cache is empty.
     pub fn is_empty(&self) -> bool {
         self.recordings.is_empty()
     }
 
-    /// Returns `true` if the specified page is cached.
-    ///
-    /// Note: This does not update the LRU order. Use [`get`](Self::get) if you
-    /// intend to access the cached data.
+    /// Returns whether any size of `page_index` is cached.
     pub fn contains(&self, page_index: usize) -> bool {
-        self.recordings.contains_key(&page_index)
+        self.recordings
+            .keys()
+            .any(|key| key.page_index == page_index)
     }
 
-    /// Returns page indices that should be prefetched for smooth navigation.
-    ///
-    /// Given the current page, this returns adjacent pages that are not yet
-    /// cached, prioritized by distance from the current page.
-    ///
-    /// # Parameters
-    ///
-    /// - `current_page`: The currently visible page index.
-    /// - `page_count`: Total number of pages in the document.
-    ///
-    /// # Returns
-    ///
-    /// A vector of page indices to prefetch, ordered by priority.
+    /// Returns uncached neighboring page indices in prefetch order.
     pub fn pages_to_prefetch(&self, current_page: usize, page_count: usize) -> Vec<usize> {
         let mut pages = Vec::new();
-
-        // Prioritize: next page, previous page, then further pages
-        for offset in [1i32, -1, 2, -2, 3, -3] {
-            let idx = current_page as i32 + offset;
-            if idx >= 0 && (idx as usize) < page_count {
-                let page_idx = idx as usize;
-                if !self.recordings.contains_key(&page_idx) {
-                    pages.push(page_idx);
-                }
+        for offset in [1_usize, 2, 3] {
+            if let Some(next) = current_page.checked_add(offset)
+                && next < page_count
+                && !self.contains(next)
+            {
+                pages.push(next);
+            }
+            if let Some(previous) = current_page.checked_sub(offset)
+                && !self.contains(previous)
+            {
+                pages.push(previous);
             }
         }
-
         pages
     }
 
-    /// Returns the maximum capacity of the cache.
+    /// Returns the maximum number of retained entries.
     pub fn capacity(&self) -> usize {
         self.max_entries
     }
 }
 
 impl Default for PageRecordingCache {
-    /// Creates a cache with a default capacity of 5 pages.
     fn default() -> Self {
         Self::new(5)
     }
@@ -202,73 +144,62 @@ impl Default for PageRecordingCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::PageTextLayout;
+    use pdf_canvas::recording_canvas::RecordingCanvas;
 
-    #[test]
-    fn test_cache_insert_and_get() {
-        let mut cache = PageRecordingCache::new(3);
-        let recording = RecordingCanvas::new(100.0, 100.0);
-
-        cache.insert(0, recording.clone());
-        assert!(cache.contains(0));
-        assert!(cache.get(0).is_some());
+    fn recorded(width: f32, height: f32) -> RecordedPage {
+        RecordedPage {
+            recording: RecordingCanvas::new(width, height),
+            text_layout: PageTextLayout::default(),
+        }
     }
 
     #[test]
-    fn test_cache_lru_eviction() {
+    fn cache_keys_entries_by_dimensions() {
+        let mut cache = PageRecordingCache::new(3);
+        cache.insert(0, recorded(100.0, 100.0));
+
+        assert!(cache.get(0, 100.0, 100.0).is_some());
+        assert!(cache.get(0, 200.0, 100.0).is_none());
+    }
+
+    #[test]
+    fn cache_evicts_least_recent_entry() {
         let mut cache = PageRecordingCache::new(2);
-
-        cache.insert(0, RecordingCanvas::new(100.0, 100.0));
-        cache.insert(1, RecordingCanvas::new(100.0, 100.0));
-
-        // Access page 0 to make it more recent
-        let _ = cache.get(0);
-
-        // Insert page 2 - should evict page 1 (least recently used)
-        cache.insert(2, RecordingCanvas::new(100.0, 100.0));
+        cache.insert(0, recorded(100.0, 100.0));
+        cache.insert(1, recorded(100.0, 100.0));
+        let _ = cache.get(0, 100.0, 100.0);
+        cache.insert(2, recorded(100.0, 100.0));
 
         assert!(cache.contains(0));
-        assert!(!cache.contains(1)); // Evicted
+        assert!(!cache.contains(1));
         assert!(cache.contains(2));
     }
 
     #[test]
-    fn test_pages_to_prefetch() {
-        let mut cache = PageRecordingCache::new(5);
-        cache.insert(5, RecordingCanvas::new(100.0, 100.0));
-
-        let to_prefetch = cache.pages_to_prefetch(5, 10);
-
-        // Should suggest pages 6, 4, 7, 3, 8, 2 (adjacent pages not in cache)
-        assert!(to_prefetch.contains(&6));
-        assert!(to_prefetch.contains(&4));
-        assert!(!to_prefetch.contains(&5)); // Already cached
-    }
-
-    #[test]
-    fn test_zero_capacity_cache_is_always_empty() {
-        let mut cache = PageRecordingCache::new(0);
-
-        cache.insert(0, RecordingCanvas::new(100.0, 100.0));
-        cache.insert(1, RecordingCanvas::new(200.0, 200.0));
-
-        assert!(cache.is_empty());
-        assert!(!cache.contains(0));
-        assert!(!cache.contains(1));
-        assert_eq!(cache.len(), 0);
-        assert!(cache.get(0).is_none());
-    }
-
-    #[test]
-    fn test_cache_clear() {
+    fn remove_drops_every_size_for_page() {
         let mut cache = PageRecordingCache::new(3);
-        cache.insert(0, RecordingCanvas::new(100.0, 100.0));
-        cache.insert(1, RecordingCanvas::new(100.0, 100.0));
+        cache.insert(0, recorded(100.0, 100.0));
+        cache.insert(0, recorded(200.0, 100.0));
 
-        assert_eq!(cache.len(), 2);
-
-        cache.clear();
-
-        assert!(cache.is_empty());
+        assert_eq!(cache.remove(0).len(), 2);
         assert!(!cache.contains(0));
+    }
+
+    #[test]
+    fn zero_capacity_cache_is_always_empty() {
+        let mut cache = PageRecordingCache::new(0);
+        cache.insert(0, recorded(100.0, 100.0));
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn pages_to_prefetch_skip_cached_pages() {
+        let mut cache = PageRecordingCache::new(5);
+        cache.insert(5, recorded(100.0, 100.0));
+        let pages = cache.pages_to_prefetch(5, 10);
+        assert!(pages.contains(&6));
+        assert!(pages.contains(&4));
+        assert!(!pages.contains(&5));
     }
 }

--- a/crates/pdf-renderer/src/text_selection.rs
+++ b/crates/pdf-renderer/src/text_selection.rs
@@ -1,18 +1,11 @@
 use pdf_graphics::rect::Rect;
 
+pub use pdf_canvas::text::TextGlyph;
+
 /// Ordered text layout for one rendered page size.
 #[derive(Debug, Clone, Default)]
 pub struct PageTextLayout {
     glyphs: Vec<TextGlyph>,
-}
-
-/// One selectable text span in device coordinates.
-#[derive(Debug, Clone, PartialEq)]
-pub struct TextGlyph {
-    /// Unicode text represented by this span.
-    pub text: String,
-    /// Axis-aligned device-space bounds.
-    pub bounds: Rect,
 }
 
 /// A hit-testable text position.
@@ -91,7 +84,7 @@ impl PageTextLayout {
             {
                 result.push('\n');
             }
-            result.push_str(&glyph.text);
+            result.extend(glyph.unicode.iter());
             previous = Some(glyph);
         }
 
@@ -123,15 +116,6 @@ impl TextSelection {
     /// Returns the inclusive glyph-index range.
     pub fn range(self) -> (usize, usize) {
         (self.start, self.end)
-    }
-}
-
-impl From<pdf_canvas::text::TextGlyph> for TextGlyph {
-    fn from(value: pdf_canvas::text::TextGlyph) -> Self {
-        Self {
-            text: value.text,
-            bounds: value.bounds,
-        }
     }
 }
 
@@ -169,10 +153,15 @@ fn is_new_line(previous: &TextGlyph, current: &TextGlyph) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pdf_font::char_vec::CharVec;
 
     fn glyph(text: &str, left: f32, top: f32, right: f32, bottom: f32) -> TextGlyph {
+        let mut unicode = CharVec::new();
+        for character in text.chars() {
+            unicode.push(character);
+        }
         TextGlyph {
-            text: text.to_string(),
+            unicode,
             bounds: Rect {
                 left,
                 top,
@@ -239,5 +228,15 @@ mod tests {
             .expect("selection should exist");
 
         assert_eq!(layout.selected_text(selection), "a\nb");
+    }
+
+    #[test]
+    fn selected_text_preserves_multi_scalar_glyphs() {
+        let layout = PageTextLayout::new(vec![glyph("fi", 0.0, 0.0, 10.0, 10.0)]);
+        let selection = layout
+            .selection_from_indices(0, 0)
+            .expect("selection should exist");
+
+        assert_eq!(layout.selected_text(selection), "fi");
     }
 }

--- a/examples/emscripten.rs
+++ b/examples/emscripten.rs
@@ -10,7 +10,7 @@ use pdf_graphics::point::Point;
 use pdf_graphics_skia::gpu_state::SkiaGpuState;
 use pdf_graphics_skia::skia_canvas_backend::SkiaCanvasBackend;
 use pdf_renderer::{PageRecordingCache, PageTextLayout, PdfRenderer, render_page_cached};
-use std::{cell::RefCell, collections::HashMap, time::Instant};
+use std::{cell::RefCell, time::Instant};
 
 const INTERACTION_CONSUMED: i32 = 1;
 const INTERACTION_REDRAW: i32 = 2;
@@ -35,10 +35,8 @@ thread_local! {
     static CURRENT_RENDERER: RefCell<Option<PdfRenderer>> = const { RefCell::new(None) };
     static GPU_STATE: RefCell<Option<SkiaGpuState>> = const { RefCell::new(None) };
     /// Page recording cache for efficient re-rendering.
-    /// Caches up to 5 pages as resolution-independent drawing commands.
+    /// Caches up to 5 dimension-specific pages with drawing commands and text layout.
     static PAGE_CACHE: RefCell<PageRecordingCache> = RefCell::new(PageRecordingCache::new(5));
-    static TEXT_LAYOUT_CACHE: RefCell<HashMap<TextLayoutCacheKey, PageTextLayout>> =
-        RefCell::new(HashMap::new());
     static TEXT_SELECTION_RECTS: RefCell<Vec<f32>> = const { RefCell::new(Vec::new()) };
     static SELECTED_TEXT: RefCell<Vec<u8>> = const { RefCell::new(Vec::new()) };
     static ANNOTATION_CONTROLLER: RefCell<AnnotationController> =
@@ -46,17 +44,7 @@ thread_local! {
     static ANNOTATION_PAGE_INDEX: RefCell<Option<usize>> = const { RefCell::new(None) };
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct TextLayoutCacheKey {
-    page_index: usize,
-    width: i32,
-    height: i32,
-}
-
 fn clear_text_selection_state() {
-    TEXT_LAYOUT_CACHE.with(|cache| {
-        cache.borrow_mut().clear();
-    });
     TEXT_SELECTION_RECTS.with(|rects| {
         rects.borrow_mut().clear();
     });
@@ -132,26 +120,23 @@ fn with_text_layout<R>(
             return None;
         }
 
-        TEXT_LAYOUT_CACHE.with(|cache| {
+        PAGE_CACHE.with(|cache| {
             let mut cache = cache.borrow_mut();
-            let key = TextLayoutCacheKey {
-                page_index,
-                width,
-                height,
-            };
-
-            if let std::collections::hash_map::Entry::Vacant(e) = cache.entry(key) {
-                let layout = match renderer.text_layout(page_index, width as f32, height as f32) {
-                    Ok(layout) => layout,
+            let width = width as f32;
+            let height = height as f32;
+            if cache.get(page_index, width, height).is_none() {
+                let recorded = match renderer.render_page_to_recording(page_index, width, height) {
+                    Ok(recorded) => recorded,
                     Err(e) => {
                         eprintln!("Text layout error: {e:?}");
                         return None;
                     }
                 };
-                e.insert(layout);
+                cache.insert(page_index, recorded);
             }
-
-            cache.get(&key).map(f)
+            cache
+                .get(page_index, width, height)
+                .map(|recorded| f(recorded.text_layout()))
         })
     })
 }
@@ -457,6 +442,7 @@ pub extern "C" fn sk_clear_cache() {
 /// Clears cached text layouts and temporary selection buffers.
 #[unsafe(export_name = "sk_clear_text_layout_cache")]
 pub extern "C" fn sk_clear_text_layout_cache() {
+    PAGE_CACHE.with(|cache| cache.borrow_mut().clear());
     clear_text_selection_state();
 }
 

--- a/examples/skia.rs
+++ b/examples/skia.rs
@@ -133,7 +133,6 @@ impl Application {
         let size = self.window.inner_size();
         let width = size.width as f32;
         let height = size.height as f32;
-        self.ensure_text_layout(width, height)?;
         self.surface.canvas().clear(SkiaColor::WHITE);
 
         if self.renderer.document().page_count() > 0 {
@@ -148,7 +147,14 @@ impl Application {
                 width,
                 height,
             };
-            self.renderer.render(&mut backend, self.current_page)?;
+            if self.text_layout.is_none() {
+                self.text_layout = Some(
+                    self.renderer
+                        .render_with_text_layout(&mut backend, self.current_page)?,
+                );
+            } else {
+                self.renderer.render(&mut backend, self.current_page)?;
+            }
             draw_selection_rects(&mut backend, &selection_rects)?;
             if let Some(page) = self.renderer.document().get_page(self.current_page)
                 && let Some(viewport) = AnnotationViewport::from_page(page, width, height)
@@ -170,7 +176,9 @@ impl Application {
         }
         self.text_layout = Some(
             self.renderer
-                .text_layout(self.current_page, width, height)?,
+                .render_page_to_recording(self.current_page, width, height)?
+                .text_layout()
+                .clone(),
         );
         Ok(())
     }


### PR DESCRIPTION
Record selectable glyph metadata in an opt-in PdfCanvas buffer without cloning text state or allocating a String for every glyph.

Return drawing commands and page text layout together so renderer caches and selection consumers reuse a single content-stream render.

Make cached recordings dimension-aware, migrate native and WASM callers, and add regression tests and a text-heavy benchmark.