### PR TITLE
pdf-image: unify raster image decoding

### DIFF
--- a/crates/pdf-annotation-form/tests/form.rs
+++ b/crates/pdf-annotation-form/tests/form.rs
@@ -14,13 +14,13 @@ use pdf_annotation_form::{
 };
 use pdf_annotation_types::{Annotation, AnnotationKind, WidgetFieldValue};
 use pdf_canvas::{
-    canvas_backend::{CanvasBackend, Image, Shader},
+    canvas_backend::{CanvasBackend, Shader},
     recording_canvas::RecordingCanvas,
     stroke_style::StrokeStyle,
 };
 use pdf_document::reader::PdfReader;
 use pdf_graphics::{
-    BlendMode, MaskMode, PathFillType, color::Color, pdf_path::PathVerb, pdf_path::PdfPath,
+    BlendMode, Image, MaskMode, PathFillType, color::Color, pdf_path::PathVerb, pdf_path::PdfPath,
     point::Point, rect::Rect, transform::Transform,
 };
 

--- a/crates/pdf-annotations/tests/render.rs
+++ b/crates/pdf-annotations/tests/render.rs
@@ -5,14 +5,14 @@ use std::sync::Arc;
 use pdf_annotation_types::Annotation;
 use pdf_annotations::{AnnotationAppearanceState, AnnotationRenderer};
 use pdf_canvas::{
-    canvas_backend::{CanvasBackend, Image, Shader},
+    canvas_backend::{CanvasBackend, Shader},
     pdf_canvas::PdfCanvas,
     recording_canvas::RecordingCanvas,
     stroke_style::StrokeStyle,
 };
 use pdf_document::reader::PdfReader;
 use pdf_graphics::{
-    BlendMode, MaskMode, PathFillType, color::Color, pdf_path::PathVerb, pdf_path::PdfPath,
+    BlendMode, Image, MaskMode, PathFillType, color::Color, pdf_path::PathVerb, pdf_path::PdfPath,
     rect::Rect, transform::Transform,
 };
 

--- a/crates/pdf-canvas/src/canvas_backend.rs
+++ b/crates/pdf-canvas/src/canvas_backend.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use pdf_graphics::{
-    BlendMode, MaskMode, PathFillType, PixelFormat, color::Color, pdf_path::PdfPath, rect::Rect,
+    BlendMode, Image, MaskMode, PathFillType, color::Color, pdf_path::PdfPath, rect::Rect,
     transform::Transform,
 };
 use pdf_shading::paint::ShadingPaint;
@@ -26,22 +26,6 @@ pub enum Shader {
         /// The vertical spacing between tiles.
         y_step: f32,
     },
-}
-
-/// Represents an image resource for drawing or pattern tiling in the PDF canvas backend.
-///
-/// The `Image` struct encapsulates raw image data, dimensions, encoding, and optional
-/// transformation or masking information.
-#[derive(Clone)]
-pub struct Image {
-    /// Shared raw image data.
-    pub data: Arc<Vec<u8>>,
-    /// The width of the image in pixels.
-    pub width: usize,
-    /// The height of the image in pixels.
-    pub height: usize,
-    /// The pixel format of the image data.
-    pub pixel_format: PixelFormat,
 }
 
 /// A low-level drawing backend for rendering PDF graphics.

--- a/crates/pdf-canvas/src/canvas_external_object_ops.rs
+++ b/crates/pdf-canvas/src/canvas_external_object_ops.rs
@@ -8,19 +8,12 @@
 //! between PDF image space (top-left origin, Y down) and PDF user space
 //! (bottom-left origin, Y up).
 
-use std::sync::Arc;
-
 use pdf_content_stream_operators::pdf_operator_backend::XObjectOps;
-use pdf_graphics::{rect::Rect, transform::Transform};
-use pdf_image::{ImageXObject, InlineImage};
-use pdf_object::object_resolver::PassthroughResolver;
+use pdf_graphics::{Image, rect::Rect, transform::Transform};
+use pdf_image::{InlineImage, decode_inline_image};
 use pdf_resources::resource::Resource;
 
-use crate::{
-    canvas_backend::{CanvasBackend, Image},
-    error::PdfCanvasError,
-    pdf_canvas::PdfCanvas,
-};
+use crate::{canvas_backend::CanvasBackend, error::PdfCanvasError, pdf_canvas::PdfCanvas};
 
 /// Tolerance in degrees for detecting right-angle rotations.
 const ROTATION_TOLERANCE_DEGREES: f32 = 1e-3;
@@ -103,7 +96,7 @@ impl<B: CanvasBackend> XObjectOps for PdfCanvas<'_, B> {
     }
 
     fn paint_inline_image(&mut self, image: &InlineImage) -> Result<(), Self::ErrorType> {
-        let decoded = ImageXObject::decode_inline_image(image, &PassthroughResolver, None)
+        let decoded = decode_inline_image(image, None)
             .map_err(|e| PdfCanvasError::InvalidImageData(e.to_string()))?;
 
         self.render_decoded_image(&decoded, true)
@@ -112,16 +105,13 @@ impl<B: CanvasBackend> XObjectOps for PdfCanvas<'_, B> {
 
 impl<B: CanvasBackend> PdfCanvas<'_, B> {
     /// Renders an image XObject to the canvas.
-    pub(crate) fn render_image_xobject(
-        &mut self,
-        image: &ImageXObject,
-    ) -> Result<(), PdfCanvasError> {
+    pub(crate) fn render_image_xobject(&mut self, image: &Image) -> Result<(), PdfCanvasError> {
         self.render_decoded_image(image, false)
     }
 
     fn render_decoded_image(
         &mut self,
-        image: &ImageXObject,
+        image: &Image,
         inline_image: bool,
     ) -> Result<(), PdfCanvasError> {
         let transform = self.current_state()?.transform;
@@ -129,28 +119,13 @@ impl<B: CanvasBackend> PdfCanvas<'_, B> {
         let transform = generate_image_orientation_matrix(transform);
         let dest_rect = Self::compute_destination_rect(&transform, rotation_degrees);
 
-        let rendered_image = Image {
-            data: Arc::clone(&image.data),
-            width: image.width,
-            height: image.height,
-            pixel_format: image.pixel_format,
-        };
-
         let blend_mode = self.current_state()?.blend_mode.clone();
         if inline_image {
-            self.canvas.draw_inline_image(
-                &rendered_image,
-                blend_mode,
-                dest_rect,
-                Some(rotation_degrees),
-            )
+            self.canvas
+                .draw_inline_image(image, blend_mode, dest_rect, Some(rotation_degrees))
         } else {
-            self.canvas.draw_image_rect(
-                &rendered_image,
-                blend_mode,
-                dest_rect,
-                Some(rotation_degrees),
-            )
+            self.canvas
+                .draw_image_rect(image, blend_mode, dest_rect, Some(rotation_degrees))
         }
     }
 

--- a/crates/pdf-canvas/src/recording_canvas.rs
+++ b/crates/pdf-canvas/src/recording_canvas.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use crate::{
-    canvas_backend::{CanvasBackend, Image as BackendImage, Shader},
+    canvas_backend::{CanvasBackend, Shader},
     error::PdfCanvasError,
     stroke_style::StrokeStyle,
 };
 use pdf_graphics::{
-    BlendMode, MaskMode, PathFillType, color::Color, pdf_path::PdfPath, rect::Rect,
-    transform::Transform,
+    BlendMode, Image as BackendImage, MaskMode, PathFillType, color::Color, pdf_path::PdfPath,
+    rect::Rect, transform::Transform,
 };
 
 /// Enum representing each drawing command that can be recorded.

--- a/crates/pdf-canvas/tests/common/mod.rs
+++ b/crates/pdf-canvas/tests/common/mod.rs
@@ -3,15 +3,15 @@
 use std::sync::Arc;
 
 use pdf_canvas::{
-    canvas_backend::{CanvasBackend, Image, Shader},
+    canvas_backend::{CanvasBackend, Shader},
     error::PdfCanvasError,
     recording_canvas::RecordingCanvas,
     stroke_style::StrokeStyle,
 };
 use pdf_content_stream::{ContentStream, ContentStreamIdAllocator};
 use pdf_graphics::{
-    BlendMode, MaskMode, PathFillType, PixelFormat, color::Color, pdf_path::PdfPath, rect::Rect,
-    transform::Transform,
+    BlendMode, Image, MaskMode, PathFillType, PixelFormat, color::Color, pdf_path::PdfPath,
+    rect::Rect, transform::Transform,
 };
 use pdf_object::{
     dictionary::Dictionary, object_resolver::PassthroughResolver, object_variant::ObjectVariant,

--- a/crates/pdf-canvas/tests/pdf_canvas.rs
+++ b/crates/pdf-canvas/tests/pdf_canvas.rs
@@ -11,7 +11,9 @@ use pdf_content_stream_operators::variants::PdfOperatorVariant;
 use pdf_document::page::PdfPage;
 use pdf_graphics::{BlendMode, PixelFormat, rect::Rect};
 use pdf_image::InlineImage;
-use pdf_object::{dictionary::Dictionary, object_variant::ObjectVariant};
+use pdf_object::{
+    dictionary::Dictionary, object_resolver::PassthroughResolver, object_variant::ObjectVariant,
+};
 use pdf_resources::{
     external_graphics_state::{ExternalGraphicsState, ExternalGraphicsStateKey},
     form::FormXObject,
@@ -81,7 +83,9 @@ fn inline_image() -> InlineImage {
             ("W".to_string(), ObjectVariant::Integer(4)),
         ])),
         vec![0b1010_0000],
+        &PassthroughResolver,
     )
+    .expect("inline image should be constructed")
 }
 
 #[test]
@@ -158,11 +162,11 @@ fn unavailable_image_xobject_is_a_no_op() {
 
 #[test]
 fn inline_image_render_path_matches_image_xobject_path() {
-    let image = pdf_image::ImageXObject::decode_normalized_image(
+    let image = pdf_image::decode_normalized_image(
         &image_dictionary(),
         Arc::new(vec![0b1010_0000]),
         &pdf_object::object_resolver::PassthroughResolver,
-        &None,
+        None,
     )
     .expect("image XObject should decode");
     let graphics_state = Resource::ExternalGraphicsState(Rc::new(ExternalGraphicsState {
@@ -180,7 +184,7 @@ fn inline_image_render_path_matches_image_xobject_path() {
     let mut inline_stream = content_stream(2, b"/GS gs 2 0 0 3 10 20 cm");
     inline_stream
         .operators
-        .push(PdfOperatorVariant::InlineImage(inline_image()));
+        .push(PdfOperatorVariant::InlineImage(Rc::new(inline_image())));
 
     let mut xobject_recording = RecordingCanvas::new(100.0, 100.0);
     render(&mut xobject_recording, &xobject_stream, Some(&resources))

--- a/crates/pdf-content-stream-operators/src/recording_pdf_operator_backend.rs
+++ b/crates/pdf-content-stream-operators/src/recording_pdf_operator_backend.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pdf_graphics::LineCap;
 use pdf_graphics::LineJoin;
 use pdf_graphics::TextRenderingMode;
@@ -189,7 +191,7 @@ pub enum RecordedOperation {
         xobject_name: String,
     },
     PaintInlineImage {
-        image: InlineImage,
+        data: Arc<Vec<u8>>,
     },
     PaintShading {
         shading_name: String,
@@ -685,7 +687,7 @@ impl XObjectOps for RecordingBackend {
 
     fn paint_inline_image(&mut self, image: &InlineImage) -> Result<(), Self::ErrorType> {
         self.operations.push(RecordedOperation::PaintInlineImage {
-            image: image.clone(),
+            data: image.shared_data(),
         });
         Ok(())
     }

--- a/crates/pdf-content-stream-operators/src/variants.rs
+++ b/crates/pdf-content-stream-operators/src/variants.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use pdf_image::InlineImage;
 
 use crate::compatibility_operators::{BeginCompatibility, EndCompatibility};
@@ -19,7 +21,7 @@ use crate::{
     xobject_and_image_operators::*,
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum PdfOperatorVariant {
     LineTo(LineTo),
     MoveTo(MoveTo),
@@ -77,7 +79,7 @@ pub enum PdfOperatorVariant {
     SetTextRise(SetTextRise),
     InvokeXObject(InvokeXObject),
     BeginCompatibility(BeginCompatibility),
-    InlineImage(InlineImage),
+    InlineImage(Rc<InlineImage>),
     EndCompatibility(EndCompatibility),
     PaintShading(PaintShading),
     SetCharWidthAndBoundingBox(SetCharWidthAndBoundingBox),

--- a/crates/pdf-content-stream-operators/src/xobject_and_image_operators.rs
+++ b/crates/pdf-content-stream-operators/src/xobject_and_image_operators.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use pdf_image::InlineImage;
 use pdf_object::object_resolver::PassthroughResolver;
 use pdf_parser::parser::PdfParser;
@@ -52,7 +54,7 @@ impl PdfOperator for InlineImage {
         parser: &mut PdfParser<'a>,
     ) -> Result<Option<PdfOperatorVariant>, PdfOperatorError> {
         let image = parser.parse_inline_image(&PassthroughResolver)?;
-        Ok(Some(PdfOperatorVariant::InlineImage(image)))
+        Ok(Some(PdfOperatorVariant::InlineImage(Rc::new(image))))
     }
 
     fn call<T: PdfOperatorBackend>(&self, backend: &mut T) -> Result<(), BackendError<T>> {
@@ -65,7 +67,9 @@ mod tests {
     use std::collections::BTreeMap;
 
     use pdf_image::InlineImage;
-    use pdf_object::dictionary::Dictionary;
+    use pdf_object::{
+        dictionary::Dictionary, object_resolver::PassthroughResolver, object_variant::ObjectVariant,
+    };
 
     use crate::{
         operator_trait::PdfOperator,
@@ -74,7 +78,17 @@ mod tests {
 
     #[test]
     fn inline_image_call_dispatches_to_backend_hook() {
-        let image = InlineImage::new(Dictionary::new(BTreeMap::new()), vec![0x01, 0x02]);
+        let image = InlineImage::new(
+            Dictionary::new(BTreeMap::from([
+                ("BPC".to_string(), ObjectVariant::Integer(8)),
+                ("CS".to_string(), ObjectVariant::Name(b"G".to_vec())),
+                ("H".to_string(), ObjectVariant::Integer(1)),
+                ("W".to_string(), ObjectVariant::Integer(2)),
+            ])),
+            vec![0x01, 0x02],
+            &PassthroughResolver,
+        )
+        .expect("unfiltered inline image should be constructed");
         let mut backend = RecordingBackend::default();
 
         image
@@ -84,7 +98,7 @@ mod tests {
         assert_eq!(
             backend.operations,
             vec![RecordedOperation::PaintInlineImage {
-                image: image.clone()
+                data: image.shared_data()
             }]
         );
     }

--- a/crates/pdf-content-stream/src/content_stream.rs
+++ b/crates/pdf-content-stream/src/content_stream.rs
@@ -140,10 +140,8 @@ mod tests {
     use crate::ContentStreamIdAllocator;
     use pdf_content_stream_operators::{
         TextElement,
-        compatibility_operators::{BeginCompatibility, EndCompatibility},
         error::PdfOperatorError,
-        graphics_state_operators::{RestoreGraphicsState, SaveGraphicsState},
-        path_operators::{LineTo, MoveTo},
+        graphics_state_operators::SaveGraphicsState,
         recording_pdf_operator_backend::{RecordedOperation, RecordingBackend},
         text_showing_operators::ShowTextArray,
         variants::PdfOperatorVariant,
@@ -162,6 +160,16 @@ mod tests {
             Box::new(Dictionary::new(BTreeMap::new())),
             data.to_vec(),
         )
+    }
+
+    fn recorded_operations(operators: &[PdfOperatorVariant]) -> Vec<RecordedOperation> {
+        let mut backend = RecordingBackend::default();
+        for operator in operators {
+            operator
+                .call(&mut backend)
+                .expect("operator should dispatch");
+        }
+        backend.operations
     }
 
     struct MapResolver {
@@ -195,13 +203,19 @@ mod tests {
         .expect("stream should parse");
 
         assert_eq!(parsed.id, 0);
+        assert!(matches!(
+            parsed.operators.first(),
+            Some(PdfOperatorVariant::BeginCompatibility(_))
+        ));
+        assert!(matches!(
+            parsed.operators.get(1),
+            Some(PdfOperatorVariant::EndCompatibility(_))
+        ));
         assert_eq!(
-            parsed.operators,
+            recorded_operations(&parsed.operators),
             vec![
-                PdfOperatorVariant::BeginCompatibility(BeginCompatibility),
-                PdfOperatorVariant::EndCompatibility(EndCompatibility),
-                PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 20.0)),
-                PdfOperatorVariant::LineTo(LineTo::new(30.0, 40.0)),
+                RecordedOperation::MoveTo { x: 10.0, y: 20.0 },
+                RecordedOperation::LineTo { x: 30.0, y: 40.0 },
             ]
         );
     }
@@ -253,7 +267,7 @@ mod tests {
     fn parsed_inline_image_can_be_dispatched() {
         let mut ids = ContentStreamIdAllocator::new();
         let parsed = ContentStream::new(
-            &ObjectVariant::Stream(stream_object(1, b"BI /W 1 /H 1 ID \x00 EI")),
+            &ObjectVariant::Stream(stream_object(1, b"BI /W 1 /H 1 /BPC 8 /CS /G ID \x00 EI")),
             &PassthroughResolver,
             &mut ids,
         )
@@ -271,7 +285,7 @@ mod tests {
         assert_eq!(
             backend.operations,
             vec![RecordedOperation::PaintInlineImage {
-                image: inline_image,
+                data: inline_image.shared_data(),
             }]
         );
     }
@@ -287,8 +301,8 @@ mod tests {
         .expect("stream should parse");
 
         assert_eq!(
-            parsed.operators,
-            vec![PdfOperatorVariant::SaveGraphicsState(SaveGraphicsState)]
+            recorded_operations(&parsed.operators),
+            vec![RecordedOperation::SaveGraphicsState]
         );
     }
 
@@ -311,8 +325,8 @@ mod tests {
 
         assert_eq!(parsed.id, 0);
         assert_eq!(
-            parsed.operators,
-            vec![PdfOperatorVariant::MoveTo(MoveTo::new(3.0, 4.0))]
+            recorded_operations(&parsed.operators),
+            vec![RecordedOperation::MoveTo { x: 3.0, y: 4.0 }]
         );
     }
 
@@ -345,10 +359,8 @@ mod tests {
 
         assert_eq!(parsed.id, 0);
         assert_eq!(
-            parsed.operators,
-            vec![PdfOperatorVariant::RestoreGraphicsState(
-                RestoreGraphicsState
-            )]
+            recorded_operations(&parsed.operators),
+            vec![RecordedOperation::RestoreGraphicsState]
         );
         assert_eq!(ids.next_id().expect("next id should advance"), 1);
     }
@@ -386,10 +398,10 @@ mod tests {
 
         assert_eq!(content_stream.id, 0);
         assert_eq!(
-            content_stream.operators,
+            recorded_operations(&content_stream.operators),
             vec![
-                PdfOperatorVariant::SaveGraphicsState(SaveGraphicsState),
-                PdfOperatorVariant::RestoreGraphicsState(RestoreGraphicsState),
+                RecordedOperation::SaveGraphicsState,
+                RecordedOperation::RestoreGraphicsState,
             ]
         );
 

--- a/crates/pdf-content-stream/src/operator_stream_parser.rs
+++ b/crates/pdf-content-stream/src/operator_stream_parser.rs
@@ -208,8 +208,7 @@ fn parse_operator(
 #[allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 mod tests {
     use pdf_content_stream_operators::{
-        graphics_state_operators::RestoreGraphicsState, path_operators::MoveTo,
-        variants::PdfOperatorVariant,
+        graphics_state_operators::RestoreGraphicsState, variants::PdfOperatorVariant,
     };
 
     use super::*;
@@ -276,10 +275,7 @@ mod tests {
 
         let operator = parse_operator(descriptor, &mut operands).expect("operator should parse");
 
-        assert_eq!(
-            operator,
-            Some(PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 20.0)))
-        );
+        assert!(matches!(operator, Some(PdfOperatorVariant::MoveTo(_))));
         assert!(operands.is_empty());
         assert!(operands.capacity() >= original_capacity);
     }
@@ -297,7 +293,7 @@ mod tests {
         let operator = parse_operator(descriptor, &mut operands)
             .expect("malformed operator should be skipped");
 
-        assert_eq!(operator, None);
+        assert!(operator.is_none());
         assert_eq!(
             operands,
             vec![
@@ -338,7 +334,8 @@ mod tests {
     #[test]
     fn parse_next_item_uses_parse_hook_and_resumes_after_inline_image() {
         let mut out = Vec::new();
-        let mut parser = OperatorStreamParser::new(b"BI ID x\nEI Q", &mut out);
+        let mut parser =
+            OperatorStreamParser::new(b"BI /W 1 /H 1 /BPC 8 /CS /G ID x\nEI Q", &mut out);
 
         assert!(
             parser
@@ -346,10 +343,18 @@ mod tests {
                 .expect("inline image should parse through hook")
         );
         assert_eq!(parser.out.len(), 1);
-        match parser.out.first() {
-            Some(PdfOperatorVariant::InlineImage(image)) => {
-                assert!(image.dictionary().dictionary.is_empty());
-                assert_eq!(image.data(), b"x\n");
+        let cloned = parser
+            .out
+            .first()
+            .cloned()
+            .expect("parsed operator should be present");
+        match (parser.out.first(), &cloned) {
+            (
+                Some(PdfOperatorVariant::InlineImage(image)),
+                PdfOperatorVariant::InlineImage(cloned_image),
+            ) => {
+                assert_eq!(image.shared_data().as_slice(), b"x\n");
+                assert!(std::rc::Rc::ptr_eq(image, cloned_image));
             }
             other => panic!("expected inline image, got {other:?}"),
         }

--- a/crates/pdf-content-stream/tests/parser_api.rs
+++ b/crates/pdf-content-stream/tests/parser_api.rs
@@ -3,9 +3,7 @@ use std::collections::BTreeMap;
 use pdf_content_stream::{ContentStream, ContentStreamIdAllocator};
 use pdf_content_stream_operators::{
     TextElement,
-    compatibility_operators::{BeginCompatibility, EndCompatibility},
-    graphics_state_operators::{RestoreGraphicsState, SaveGraphicsState},
-    path_operators::{LineTo, MoveTo},
+    graphics_state_operators::SaveGraphicsState,
     recording_pdf_operator_backend::{RecordedOperation, RecordingBackend},
     text_showing_operators::ShowTextArray,
     variants::PdfOperatorVariant,
@@ -22,6 +20,16 @@ fn stream_object(object_number: usize, data: &[u8]) -> StreamObject {
         Box::new(Dictionary::new(BTreeMap::new())),
         data.to_vec(),
     )
+}
+
+fn recorded_operations(operators: &[PdfOperatorVariant]) -> Vec<RecordedOperation> {
+    let mut backend = RecordingBackend::default();
+    for operator in operators {
+        operator
+            .call(&mut backend)
+            .expect("operator should dispatch");
+    }
+    backend.operations
 }
 
 struct MapResolver {
@@ -57,13 +65,19 @@ fn content_stream_new_returns_expected_operators_and_assigns_ids() {
     .expect("stream should parse");
 
     assert_eq!(parsed.id, 0);
+    assert!(matches!(
+        parsed.operators.first(),
+        Some(PdfOperatorVariant::BeginCompatibility(_))
+    ));
+    assert!(matches!(
+        parsed.operators.get(1),
+        Some(PdfOperatorVariant::EndCompatibility(_))
+    ));
     assert_eq!(
-        parsed.operators,
+        recorded_operations(&parsed.operators),
         vec![
-            PdfOperatorVariant::BeginCompatibility(BeginCompatibility),
-            PdfOperatorVariant::EndCompatibility(EndCompatibility),
-            PdfOperatorVariant::MoveTo(MoveTo::new(10.0, 20.0)),
-            PdfOperatorVariant::LineTo(LineTo::new(30.0, 40.0)),
+            RecordedOperation::MoveTo { x: 10.0, y: 20.0 },
+            RecordedOperation::LineTo { x: 30.0, y: 40.0 },
         ]
     );
 }
@@ -115,7 +129,7 @@ fn content_stream_new_handles_bare_sign_text_array_adjustment() {
 fn parsed_inline_image_can_be_dispatched() {
     let mut ids = ContentStreamIdAllocator::new();
     let parsed = ContentStream::new(
-        &ObjectVariant::Stream(stream_object(1, b"BI /W 1 /H 1 ID \x00 EI")),
+        &ObjectVariant::Stream(stream_object(1, b"BI /W 1 /H 1 /BPC 8 /CS /G ID \x00 EI")),
         &PassthroughResolver,
         &mut ids,
     )
@@ -133,7 +147,7 @@ fn parsed_inline_image_can_be_dispatched() {
     assert_eq!(
         backend.operations,
         vec![RecordedOperation::PaintInlineImage {
-            image: inline_image,
+            data: inline_image.shared_data(),
         }]
     );
 }
@@ -149,8 +163,8 @@ fn content_stream_new_skips_unknown_operator_and_recovers() {
     .expect("stream should parse");
 
     assert_eq!(
-        parsed.operators,
-        vec![PdfOperatorVariant::SaveGraphicsState(SaveGraphicsState)]
+        recorded_operations(&parsed.operators),
+        vec![RecordedOperation::SaveGraphicsState]
     );
 }
 
@@ -187,8 +201,8 @@ fn from_dictionary_parses_stream_arrays_and_allocates_monotonically() {
 
     assert_eq!(content_stream.id, 0);
     assert_eq!(
-        content_stream.operators,
-        vec![PdfOperatorVariant::MoveTo(MoveTo::new(3.0, 4.0))]
+        recorded_operations(&content_stream.operators),
+        vec![RecordedOperation::MoveTo { x: 3.0, y: 4.0 }]
     );
 
     let next = ContentStream::new(
@@ -231,10 +245,8 @@ fn content_stream_new_skips_malformed_inline_image_and_consumes_an_id() {
 
     assert_eq!(parsed.id, 0);
     assert_eq!(
-        parsed.operators,
-        vec![PdfOperatorVariant::RestoreGraphicsState(
-            RestoreGraphicsState
-        )]
+        recorded_operations(&parsed.operators),
+        vec![RecordedOperation::RestoreGraphicsState]
     );
     assert_eq!(ids.next_id().expect("next id should advance"), 1);
 }

--- a/crates/pdf-decode/src/map.rs
+++ b/crates/pdf-decode/src/map.rs
@@ -7,7 +7,7 @@ use pdf_object::{
 use crate::{error::DecodeError, range::DecodeRange};
 
 /// Stores the per-component decode ranges used to transform packed samples.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DecodeMap {
     ranges: Vec<DecodeRange>,
 }

--- a/crates/pdf-decode/src/range.rs
+++ b/crates/pdf-decode/src/range.rs
@@ -5,7 +5,7 @@ use num_traits::ToPrimitive;
 use crate::error::DecodeError;
 
 /// Represents a `/Decode` range for a single PDF sample component.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct DecodeRange {
     min: f32,
     max: f32,

--- a/crates/pdf-graphics-femtovg/src/femtovg_canvas_backend.rs
+++ b/crates/pdf-graphics-femtovg/src/femtovg_canvas_backend.rs
@@ -2,13 +2,13 @@ use std::sync::Arc;
 
 use femtovg::{Canvas, Color, FillRule, Paint, Path};
 use pdf_canvas::{
-    canvas_backend::{CanvasBackend, Image, Shader},
+    canvas_backend::{CanvasBackend, Shader},
     error::PdfCanvasError,
     recording_canvas::RecordingCanvas,
     stroke_style::StrokeStyle,
 };
 use pdf_graphics::{
-    BlendMode, MaskMode, PathFillType,
+    BlendMode, Image, MaskMode, PathFillType,
     pdf_path::{PathVerb, PdfPath},
 };
 

--- a/crates/pdf-graphics-skia/src/skia_canvas_backend.rs
+++ b/crates/pdf-graphics-skia/src/skia_canvas_backend.rs
@@ -1,13 +1,13 @@
 use std::sync::Arc;
 
 use pdf_canvas::{
-    canvas_backend::{CanvasBackend, Image, Shader},
+    canvas_backend::{CanvasBackend, Shader},
     error::PdfCanvasError,
     recording_canvas::RecordingCanvas,
     stroke_style::StrokeStyle,
 };
 use pdf_graphics::{
-    BlendMode, MaskMode, PathFillType, PixelFormat,
+    BlendMode, Image, MaskMode, PathFillType, PixelFormat,
     color::Color,
     pdf_path::{PathVerb, PdfPath},
     transform::Transform,

--- a/crates/pdf-graphics/Cargo.toml
+++ b/crates/pdf-graphics/Cargo.toml
@@ -11,3 +11,10 @@ workspace = true
 num-traits = "0.2"
 num-derive = "0.4"
 thiserror = "2.0.12"
+
+[dev-dependencies]
+criterion = "0.8"
+
+[[bench]]
+name = "image_conversion"
+harness = false

--- a/crates/pdf-graphics/benches/image_conversion.rs
+++ b/crates/pdf-graphics/benches/image_conversion.rs
@@ -1,0 +1,77 @@
+#![allow(clippy::arithmetic_side_effects)]
+
+use std::{hint::black_box, sync::Arc};
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use pdf_graphics::{Image, PixelFormat};
+
+const WIDTH: usize = 512;
+const HEIGHT: usize = 512;
+const NUM_PIXELS: usize = WIDTH * HEIGHT;
+const NUM_PIXELS_U64: u64 = 262_144;
+
+fn benchmark_image_conversion(criterion: &mut Criterion) {
+    let gray = Arc::new(vec![0x80; NUM_PIXELS]);
+    let rgb = Arc::new([0x20, 0x80, 0xE0].repeat(NUM_PIXELS));
+    let cmyk = Arc::new([0x10, 0x40, 0x80, 0x20].repeat(NUM_PIXELS));
+    let two_components = Arc::new([0x40, 0xC0].repeat(NUM_PIXELS));
+    let soft_mask = Image {
+        data: Arc::new(vec![0xA0; NUM_PIXELS]),
+        width: WIDTH,
+        height: HEIGHT,
+        pixel_format: PixelFormat::Gray8,
+    };
+
+    let mut group = criterion.benchmark_group("image_conversion");
+    group.throughput(Throughput::Elements(NUM_PIXELS_U64));
+
+    group.bench_function("gray_with_soft_mask", |bencher| {
+        bencher.iter(|| {
+            black_box(Image::from_decoded_samples(
+                Arc::clone(&gray),
+                WIDTH,
+                HEIGHT,
+                1,
+                Some(&soft_mask),
+            ))
+        });
+    });
+    group.bench_function("rgb", |bencher| {
+        bencher.iter(|| {
+            black_box(Image::from_decoded_samples(
+                Arc::clone(&rgb),
+                WIDTH,
+                HEIGHT,
+                3,
+                None,
+            ))
+        });
+    });
+    group.bench_function("cmyk", |bencher| {
+        bencher.iter(|| {
+            black_box(Image::from_decoded_samples(
+                Arc::clone(&cmyk),
+                WIDTH,
+                HEIGHT,
+                4,
+                None,
+            ))
+        });
+    });
+    group.bench_function("two_component_fallback", |bencher| {
+        bencher.iter(|| {
+            black_box(Image::from_decoded_samples(
+                Arc::clone(&two_components),
+                WIDTH,
+                HEIGHT,
+                2,
+                None,
+            ))
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_image_conversion);
+criterion_main!(benches);

--- a/crates/pdf-graphics/src/image.rs
+++ b/crates/pdf-graphics/src/image.rs
@@ -1,0 +1,309 @@
+use std::sync::Arc;
+
+use crate::PixelFormat;
+
+/// Represents render-ready raster image pixels.
+#[derive(Debug, Clone)]
+pub struct Image {
+    /// Shared pixel data.
+    pub data: Arc<Vec<u8>>,
+    /// The width of the image in pixels.
+    pub width: usize,
+    /// The height of the image in pixels.
+    pub height: usize,
+    /// The pixel format of the image data.
+    pub pixel_format: PixelFormat,
+}
+
+impl Image {
+    /// Creates a render-ready image from decoded component samples.
+    ///
+    /// Single-component images without a soft mask retain their grayscale
+    /// buffer. All other images are converted to RGBA pixels.
+    pub fn from_decoded_samples(
+        data: Arc<Vec<u8>>,
+        width: usize,
+        height: usize,
+        num_color_components: usize,
+        soft_mask: Option<&Self>,
+    ) -> Self {
+        let convert_to_rgba = soft_mask.is_some() || num_color_components != 1;
+        if !convert_to_rgba {
+            return Self {
+                data,
+                width,
+                height,
+                pixel_format: PixelFormat::Gray8,
+            };
+        }
+
+        Self {
+            data: Arc::new(Self::to_rgba(
+                data.as_ref(),
+                width,
+                height,
+                num_color_components,
+                soft_mask,
+            )),
+            width,
+            height,
+            pixel_format: PixelFormat::RGBA8888,
+        }
+    }
+
+    /// Converts decoded image samples into RGBA pixels with an optional soft-mask alpha channel.
+    fn to_rgba(
+        image_data: &[u8],
+        width: usize,
+        height: usize,
+        num_color_components: usize,
+        soft_mask: Option<&Self>,
+    ) -> Vec<u8> {
+        match num_color_components {
+            0 => Vec::new(),
+            1 => Self::convert_pixels(
+                image_data,
+                width,
+                height,
+                num_color_components,
+                soft_mask,
+                Self::append_gray_rgba,
+            ),
+            3 => Self::convert_pixels(
+                image_data,
+                width,
+                height,
+                num_color_components,
+                soft_mask,
+                Self::append_rgb_rgba,
+            ),
+            4 => Self::convert_pixels(
+                image_data,
+                width,
+                height,
+                num_color_components,
+                soft_mask,
+                Self::append_cmyk_rgba,
+            ),
+            _ => Self::convert_pixels(
+                image_data,
+                width,
+                height,
+                num_color_components,
+                soft_mask,
+                Self::append_fallback_rgba,
+            ),
+        }
+    }
+
+    /// Converts component chunks with a format-specific pixel writer.
+    #[inline]
+    fn convert_pixels(
+        image_data: &[u8],
+        width: usize,
+        height: usize,
+        num_color_components: usize,
+        soft_mask: Option<&Self>,
+        mut write_pixel: impl FnMut(&mut [u8], &[u8], u8),
+    ) -> Vec<u8> {
+        let declared_pixels = width.saturating_mul(height);
+        let available_pixels = image_data
+            .len()
+            .checked_div(num_color_components)
+            .map_or(0, std::convert::identity);
+        let num_pixels = declared_pixels.min(available_pixels);
+        let mut out = vec![0; num_pixels.saturating_mul(4)];
+        let mut pixels = out
+            .chunks_exact_mut(4)
+            .zip(image_data.chunks_exact(num_color_components));
+
+        if let Some(mask) = soft_mask {
+            for (alpha, (out_pixel, components)) in mask.data.iter().copied().zip(pixels.by_ref()) {
+                write_pixel(out_pixel, components, alpha);
+            }
+        }
+
+        for (out_pixel, components) in pixels {
+            write_pixel(out_pixel, components, 255);
+        }
+
+        out
+    }
+
+    /// Appends a grayscale sample as an RGBA pixel.
+    #[inline]
+    fn append_gray_rgba(out: &mut [u8], components: &[u8], alpha: u8) {
+        let &[gray] = components else {
+            return;
+        };
+        let [r, g, b, a] = out else {
+            return;
+        };
+        *r = gray;
+        *g = gray;
+        *b = gray;
+        *a = alpha;
+    }
+
+    /// Appends an RGB sample as an RGBA pixel.
+    #[inline]
+    fn append_rgb_rgba(out: &mut [u8], rgb: &[u8], alpha: u8) {
+        let &[r, g, b] = rgb else {
+            return;
+        };
+        let [out_r, out_g, out_b, out_a] = out else {
+            return;
+        };
+        *out_r = r;
+        *out_g = g;
+        *out_b = b;
+        *out_a = alpha;
+    }
+
+    /// Appends a CMYK sample converted to RGBA.
+    #[inline]
+    fn append_cmyk_rgba(out: &mut [u8], cmyk: &[u8], alpha: u8) {
+        let &[c, m, y, k] = cmyk else {
+            return;
+        };
+        let [r, g, b, a] = out else {
+            return;
+        };
+        *r = Self::cmyk_channel(c, k);
+        *g = Self::cmyk_channel(m, k);
+        *b = Self::cmyk_channel(y, k);
+        *a = alpha;
+    }
+
+    /// Converts one CMYK color channel to its RGB equivalent.
+    #[inline]
+    fn cmyk_channel(component: u8, key: u8) -> u8 {
+        let component = 255u16.saturating_sub(u16::from(component));
+        let key = 255u16.saturating_sub(u16::from(key));
+        let channel = component.saturating_mul(key) / 255;
+
+        u8::try_from(channel).map_or(u8::MAX, std::convert::identity)
+    }
+
+    /// Appends a best-effort RGBA pixel for unsupported component counts.
+    #[inline]
+    fn append_fallback_rgba(out: &mut [u8], components: &[u8], alpha: u8) {
+        let [r, g, b, a] = out else {
+            return;
+        };
+        for (channel, component) in [r, g, b].into_iter().zip(components) {
+            *channel = *component;
+        }
+        *a = alpha;
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::Image;
+    use crate::PixelFormat;
+
+    #[test]
+    fn clone_shares_pixel_data() {
+        let data = Arc::new(vec![1, 2, 3, 4]);
+        let image = Image {
+            data: Arc::clone(&data),
+            width: 1,
+            height: 1,
+            pixel_format: PixelFormat::RGBA8888,
+        };
+
+        assert!(Arc::ptr_eq(&image.clone().data, &data));
+    }
+
+    #[test]
+    fn grayscale_without_soft_mask_reuses_samples() {
+        let data = Arc::new(vec![12, 34]);
+        let image = Image::from_decoded_samples(Arc::clone(&data), 2, 1, 1, None);
+
+        assert!(Arc::ptr_eq(&image.data, &data));
+        assert_eq!(image.pixel_format, PixelFormat::Gray8);
+    }
+
+    #[test]
+    fn rgb_samples_are_expanded_to_rgba() {
+        let image = Image::from_decoded_samples(Arc::new(vec![10, 20, 30]), 1, 1, 3, None);
+
+        assert_eq!(image.pixel_format, PixelFormat::RGBA8888);
+        assert_eq!(image.data.as_ref(), &[10, 20, 30, 255]);
+    }
+
+    #[test]
+    fn cmyk_samples_are_converted_to_rgba() {
+        let image = Image::from_decoded_samples(Arc::new(vec![0, 0, 0, 0]), 1, 1, 4, None);
+
+        assert_eq!(image.data.as_ref(), &[255, 255, 255, 255]);
+    }
+
+    #[test]
+    fn uncommon_component_counts_use_available_color_channels() {
+        let image = Image::from_decoded_samples(Arc::new(vec![10, 20]), 1, 1, 2, None);
+
+        assert_eq!(image.data.as_ref(), &[10, 20, 0, 255]);
+    }
+
+    #[test]
+    fn soft_mask_supplies_alpha_samples() {
+        let soft_mask = Image {
+            data: Arc::new(vec![0x10, 0xE0]),
+            width: 2,
+            height: 1,
+            pixel_format: PixelFormat::Gray8,
+        };
+        let image =
+            Image::from_decoded_samples(Arc::new(vec![0x20, 0xC0]), 2, 1, 1, Some(&soft_mask));
+
+        assert_eq!(
+            image.data.as_ref(),
+            &[0x20, 0x20, 0x20, 0x10, 0xC0, 0xC0, 0xC0, 0xE0]
+        );
+    }
+
+    #[test]
+    fn short_soft_mask_defaults_remaining_pixels_to_opaque() {
+        let soft_mask = Image {
+            data: Arc::new(vec![0x10]),
+            width: 1,
+            height: 1,
+            pixel_format: PixelFormat::Gray8,
+        };
+        let image =
+            Image::from_decoded_samples(Arc::new(vec![0x20, 0xC0]), 2, 1, 1, Some(&soft_mask));
+
+        assert_eq!(
+            image.data.as_ref(),
+            &[0x20, 0x20, 0x20, 0x10, 0xC0, 0xC0, 0xC0, 0xFF]
+        );
+    }
+
+    #[test]
+    fn zero_components_produce_an_empty_rgba_image() {
+        let image = Image::from_decoded_samples(Arc::new(vec![10, 20]), 1, 1, 0, None);
+
+        assert_eq!(image.pixel_format, PixelFormat::RGBA8888);
+        assert!(image.data.is_empty());
+    }
+
+    #[test]
+    fn incomplete_trailing_components_are_ignored() {
+        let image = Image::from_decoded_samples(Arc::new(vec![10, 20, 30, 40, 50]), 2, 1, 3, None);
+
+        assert_eq!(image.data.as_ref(), &[10, 20, 30, 255]);
+    }
+
+    #[test]
+    fn conversion_stops_at_the_declared_pixel_count() {
+        let image =
+            Image::from_decoded_samples(Arc::new(vec![10, 20, 30, 40, 50, 60]), 1, 1, 3, None);
+
+        assert_eq!(image.data.as_ref(), &[10, 20, 30, 255]);
+    }
+}

--- a/crates/pdf-graphics/src/lib.rs
+++ b/crates/pdf-graphics/src/lib.rs
@@ -3,6 +3,7 @@ pub mod blend_mode;
 mod bounds_accumulator;
 pub mod color;
 pub mod dash_pattern;
+mod image;
 pub mod mask_mode;
 pub mod pdf_path;
 pub mod point;
@@ -12,6 +13,7 @@ pub mod transform;
 pub use blend_mode::BlendMode;
 pub use bounds_accumulator::BoundsAccumulator;
 pub use dash_pattern::DashPattern;
+pub use image::Image;
 pub use mask_mode::MaskMode;
 use num_derive::FromPrimitive;
 

--- a/crates/pdf-image/src/decoded_samples.rs
+++ b/crates/pdf-image/src/decoded_samples.rs
@@ -1,10 +1,8 @@
 use std::{borrow::Cow, sync::Arc};
 
-use pdf_color_space::{color_space::ColorSpace, indexed_color_space::IndexedColorSpace};
 use pdf_decode::{
     DecodeMap, DecodeRange, SampleLayout, decode_sample_bytes, expand_indexed_values,
 };
-use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver};
 
 use crate::error::PdfImageError;
 use crate::image_metadata::ImageMetadata;
@@ -12,8 +10,6 @@ use crate::image_metadata::ImageMetadata;
 /// Stores decoded sample bytes before the final pixel format conversion.
 #[derive(Debug, Clone)]
 pub(crate) struct DecodedSamples {
-    pub(crate) bits_per_component: usize,
-    pub(crate) stored_color_space: Option<ColorSpace>,
     pub(crate) num_color_components: usize,
     pub(crate) image_data: Arc<Vec<u8>>,
 }
@@ -21,9 +17,7 @@ pub(crate) struct DecodedSamples {
 impl DecodedSamples {
     /// Decodes raw image bytes into component samples based on the configured color space.
     pub(crate) fn decode(
-        dictionary: &Dictionary,
         raw_data: Arc<Vec<u8>>,
-        objects: &dyn ObjectResolver,
         metadata: &ImageMetadata,
     ) -> Result<Self, PdfImageError> {
         let decoded_samples = if let Some(decoded_samples) =
@@ -33,11 +27,20 @@ impl DecodedSamples {
         } else if let Some(decoded_samples) = Self::decode_preconverted_dct(&raw_data, metadata) {
             decoded_samples
         } else {
-            match metadata.color_space.as_ref() {
-                Some(ColorSpace::Indexed(indexed)) => {
-                    Self::decode_indexed(dictionary, raw_data, objects, metadata, indexed)
+            match &metadata.color_space {
+                Some(pdf_color_space::color_space::ColorSpace::Indexed(indexed)) => {
+                    Self::decode_indexed(
+                        raw_data,
+                        metadata,
+                        indexed.base.num_color_components(),
+                        indexed.hival,
+                        &indexed.lookup,
+                    )
                 }
-                _ => Self::decode_direct(dictionary, raw_data, objects, metadata),
+                Some(color_space) => {
+                    Self::decode_direct(raw_data, metadata, color_space.num_color_components())
+                }
+                None => Self::decode_direct(raw_data, metadata, 1),
             }?
         };
 
@@ -78,11 +81,6 @@ impl DecodedSamples {
             Self::decoded_dct_component_count(raw_data.as_slice(), num_pixels)
                 .or_else(|| Self::decoded_single_pixel_component_count(raw_data.as_slice()))?;
 
-        let stored_color_space = match num_color_components {
-            1 => Some(ColorSpace::DeviceGray),
-            3 => Some(ColorSpace::DeviceRGB),
-            _ => metadata.color_space.clone(),
-        };
         let image_data = if raw_data.len() == num_color_components && num_pixels > 1 {
             Arc::new(raw_data.repeat(num_pixels))
         } else {
@@ -90,8 +88,6 @@ impl DecodedSamples {
         };
 
         Some(Self {
-            bits_per_component: metadata.bits_per_component,
-            stored_color_space,
             num_color_components,
             image_data,
         })
@@ -113,17 +109,13 @@ impl DecodedSamples {
             return None;
         }
 
-        let (num_color_components, bits_per_component, stored_color_space) = match bytes_per_pixel {
-            1 => (1, 8, Some(ColorSpace::DeviceGray)),
-            2 => (1, 16, Some(ColorSpace::DeviceGray)),
-            3 => (3, 8, Some(ColorSpace::DeviceRGB)),
-            6 => (3, 16, Some(ColorSpace::DeviceRGB)),
+        let num_color_components = match bytes_per_pixel {
+            1 | 2 => 1,
+            3 | 6 => 3,
             _ => return None,
         };
 
         Some(Self {
-            bits_per_component,
-            stored_color_space,
             num_color_components,
             image_data: Arc::clone(raw_data),
         })
@@ -143,61 +135,50 @@ impl DecodedSamples {
 
     /// Decodes indexed image samples, applies `/Decode`, and expands palette entries.
     fn decode_indexed(
-        dictionary: &Dictionary,
         raw_data: Arc<Vec<u8>>,
-        objects: &dyn ObjectResolver,
         metadata: &ImageMetadata,
-        indexed: &IndexedColorSpace,
+        base_color_components: usize,
+        hival: u8,
+        lookup: &Arc<Vec<u8>>,
     ) -> Result<Self, PdfImageError> {
         let sample_codes = Self::decode_image_sample_codes(raw_data, 1, metadata)?;
         let sample_max = Self::sample_max(metadata.bits_per_component)?;
-        let decode = DecodeMap::from_dictionary(dictionary, objects, 1)?;
         let decoded_indices = Self::apply_decode(
             sample_codes,
-            decode.as_ref(),
+            metadata.decode.as_ref(),
             sample_max,
             sample_max,
             metadata.image_mask,
         );
-        let base_components = indexed.base.num_color_components();
 
         let image_data = expand_indexed_values(
             decoded_indices.as_ref(),
-            &indexed.lookup,
-            indexed.hival,
-            base_components,
+            lookup,
+            hival,
+            base_color_components,
         )?;
 
         Ok(Self {
-            bits_per_component: metadata.bits_per_component,
-            stored_color_space: Some(*indexed.base.clone()),
-            num_color_components: base_components,
+            num_color_components: base_color_components,
             image_data: Arc::new(image_data),
         })
     }
 
     /// Decodes non-indexed image samples and applies the `/Decode` transform.
     fn decode_direct(
-        dictionary: &Dictionary,
         raw_data: Arc<Vec<u8>>,
-        objects: &dyn ObjectResolver,
         metadata: &ImageMetadata,
+        num_color_components: usize,
     ) -> Result<Self, PdfImageError> {
-        let num_components = metadata
-            .color_space
-            .as_ref()
-            .map_or(1, ColorSpace::num_color_components);
-        let sample_codes = Self::decode_image_sample_codes(raw_data, num_components, metadata)?;
-        let decode = DecodeMap::from_dictionary(dictionary, objects, num_components)?;
+        let sample_codes =
+            Self::decode_image_sample_codes(raw_data, num_color_components, metadata)?;
         let sample_max = Self::sample_max(metadata.bits_per_component)?;
 
         Ok(Self {
-            bits_per_component: metadata.bits_per_component,
-            stored_color_space: metadata.color_space.clone(),
-            num_color_components: num_components,
+            num_color_components,
             image_data: Self::apply_decode(
                 sample_codes,
-                decode.as_ref(),
+                metadata.decode.as_ref(),
                 sample_max,
                 255,
                 metadata.image_mask,
@@ -271,7 +252,9 @@ impl DecodedSamples {
 mod tests {
     use std::collections::BTreeMap;
 
-    use pdf_object::{object_resolver::PassthroughResolver, object_variant::ObjectVariant};
+    use pdf_object::{
+        dictionary::Dictionary, object_resolver::PassthroughResolver, object_variant::ObjectVariant,
+    };
 
     use super::*;
 
@@ -298,13 +281,8 @@ mod tests {
             .expect("direct image metadata should be valid");
         let samples = Arc::new(vec![12, 34]);
 
-        let decoded = DecodedSamples::decode_direct(
-            &dictionary,
-            Arc::clone(&samples),
-            &PassthroughResolver,
-            &metadata,
-        )
-        .expect("identity samples should decode");
+        let decoded = DecodedSamples::decode_direct(Arc::clone(&samples), &metadata, 1)
+            .expect("identity samples should decode");
 
         assert!(Arc::ptr_eq(&decoded.image_data, &samples));
     }

--- a/crates/pdf-image/src/image_decoder.rs
+++ b/crates/pdf-image/src/image_decoder.rs
@@ -1,8 +1,7 @@
 use std::sync::Arc;
 
-use pdf_color_space::color_space::ColorSpace;
-use pdf_filter::filter::{decode_data_with_resolver, decode_with_resolver};
-use pdf_graphics::PixelFormat;
+use pdf_filter::filter::decode_with_resolver;
+use pdf_graphics::Image;
 use pdf_object::{dictionary::Dictionary, object_resolver::ObjectResolver, stream::StreamObject};
 
 use crate::InlineImage;
@@ -10,186 +9,62 @@ use crate::decoded_samples::DecodedSamples;
 use crate::error::PdfImageError;
 use crate::image_metadata::ImageMetadata;
 
-/// Represents a PDF Image XObject, which is a self-contained raster image.
-#[derive(Debug, Clone)]
-pub struct ImageXObject {
-    /// The width of the image in samples (pixels).
-    pub width: usize,
-    /// The height of the image in samples (pixels).
-    pub height: usize,
-    /// The number of bits used to represent each color component.
-    pub bits_per_component: usize,
-    /// The shared image stream data (with soft mask alpha applied if present).
-    pub data: Arc<Vec<u8>>,
-    /// The pixel format of the image data.
-    pub pixel_format: PixelFormat,
-    /// The color space of the image samples.
-    pub color_space: Option<ColorSpace>,
+/// Parses an Image XObject from a PDF stream dictionary and data.
+pub fn read_xobject(
+    dictionary: &Dictionary,
+    stream_data: &StreamObject,
+    objects: &dyn ObjectResolver,
+    soft_mask: Option<&Image>,
+) -> Result<Image, PdfImageError> {
+    let metadata = ImageMetadata::from_dictionary(dictionary, objects)?;
+    let decoded = if stream_data.filters_applied() {
+        stream_data.shared_data()
+    } else {
+        decode_with_resolver(stream_data, objects)?
+    };
+
+    decode_normalized_image_with_metadata(decoded, soft_mask, &metadata)
 }
 
-impl ImageXObject {
-    /// Parses an Image XObject from a PDF stream dictionary and data.
-    pub fn read_xobject(
-        dictionary: &Dictionary,
-        stream_data: &StreamObject,
-        objects: &dyn ObjectResolver,
-        soft_mask: Option<ImageXObject>,
-    ) -> Result<Self, PdfImageError> {
-        let metadata = ImageMetadata::from_dictionary(dictionary, objects)?;
-        let decoded = if stream_data.filters_applied() {
-            stream_data.shared_data()
-        } else {
-            decode_with_resolver(stream_data, objects)?
-        };
+/// Decodes an inline image, including its filter chain and normalized sample data.
+pub fn decode_inline_image(
+    image: &InlineImage,
+    soft_mask: Option<&Image>,
+) -> Result<Image, PdfImageError> {
+    decode_normalized_image_with_metadata(image.shared_data(), soft_mask, image.metadata())
+}
 
-        Self::decode_normalized_image_with_metadata(
-            dictionary, decoded, objects, &soft_mask, &metadata,
-        )
-    }
+/// Decodes a normalized image dictionary and shared raw bytes into a raster image.
+///
+/// The dictionary must already use canonical image keys such as `Width`,
+/// `Height`, `BitsPerComponent`, and `ColorSpace`.
+pub fn decode_normalized_image(
+    dictionary: &Dictionary,
+    raw_data: Arc<Vec<u8>>,
+    objects: &dyn ObjectResolver,
+    soft_mask: Option<&Image>,
+) -> Result<Image, PdfImageError> {
+    let metadata = ImageMetadata::from_dictionary(dictionary, objects)?;
+    decode_normalized_image_with_metadata(raw_data, soft_mask, &metadata)
+}
 
-    /// Decodes an inline image, including its filter chain and normalized sample data.
-    pub fn decode_inline_image(
-        image: &InlineImage,
-        objects: &dyn ObjectResolver,
-        soft_mask: Option<ImageXObject>,
-    ) -> Result<Self, PdfImageError> {
-        let dictionary = image.normalized_dictionary();
-        let decoded = decode_data_with_resolver(&dictionary, image.shared_data(), objects)?;
-
-        Self::decode_normalized_image(&dictionary, decoded, objects, &soft_mask)
-    }
-
-    /// Decodes a normalized image dictionary and shared raw bytes into a raster image.
-    ///
-    /// The dictionary must already use canonical image keys such as `Width`,
-    /// `Height`, `BitsPerComponent`, and `ColorSpace`.
-    pub fn decode_normalized_image(
-        dictionary: &Dictionary,
-        raw_data: Arc<Vec<u8>>,
-        objects: &dyn ObjectResolver,
-        soft_mask: &Option<ImageXObject>,
-    ) -> Result<Self, PdfImageError> {
-        let metadata = ImageMetadata::from_dictionary(dictionary, objects)?;
-        Self::decode_normalized_image_with_metadata(
-            dictionary, raw_data, objects, soft_mask, &metadata,
-        )
-    }
-
-    fn decode_normalized_image_with_metadata(
-        dictionary: &Dictionary,
-        raw_data: Arc<Vec<u8>>,
-        objects: &dyn ObjectResolver,
-        soft_mask: &Option<ImageXObject>,
-        metadata: &ImageMetadata,
-    ) -> Result<Self, PdfImageError> {
-        let decoded_samples = DecodedSamples::decode(dictionary, raw_data, objects, metadata)?;
-        let DecodedSamples {
-            bits_per_component,
-            stored_color_space,
-            num_color_components,
-            image_data,
-        } = decoded_samples;
-        let convert_to_rgba = soft_mask.is_some() || num_color_components != 1;
-        let pixel_format = if convert_to_rgba {
-            PixelFormat::RGBA8888
-        } else {
-            PixelFormat::Gray8
-        };
-        let data = if convert_to_rgba {
-            Arc::new(Self::to_rgba(
-                image_data.as_ref(),
-                metadata.size.width(),
-                metadata.size.height(),
-                num_color_components,
-                soft_mask.as_ref(),
-            ))
-        } else {
-            image_data
-        };
-
-        Ok(Self {
-            width: metadata.size.width(),
-            height: metadata.size.height(),
-            bits_per_component,
-            data,
-            pixel_format,
-            color_space: stored_color_space,
-        })
-    }
-
-    /// Converts decoded image samples into RGBA pixels with an optional soft-mask alpha channel.
-    fn to_rgba(
-        image_data: &[u8],
-        width: usize,
-        height: usize,
-        num_color_components: usize,
-        smask: Option<&ImageXObject>,
-    ) -> Vec<u8> {
-        let num_pixels = width.saturating_mul(height);
-        let mut out = Vec::with_capacity(num_pixels.saturating_mul(4));
-
-        for (pixel_index, chunk) in image_data
-            .chunks_exact(num_color_components)
-            .take(num_pixels)
-            .enumerate()
-        {
-            let alpha = Self::alpha_for_pixel(smask, pixel_index);
-            match num_color_components {
-                4 => Self::append_cmyk_rgba(&mut out, chunk, alpha),
-                3 => Self::append_rgb_rgba(&mut out, chunk, alpha),
-                1 => Self::append_gray_rgba(&mut out, chunk.first().copied().unwrap_or(0), alpha),
-                _ => Self::append_fallback_rgba(&mut out, chunk, alpha),
-            }
-        }
-
-        out
-    }
-
-    /// Returns the alpha value for a pixel from the soft mask, defaulting to full opacity.
-    fn alpha_for_pixel(smask: Option<&ImageXObject>, pixel_index: usize) -> u8 {
-        smask
-            .and_then(|mask| mask.data.get(pixel_index).copied())
-            .unwrap_or(255)
-    }
-
-    /// Appends a grayscale sample as an RGBA pixel.
-    fn append_gray_rgba(out: &mut Vec<u8>, gray: u8, alpha: u8) {
-        out.extend_from_slice(&[gray, gray, gray, alpha]);
-    }
-
-    /// Appends an RGB sample as an RGBA pixel.
-    fn append_rgb_rgba(out: &mut Vec<u8>, rgb: &[u8], alpha: u8) {
-        let r = rgb.first().copied().unwrap_or(0);
-        let g = rgb.get(1).copied().unwrap_or(0);
-        let b = rgb.get(2).copied().unwrap_or(0);
-        out.extend_from_slice(&[r, g, b, alpha]);
-    }
-
-    /// Appends a CMYK sample converted to RGBA.
-    fn append_cmyk_rgba(out: &mut Vec<u8>, cmyk: &[u8], alpha: u8) {
-        let c = cmyk.first().copied().unwrap_or(0);
-        let m = cmyk.get(1).copied().unwrap_or(0);
-        let y = cmyk.get(2).copied().unwrap_or(0);
-        let k = cmyk.get(3).copied().unwrap_or(0);
-
-        let c_inv = 255u16.saturating_sub(u16::from(c));
-        let m_inv = 255u16.saturating_sub(u16::from(m));
-        let y_inv = 255u16.saturating_sub(u16::from(y));
-        let k_inv = 255u16.saturating_sub(u16::from(k));
-
-        let r = u8::try_from(c_inv.saturating_mul(k_inv) / 255).unwrap_or(0);
-        let g = u8::try_from(m_inv.saturating_mul(k_inv) / 255).unwrap_or(0);
-        let b = u8::try_from(y_inv.saturating_mul(k_inv) / 255).unwrap_or(0);
-        out.extend_from_slice(&[r, g, b, alpha]);
-    }
-
-    /// Appends a best-effort RGBA pixel for unsupported component counts.
-    fn append_fallback_rgba(out: &mut Vec<u8>, components: &[u8], alpha: u8) {
-        let r = components.first().copied().unwrap_or(0);
-        let g = components.get(1).copied().unwrap_or(0);
-        let b = components.get(2).copied().unwrap_or(0);
-        out.extend_from_slice(&[r, g, b, alpha]);
-    }
+fn decode_normalized_image_with_metadata(
+    raw_data: Arc<Vec<u8>>,
+    soft_mask: Option<&Image>,
+    metadata: &ImageMetadata,
+) -> Result<Image, PdfImageError> {
+    let decoded_samples = DecodedSamples::decode(raw_data, metadata)?;
+    let DecodedSamples {
+        num_color_components,
+        image_data,
+    } = decoded_samples;
+    Ok(Image::from_decoded_samples(
+        image_data,
+        metadata.size.width(),
+        metadata.size.height(),
+        num_color_components,
+        soft_mask,
+    ))
 }
 
 #[cfg(test)]
@@ -202,32 +77,17 @@ mod tests {
         object_variant::ObjectVariant, stream::StreamObject,
     };
 
-    use super::{ImageXObject, InlineImage};
+    use pdf_graphics::{Image, PixelFormat};
+
+    use super::{InlineImage, decode_inline_image, decode_normalized_image, read_xobject};
     use crate::error::PdfImageError;
-
-    #[test]
-    fn cloned_image_xobject_shares_data() {
-        let data = Arc::new(vec![1, 2, 3, 4]);
-        let image = ImageXObject {
-            width: 1,
-            height: 1,
-            bits_per_component: 8,
-            data: Arc::clone(&data),
-            pixel_format: pdf_graphics::PixelFormat::RGBA8888,
-            color_space: None,
-        };
-
-        let cloned = image.clone();
-
-        assert!(Arc::ptr_eq(&cloned.data, &data));
-    }
 
     #[test]
     fn read_xobject_uses_predecoded_filtered_stream_data() {
         let dictionary = filtered_gray_dictionary();
         let stream = StreamObject::new(1, 0, Box::new(dictionary.clone()), vec![0x2A]);
 
-        let image = ImageXObject::read_xobject(&dictionary, &stream, &PassthroughResolver, None)
+        let image = read_xobject(&dictionary, &stream, &PassthroughResolver, None)
             .expect("predecoded image data should not be filtered again");
 
         assert!(Arc::ptr_eq(&image.data, &stream.data));
@@ -239,7 +99,7 @@ mod tests {
         let dictionary = filtered_gray_dictionary();
         let stream = StreamObject::new_encoded(1, 0, Box::new(dictionary.clone()), b"2A>".to_vec());
 
-        let image = ImageXObject::read_xobject(&dictionary, &stream, &PassthroughResolver, None)
+        let image = read_xobject(&dictionary, &stream, &PassthroughResolver, None)
             .expect("encoded image data should have its filter applied");
 
         assert_eq!(image.data.as_ref(), &[0x2A]);
@@ -261,11 +121,11 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(4)),
         ]));
 
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![0b1010_0000]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("1-bpc decoded grayscale image should decode");
 
@@ -289,11 +149,11 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(2)),
         ]));
 
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![0, 255]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("8-bpc decoded grayscale image should decode");
 
@@ -322,11 +182,11 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(2)),
         ]));
 
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![0b1000_0000]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("decoded indexed image should decode");
 
@@ -350,13 +210,9 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(1)),
         ]));
 
-        let err = ImageXObject::decode_normalized_image(
-            &dictionary,
-            Arc::new(vec![0]),
-            &PassthroughResolver,
-            &None,
-        )
-        .expect_err("invalid /Decode length should fail");
+        let err =
+            decode_normalized_image(&dictionary, Arc::new(vec![0]), &PassthroughResolver, None)
+                .expect_err("invalid /Decode length should fail");
 
         assert!(matches!(
             err,
@@ -380,11 +236,11 @@ mod tests {
         ]));
 
         let samples = Arc::new(vec![12, 34]);
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::clone(&samples),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("grayscale image without /Decode should decode");
 
@@ -406,11 +262,11 @@ mod tests {
         ]));
         let samples = Arc::new(vec![12, 34, 56]);
 
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::clone(&samples),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("trailing samples should be ignored");
 
@@ -426,16 +282,14 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(4)),
         ]));
 
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![0b1010_0000]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("image masks should default missing BitsPerComponent to 1");
 
-        assert_eq!(image.bits_per_component, 1);
-        assert!(image.color_space.is_none());
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::Gray8);
         assert_eq!(image.data.as_ref(), &[0x00, 0xFF, 0x00, 0xFF]);
     }
@@ -451,19 +305,14 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(2)),
         ]));
 
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![1, 2, 3, 4, 5, 6]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("JPX images should decode without BitsPerComponent when already expanded");
 
-        assert_eq!(image.bits_per_component, 8);
-        assert!(matches!(
-            image.color_space,
-            Some(pdf_color_space::color_space::ColorSpace::DeviceRGB)
-        ));
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
         assert_eq!(image.data.as_ref(), &[1, 2, 3, 255, 4, 5, 6, 255]);
     }
@@ -479,13 +328,9 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(1)),
         ]));
 
-        let err = ImageXObject::decode_normalized_image(
-            &dictionary,
-            Arc::new(vec![0]),
-            &PassthroughResolver,
-            &None,
-        )
-        .expect_err("non-mask images should still require BitsPerComponent");
+        let err =
+            decode_normalized_image(&dictionary, Arc::new(vec![0]), &PassthroughResolver, None)
+                .expect_err("non-mask images should still require BitsPerComponent");
 
         assert!(matches!(
             err,
@@ -509,20 +354,16 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(2)),
         ]));
 
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![10, 20, 30, 40, 50, 60]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("DCT-decoded RGB bytes should not be validated as CMYK samples");
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
         assert_eq!(image.data.as_ref(), &[10, 20, 30, 255, 40, 50, 60, 255]);
-        assert!(matches!(
-            image.color_space,
-            Some(pdf_color_space::color_space::ColorSpace::DeviceRGB)
-        ));
     }
 
     #[test]
@@ -537,11 +378,11 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(2)),
         ]));
 
-        let err = ImageXObject::decode_normalized_image(
+        let err = decode_normalized_image(
             &dictionary,
             Arc::new(vec![10, 20, 30, 40, 50, 60]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect_err("non-DCT CMYK image data should still require four components");
 
@@ -570,11 +411,11 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(2)),
         ]));
 
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![0xAA, 0x10, 0x20]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("single decoded DCT pixel should expand to the declared image size");
 
@@ -583,10 +424,6 @@ mod tests {
             image.data.as_ref(),
             &[0xAA, 0x10, 0x20, 255, 0xAA, 0x10, 0x20, 255]
         );
-        assert!(matches!(
-            image.color_space,
-            Some(pdf_color_space::color_space::ColorSpace::DeviceRGB)
-        ));
     }
 
     #[test]
@@ -600,20 +437,18 @@ mod tests {
             ("Height".to_string(), ObjectVariant::Integer(1)),
             ("Width".to_string(), ObjectVariant::Integer(2)),
         ]));
-        let soft_mask = ImageXObject {
+        let soft_mask = Image {
             width: 2,
             height: 1,
-            bits_per_component: 8,
             data: vec![0x10, 0xE0].into(),
-            pixel_format: pdf_graphics::PixelFormat::Gray8,
-            color_space: None,
+            pixel_format: PixelFormat::Gray8,
         };
 
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![0x20, 0xC0]),
             &PassthroughResolver,
-            &Some(soft_mask),
+            Some(&soft_mask),
         )
         .expect("resolved soft mask should be applied");
 
@@ -641,10 +476,11 @@ mod tests {
                 ("W".to_string(), ObjectVariant::Integer(1)),
             ])),
             b"2A>".to_vec(),
-        );
+            &PassthroughResolver,
+        )
+        .expect("inline image filters should decode");
 
-        let decoded = ImageXObject::decode_inline_image(&image, &PassthroughResolver, None)
-            .expect("inline image should decode");
+        let decoded = decode_inline_image(&image, None).expect("inline image should decode");
 
         assert_eq!(decoded.pixel_format, pdf_graphics::PixelFormat::Gray8);
         assert_eq!(decoded.data.as_ref(), &[0x2A]);
@@ -660,9 +496,11 @@ mod tests {
                 ("W".to_string(), ObjectVariant::Integer(4)),
             ])),
             vec![0b1010_0000],
-        );
+            &PassthroughResolver,
+        )
+        .expect("inline image should be constructed");
 
-        let decoded = ImageXObject::decode_inline_image(&image, &PassthroughResolver, None)
+        let decoded = decode_inline_image(&image, None)
             .expect("inline image with abbreviated gray color space should decode");
 
         assert_eq!(decoded.pixel_format, pdf_graphics::PixelFormat::Gray8);
@@ -679,11 +517,13 @@ mod tests {
                 ("W".to_string(), ObjectVariant::Integer(2)),
             ])),
             vec![12, 34],
-        );
+            &PassthroughResolver,
+        )
+        .expect("inline image should be constructed");
         let samples = image.shared_data();
 
-        let decoded = ImageXObject::decode_inline_image(&image, &PassthroughResolver, None)
-            .expect("unfiltered inline image should decode");
+        let decoded =
+            decode_inline_image(&image, None).expect("unfiltered inline image should decode");
 
         assert!(Arc::ptr_eq(&decoded.data, &samples));
         assert_eq!(decoded.data.as_ref(), &[12, 34]);
@@ -707,9 +547,11 @@ mod tests {
                 ("W".to_string(), ObjectVariant::Integer(4)),
             ])),
             vec![0b1010_0000],
-        );
+            &PassthroughResolver,
+        )
+        .expect("inline image should be constructed");
 
-        let decoded = ImageXObject::decode_inline_image(&image, &PassthroughResolver, None)
+        let decoded = decode_inline_image(&image, None)
             .expect("inline image with abbreviated indexed color space should decode");
 
         assert_eq!(decoded.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
@@ -733,11 +575,11 @@ mod tests {
             ("Width".to_string(), ObjectVariant::Integer(8)),
         ]));
 
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![0b1011_0010]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("1-bpc image should decode");
 
@@ -751,11 +593,11 @@ mod tests {
     #[test]
     fn decode_normalized_indexed_image_1bpc_expands_samples() {
         let dictionary = indexed_dictionary(1);
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![0b1010_0000]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("1-bpc indexed image should decode");
 
@@ -771,11 +613,11 @@ mod tests {
     #[test]
     fn decode_normalized_indexed_image_2bpc_expands_samples() {
         let dictionary = indexed_dictionary(2);
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![0x1B]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("2-bpc indexed image should decode");
 
@@ -791,11 +633,11 @@ mod tests {
     #[test]
     fn decode_normalized_indexed_image_4bpc_expands_samples() {
         let dictionary = indexed_dictionary(4);
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![0x01, 0x23]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("4-bpc indexed image should decode");
 
@@ -811,11 +653,11 @@ mod tests {
     #[test]
     fn decode_normalized_indexed_image_8bpc_continues_to_work() {
         let dictionary = indexed_dictionary(8);
-        let image = ImageXObject::decode_normalized_image(
+        let image = decode_normalized_image(
             &dictionary,
             Arc::new(vec![0, 1, 2, 3]),
             &PassthroughResolver,
-            &None,
+            None,
         )
         .expect("8-bpc indexed image should decode");
 

--- a/crates/pdf-image/src/image_metadata.rs
+++ b/crates/pdf-image/src/image_metadata.rs
@@ -1,4 +1,5 @@
 use pdf_color_space::color_space::ColorSpace;
+use pdf_decode::DecodeMap;
 use pdf_filter::filter::Filters;
 use pdf_graphics::rect::Rect;
 use pdf_object::{
@@ -10,11 +11,21 @@ use crate::error::PdfImageError;
 /// Stores the normalized metadata needed to decode an image stream.
 #[derive(Debug, Clone)]
 pub(crate) struct ImageMetadata {
+    /// Image dimensions in pixels.
     pub(crate) size: Rect<usize>,
+    /// Number of bits used to encode each color component.
     pub(crate) bits_per_component: usize,
+    /// Color space used to interpret component samples, or `None` for an image mask.
     pub(crate) color_space: Option<ColorSpace>,
+    /// Whether the image samples form a stencil mask instead of color values.
     pub(crate) image_mask: bool,
+    /// Filter chain declared by the image dictionary.
+    ///
+    /// The chain is retained after filtering because some decoders, such as DCT and JPX,
+    /// produce samples that require filter-specific handling.
     pub(crate) filters: Option<Filters>,
+    /// Optional mapping from encoded component samples to decoded component values.
+    pub(crate) decode: Option<DecodeMap>,
 }
 
 impl ImageMetadata {
@@ -49,6 +60,10 @@ impl ImageMetadata {
             ColorSpace::from_dictionary(dictionary, objects)?
         };
         validate_bits_per_component(bits_per_component, image_mask, color_space.as_ref())?;
+        let num_color_components = color_space
+            .as_ref()
+            .map_or(1, ColorSpace::num_color_components);
+        let decode = DecodeMap::from_dictionary(dictionary, objects, num_color_components)?;
 
         Ok(Self {
             size,
@@ -56,6 +71,7 @@ impl ImageMetadata {
             color_space,
             image_mask,
             filters,
+            decode,
         })
     }
 }

--- a/crates/pdf-image/src/inline_image.rs
+++ b/crates/pdf-image/src/inline_image.rs
@@ -1,51 +1,41 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use pdf_object::{dictionary::Dictionary, object_variant::ObjectVariant};
+use pdf_filter::filter::decode_data_with_resolver;
+use pdf_object::{
+    dictionary::Dictionary, object_resolver::ObjectResolver, object_variant::ObjectVariant,
+};
+
+use crate::{error::PdfImageError, image_metadata::ImageMetadata};
 
 /// Canonical parsed representation of a PDF inline image.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub struct InlineImage {
-    dictionary: Dictionary,
+    metadata: ImageMetadata,
     data: Arc<Vec<u8>>,
 }
 
 impl InlineImage {
-    /// Creates a new inline image from its parsed dictionary and raw payload bytes.
-    pub fn new(dictionary: Dictionary, data: impl Into<Arc<Vec<u8>>>) -> Self {
-        Self {
-            dictionary,
-            data: data.into(),
-        }
+    /// Creates an inline image from its parsed dictionary and encoded payload bytes.
+    pub fn new(
+        dictionary: Dictionary,
+        data: impl Into<Arc<Vec<u8>>>,
+        objects: &dyn ObjectResolver,
+    ) -> Result<Self, PdfImageError> {
+        let dictionary = normalize_inline_image_dictionary(&dictionary);
+        let metadata = ImageMetadata::from_dictionary(&dictionary, objects)?;
+        let data = decode_data_with_resolver(&dictionary, data.into(), objects)?;
+
+        Ok(Self { metadata, data })
     }
 
-    /// Returns the parsed inline-image dictionary.
-    pub fn dictionary(&self) -> &Dictionary {
-        &self.dictionary
-    }
-
-    /// Returns the raw inline-image payload bytes.
-    pub fn data(&self) -> &[u8] {
-        self.data.as_slice()
-    }
-
-    /// Returns shared ownership of the raw inline-image payload bytes.
+    /// Returns shared ownership of the filter-decoded inline-image samples.
     pub fn shared_data(&self) -> Arc<Vec<u8>> {
         Arc::clone(&self.data)
     }
 
-    /// Splits the inline image into its parsed dictionary and shared raw payload.
-    pub fn into_parts(self) -> (Dictionary, Arc<Vec<u8>>) {
-        (self.dictionary, self.data)
-    }
-
-    /// Returns a normalized copy of the inline-image dictionary.
-    ///
-    /// PDF inline images use abbreviated keys such as `W`, `H`, and `BPC`.
-    /// Normalization maps those abbreviations to the canonical image keys so the
-    /// downstream image decoder can share the same path as image XObjects.
-    pub fn normalized_dictionary(&self) -> Dictionary {
-        normalize_inline_image_dictionary(&self.dictionary)
+    pub(crate) fn metadata(&self) -> &ImageMetadata {
+        &self.metadata
     }
 }
 
@@ -53,7 +43,7 @@ impl InlineImage {
 ///
 /// The parser preserves the abbreviated inline-image keys from the content stream.
 /// This helper expands the keys that are commonly shared with image XObjects.
-pub fn normalize_inline_image_dictionary(dictionary: &Dictionary) -> Dictionary {
+fn normalize_inline_image_dictionary(dictionary: &Dictionary) -> Dictionary {
     let mut normalized = BTreeMap::new();
 
     for (key, value) in &dictionary.dictionary {
@@ -108,27 +98,13 @@ fn normalize_inline_image_value(key: &str, value: &ObjectVariant) -> ObjectVaria
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-    use std::sync::Arc;
+    use std::{collections::BTreeMap, sync::Arc};
 
-    use pdf_object::object_variant::ObjectVariant;
+    use pdf_object::{
+        dictionary::Dictionary, object_resolver::PassthroughResolver, object_variant::ObjectVariant,
+    };
 
     use super::{InlineImage, normalize_inline_image_dictionary};
-
-    #[test]
-    fn inline_image_shares_payload_data() {
-        let data = Arc::new(vec![1, 2, 3, 4]);
-        let image = InlineImage::new(
-            pdf_object::dictionary::Dictionary::new(BTreeMap::new()),
-            Arc::clone(&data),
-        );
-
-        assert!(Arc::ptr_eq(&image.shared_data(), &data));
-        assert_eq!(image.data(), data.as_slice());
-
-        let (_, payload) = image.into_parts();
-        assert!(Arc::ptr_eq(&payload, &data));
-    }
 
     #[test]
     fn normalize_inline_image_dictionary_expands_abbreviations() {
@@ -218,18 +194,46 @@ mod tests {
     }
 
     #[test]
-    fn inline_image_normalized_dictionary_matches_helper() {
-        let inline = InlineImage::new(
-            pdf_object::dictionary::Dictionary::new(BTreeMap::from([(
-                "W".to_string(),
-                ObjectVariant::Integer(1),
-            )])),
-            vec![1],
+    fn inline_image_shares_unfiltered_samples() {
+        let data = Arc::new(vec![1, 2]);
+        let image = InlineImage::new(gray_dictionary(), Arc::clone(&data), &PassthroughResolver)
+            .expect("unfiltered image should be constructed");
+
+        assert!(Arc::ptr_eq(&image.shared_data(), &data));
+    }
+
+    #[test]
+    fn inline_image_applies_filters_during_construction() {
+        let mut dictionary = gray_dictionary();
+        dictionary.dictionary.insert(
+            "F".to_string(),
+            ObjectVariant::Name(b"ASCIIHexDecode".to_vec()),
         );
 
-        assert_eq!(
-            inline.normalized_dictionary().dictionary,
-            normalize_inline_image_dictionary(inline.dictionary()).dictionary
-        );
+        let image = InlineImage::new(dictionary, b"2A>".to_vec(), &PassthroughResolver)
+            .expect("filter should decode during construction");
+
+        assert_eq!(image.shared_data().as_ref(), &[0x2A]);
+    }
+
+    #[test]
+    fn invalid_metadata_is_rejected_during_construction() {
+        let error = InlineImage::new(
+            Dictionary::new(BTreeMap::new()),
+            vec![1],
+            &PassthroughResolver,
+        )
+        .expect_err("invalid metadata should prevent construction");
+
+        assert!(matches!(error, crate::error::PdfImageError::Object(_)));
+    }
+
+    fn gray_dictionary() -> Dictionary {
+        Dictionary::new(BTreeMap::from([
+            ("BPC".to_string(), ObjectVariant::Integer(8)),
+            ("CS".to_string(), ObjectVariant::Name(b"G".to_vec())),
+            ("H".to_string(), ObjectVariant::Integer(1)),
+            ("W".to_string(), ObjectVariant::Integer(2)),
+        ]))
     }
 }

--- a/crates/pdf-image/src/lib.rs
+++ b/crates/pdf-image/src/lib.rs
@@ -1,9 +1,9 @@
 mod decoded_samples;
 pub mod error;
+pub mod image_decoder;
 mod image_metadata;
-pub mod image_xobject;
 pub mod inline_image;
 
 pub use error::PdfImageError;
-pub use image_xobject::ImageXObject;
-pub use inline_image::{InlineImage, normalize_inline_image_dictionary};
+pub use image_decoder::{decode_inline_image, decode_normalized_image, read_xobject};
+pub use inline_image::InlineImage;

--- a/crates/pdf-parser/src/error.rs
+++ b/crates/pdf-parser/src/error.rs
@@ -60,4 +60,6 @@ pub enum ParserError {
     InvalidXrefAtOffset { offset: usize },
     #[error("Filter error: {0}")]
     FilterError(#[from] FilterError),
+    #[error("Inline image error: {0}")]
+    InlineImageError(String),
 }

--- a/crates/pdf-parser/src/inline_image.rs
+++ b/crates/pdf-parser/src/inline_image.rs
@@ -18,7 +18,8 @@ impl PdfParser<'_> {
         self.read_keyword_with_optional_eol(INLINE_IMAGE_DATA_BEGIN, false)?;
         self.consume_inline_image_data_separator()?;
         let data = self.read_inline_image_data_until_end(&dictionary, objects)?;
-        Ok(InlineImage::new(dictionary, data))
+        InlineImage::new(dictionary, data, objects)
+            .map_err(|error| ParserError::InlineImageError(error.to_string()))
     }
 
     /// Consumes the mandatory separator immediately after the `ID` keyword.
@@ -237,7 +238,7 @@ impl PdfParser<'_> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use pdf_object::{object_resolver::PassthroughResolver, object_variant::ObjectVariant};
+    use pdf_object::object_resolver::PassthroughResolver;
 
     use super::*;
 
@@ -265,11 +266,11 @@ mod tests {
 
     #[test]
     fn ignores_embedded_ei_without_whitespace_boundary() {
-        let mut parser = PdfParser::from(b"/W 1 /H 1 ID abcEIxdef\nEI Q".as_slice());
+        let mut parser = PdfParser::from(b"/W 1 /H 1 /BPC 8 /CS /G ID abcEIxdef\nEI Q".as_slice());
 
         let image = parser.parse_inline_image(&PassthroughResolver).unwrap();
 
-        assert_eq!(image.data(), b"abcEIxdef\n");
+        assert_eq!(image.shared_data().as_slice(), b"abcEIxdef\n");
         assert_eq!(parser.tokenizer.data(), b" Q");
     }
 
@@ -282,8 +283,14 @@ mod tests {
         let mut parser = PdfParser::from(input.as_slice());
         let image = parser.parse_inline_image(&PassthroughResolver).unwrap();
 
-        assert_eq!(image.data().len(), 34);
-        assert!(image.data().iter().all(|byte| *byte == 0xFF));
+        assert_eq!(image.shared_data().as_slice().len(), 34);
+        assert!(
+            image
+                .shared_data()
+                .as_slice()
+                .iter()
+                .all(|byte| *byte == 0xFF)
+        );
         assert_eq!(parser.tokenizer.data(), b" Q");
     }
 
@@ -294,7 +301,7 @@ mod tests {
 
         let image = parser.parse_inline_image(&PassthroughResolver).unwrap();
 
-        assert_eq!(image.data(), b"abc EIxyzj");
+        assert_eq!(image.shared_data().as_slice(), b"abc EIxyzj");
         assert_eq!(parser.tokenizer.data(), b" Q");
     }
 
@@ -304,7 +311,7 @@ mod tests {
 
         let image = parser.parse_inline_image(&PassthroughResolver).unwrap();
 
-        assert_eq!(image.data(), b"\x00\n");
+        assert_eq!(image.shared_data().as_slice(), b"\x00\n");
         assert_eq!(parser.tokenizer.data(), b" Q");
     }
 
@@ -317,43 +324,36 @@ mod tests {
         let mut parser = PdfParser::from(input.as_slice());
         let image = parser.parse_inline_image(&PassthroughResolver).unwrap();
 
-        assert_eq!(image.data(), &[0xFF, 0x80, b'\n']);
+        assert_eq!(image.shared_data().as_slice(), &[0xFF, 0x80, b'\n']);
         assert_eq!(parser.tokenizer.data(), b" Q");
     }
 
     #[test]
-    fn filtered_inline_image_still_uses_scan_terminator_detection() {
-        let mut parser =
-            PdfParser::from(b"/W 1 /H 1 /BPC 8 /F /ASCIIHexDecode ID aa EIxyz\nEI Q".as_slice());
+    fn filtered_inline_image_scans_to_the_terminator_before_filtering() {
+        let mut parser = PdfParser::from(
+            b"/W 1 /H 1 /BPC 8 /CS /G /F /ASCIIHexDecode ID aa EIxyz\nEI Q".as_slice(),
+        );
 
-        let image = parser.parse_inline_image(&PassthroughResolver).unwrap();
+        assert!(parser.parse_inline_image(&PassthroughResolver).is_err());
 
-        assert_eq!(image.data(), b"aa EIxyz\n");
         assert_eq!(parser.tokenizer.data(), b" Q");
     }
 
     #[test]
-    fn parses_empty_inline_image_dictionary() {
+    fn rejects_empty_inline_image_dictionary() {
         let mut parser = PdfParser::from(b"ID x\nEI".as_slice());
 
-        let image = parser.parse_inline_image(&PassthroughResolver).unwrap();
-
-        assert!(image.dictionary().dictionary.is_empty());
-        assert_eq!(image.data(), b"x\n");
+        assert!(parser.parse_inline_image(&PassthroughResolver).is_err());
         assert_eq!(parser.tokenizer.data(), b"");
     }
 
     #[test]
-    fn inline_image_dictionary_stops_before_id_after_name_value() {
-        let mut parser = PdfParser::from(b"/CS /DeviceGray ID x\nEI".as_slice());
+    fn inline_image_metadata_stops_before_id_after_name_value() {
+        let mut parser = PdfParser::from(b"/W 1 /H 1 /BPC 8 /CS /DeviceGray ID x\nEI".as_slice());
 
         let image = parser.parse_inline_image(&PassthroughResolver).unwrap();
 
-        assert_eq!(
-            image.dictionary().get("CS"),
-            Some(&ObjectVariant::Name(b"DeviceGray".to_vec()))
-        );
-        assert_eq!(image.data(), b"x\n");
+        assert_eq!(image.shared_data().as_slice(), b"x\n");
         assert_eq!(parser.tokenizer.data(), b"");
     }
 

--- a/crates/pdf-resources/src/resource.rs
+++ b/crates/pdf-resources/src/resource.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use pdf_color_space::color_space::ColorSpace;
 use pdf_font::font::Font;
-use pdf_image::ImageXObject;
+use pdf_graphics::Image;
 use pdf_shading::model::Shading;
 use std::{cell::OnceCell, rc::Rc};
 
@@ -47,7 +47,7 @@ pub enum Resource {
     /// An external graphics state resource.
     ExternalGraphicsState(Rc<ExternalGraphicsState>),
     /// An image XObject resource.
-    Image(Rc<ImageXObject>),
+    Image(Rc<Image>),
     /// An image XObject whose dimensions are malformed and cannot be rendered.
     UnavailableImage,
     /// A form XObject resource.
@@ -122,8 +122,8 @@ impl Resource {
     }
 }
 
-impl From<ImageXObject> for Resource {
-    fn from(image: ImageXObject) -> Self {
+impl From<Image> for Resource {
+    fn from(image: Image) -> Self {
         Self::Image(Rc::new(image))
     }
 }

--- a/crates/pdf-resources/src/xobject.rs
+++ b/crates/pdf-resources/src/xobject.rs
@@ -3,7 +3,8 @@ use crate::{
     resource_cache::ResourceCache,
 };
 use pdf_content_stream::ContentStreamIdAllocator;
-use pdf_image::{ImageXObject, PdfImageError};
+use pdf_graphics::Image;
+use pdf_image::{PdfImageError, read_xobject as decode_image_xobject};
 use pdf_object::{
     dictionary::Dictionary, object_lookup::ObjectLookupExt, object_resolver::ObjectResolver,
     object_variant::ObjectVariant, stream::StreamObject,
@@ -59,11 +60,11 @@ fn read_xobject_inner(
 
             let soft_mask =
                 resolve_image_soft_mask(dictionary, objects, cache, cycle_tracker, id_allocator)?;
-            Ok(Resource::from(ImageXObject::read_xobject(
+            Ok(Resource::from(decode_image_xobject(
                 dictionary,
                 stream_data,
                 objects,
-                soft_mask,
+                soft_mask.as_ref(),
             )?))
         }
         "Form" => FormXObject::read_xobject(
@@ -93,7 +94,7 @@ fn resolve_image_soft_mask(
     cache: &mut dyn ResourceCache,
     cycle_tracker: &mut ReadCycleTracker,
     id_allocator: &mut ContentStreamIdAllocator,
-) -> Result<Option<ImageXObject>, PdfPagesError> {
+) -> Result<Option<Image>, PdfPagesError> {
     let Some(smask_obj) = dictionary.get("SMask") else {
         return Ok(None);
     };


### PR DESCRIPTION
Move render-ready images into pdf-graphics and route XObjects and inline images through a shared normalized sample pipeline. Decode inline image metadata and filters once while preserving shared buffers.

Specialize RGBA conversion around fixed output chunks, retain soft-mask and uncommon-component behavior, and add focused tests and benchmarks.