### PR TITLE
pdf-image: honor declared image color spaces

### DIFF
--- a/crates/pdf-decode/src/map.rs
+++ b/crates/pdf-decode/src/map.rs
@@ -73,6 +73,20 @@ impl DecodeMap {
         }
         out
     }
+
+    /// Applies the decode ranges while retaining their floating-point component domains.
+    #[must_use]
+    pub fn apply_to_f32(&self, samples: &[u8], sample_max: u8) -> Vec<f32> {
+        if self.ranges.is_empty() {
+            return Vec::new();
+        }
+
+        samples
+            .iter()
+            .zip(self.ranges.iter().cycle())
+            .map(|(sample, range)| range.map_f32(*sample, sample_max))
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -150,5 +164,14 @@ mod tests {
         let out = map.apply_to_bytes(&[255, 0, 0, 255], 255, 255);
 
         assert_eq!(out, vec![128, 255, 0, 0]);
+    }
+
+    #[test]
+    fn decode_map_preserves_non_normalized_float_ranges() {
+        let map = DecodeMap {
+            ranges: vec![DecodeRange::new(-100.0, 100.0).unwrap()],
+        };
+
+        assert_eq!(map.apply_to_f32(&[0, 255], 255), vec![-100.0, 100.0]);
     }
 }

--- a/crates/pdf-decode/src/range.rs
+++ b/crates/pdf-decode/src/range.rs
@@ -33,11 +33,16 @@ impl DecodeRange {
 
     /// Maps one packed sample byte into the requested output range.
     pub fn map_byte(&self, sample: u8, sample_max: u8, output_max: u8) -> u8 {
-        let sample_max = f32::from(sample_max.max(1));
-        let normalized = f32::from(sample) / sample_max;
-        let decoded = self.min + normalized * (self.max - self.min);
+        let decoded = self.map_f32(sample, sample_max);
         let scaled = decoded * f32::from(output_max);
         let clamped = scaled.clamp(0.0, f32::from(output_max));
         clamped.round().to_u8().unwrap_or(u8::MAX)
+    }
+
+    /// Maps one packed sample byte into this range without quantizing the result.
+    pub fn map_f32(&self, sample: u8, sample_max: u8) -> f32 {
+        let sample_max = f32::from(sample_max.max(1));
+        let normalized = f32::from(sample) / sample_max;
+        self.min + normalized * (self.max - self.min)
     }
 }

--- a/crates/pdf-image/src/decoded_samples.rs
+++ b/crates/pdf-image/src/decoded_samples.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
+use pdf_color_space::color_space::ColorSpace;
 use pdf_decode::{
     DecodeMap, DecodeRange, SampleLayout, decode_sample_bytes, expand_indexed_values,
 };
@@ -12,6 +13,8 @@ use crate::image_metadata::ImageMetadata;
 pub(crate) struct DecodedSamples {
     pub(crate) num_color_components: usize,
     pub(crate) image_data: Arc<Vec<u8>>,
+    /// Whether `image_data` is already render-ready RGBA rather than source components.
+    pub(crate) is_rgba: bool,
 }
 
 impl DecodedSamples {
@@ -28,14 +31,21 @@ impl DecodedSamples {
             decoded_samples
         } else {
             match &metadata.color_space {
-                Some(pdf_color_space::color_space::ColorSpace::Indexed(indexed)) => {
-                    Self::decode_indexed(
-                        raw_data,
-                        metadata,
-                        indexed.base.num_color_components(),
-                        indexed.hival,
-                        &indexed.lookup,
-                    )
+                Some(ColorSpace::Indexed(indexed)) => {
+                    if indexed.base.is_device_space() {
+                        Self::decode_indexed(
+                            raw_data,
+                            metadata,
+                            indexed.base.num_color_components(),
+                            indexed.hival,
+                            &indexed.lookup,
+                        )
+                    } else {
+                        Self::decode_indexed_rgba(raw_data, metadata, indexed)
+                    }
+                }
+                Some(color_space) if !color_space.is_device_space() => {
+                    Self::decode_direct_rgba(raw_data, metadata, color_space)
                 }
                 Some(color_space) => {
                     Self::decode_direct(raw_data, metadata, color_space.num_color_components())
@@ -90,6 +100,7 @@ impl DecodedSamples {
         Some(Self {
             num_color_components,
             image_data,
+            is_rgba: false,
         })
     }
 
@@ -118,6 +129,7 @@ impl DecodedSamples {
         Some(Self {
             num_color_components,
             image_data: Arc::clone(raw_data),
+            is_rgba: false,
         })
     }
 
@@ -161,6 +173,47 @@ impl DecodedSamples {
         Ok(Self {
             num_color_components: base_color_components,
             image_data: Arc::new(image_data),
+            is_rgba: false,
+        })
+    }
+
+    /// Converts an Indexed palette through a non-device base once, then maps pixels to RGBA.
+    fn decode_indexed_rgba(
+        raw_data: Arc<Vec<u8>>,
+        metadata: &ImageMetadata,
+        indexed: &pdf_color_space::indexed_color_space::IndexedColorSpace,
+    ) -> Result<Self, PdfImageError> {
+        let sample_codes = Self::decode_image_sample_codes(raw_data, 1, metadata)?;
+        let sample_max = Self::sample_max(metadata.bits_per_component)?;
+        let indices = Self::apply_decode(
+            sample_codes,
+            metadata.decode.as_ref(),
+            sample_max,
+            sample_max,
+            metadata.image_mask,
+        );
+
+        let indexed_color_space = ColorSpace::Indexed(indexed.clone());
+        let mut palette = Vec::with_capacity(usize::from(indexed.hival).saturating_add(1));
+        for index in 0..=indexed.hival {
+            palette.push(indexed_color_space.apply(&[f32::from(index)])?.to_rgba8());
+        }
+
+        let mut image_data = Vec::with_capacity(indices.len().saturating_mul(4));
+        for index in indices.iter().copied() {
+            let bounded = index.min(indexed.hival);
+            let rgba = palette.get(usize::from(bounded)).ok_or_else(|| {
+                PdfImageError::InvalidImageData(format!(
+                    "Indexed RGBA palette entry {bounded} is unavailable"
+                ))
+            })?;
+            image_data.extend_from_slice(rgba);
+        }
+
+        Ok(Self {
+            num_color_components: 4,
+            image_data: Arc::new(image_data),
+            is_rgba: true,
         })
     }
 
@@ -183,7 +236,69 @@ impl DecodedSamples {
                 255,
                 metadata.image_mask,
             ),
+            is_rgba: false,
         })
+    }
+
+    /// Converts decoded samples through their declared non-device color space.
+    fn decode_direct_rgba(
+        raw_data: Arc<Vec<u8>>,
+        metadata: &ImageMetadata,
+        color_space: &ColorSpace,
+    ) -> Result<Self, PdfImageError> {
+        let components = color_space.num_color_components();
+        let sample_codes = Self::decode_image_sample_codes(raw_data, components, metadata)?;
+        let sample_max = Self::sample_max(metadata.bits_per_component)?;
+        let decoded = metadata.decode.as_ref().map_or_else(
+            || Self::default_color_components(sample_codes.as_ref(), sample_max, color_space),
+            |decode| decode.apply_to_f32(sample_codes.as_ref(), sample_max),
+        );
+        let mut image_data = Vec::with_capacity(
+            decoded
+                .len()
+                .checked_div(components)
+                .unwrap_or(0)
+                .saturating_mul(4),
+        );
+        for pixel in decoded.chunks_exact(components) {
+            image_data.extend_from_slice(&color_space.apply(pixel)?.to_rgba8());
+        }
+
+        Ok(Self {
+            num_color_components: 4,
+            image_data: Arc::new(image_data),
+            is_rgba: true,
+        })
+    }
+
+    /// Applies the implicit decode domains for non-device color spaces.
+    fn default_color_components(
+        samples: &[u8],
+        sample_max: u8,
+        color_space: &ColorSpace,
+    ) -> Vec<f32> {
+        let denominator = f32::from(sample_max.max(1));
+        match color_space {
+            ColorSpace::Lab(lab) => samples
+                .chunks_exact(3)
+                .flat_map(|pixel| {
+                    let [l, a, b] = pixel else {
+                        return [0.0; 3];
+                    };
+                    let [amin, amax, bmin, bmax] = lab.range;
+                    let normalized = |sample| f32::from(sample) / denominator;
+                    [
+                        normalized(*l) * 100.0,
+                        amin + normalized(*a) * (amax - amin),
+                        bmin + normalized(*b) * (bmax - bmin),
+                    ]
+                })
+                .collect(),
+            _ => samples
+                .iter()
+                .map(|sample| f32::from(*sample) / denominator)
+                .collect(),
+        }
     }
 
     /// Applies an explicit decode map or the implicit PDF identity/inverted default.

--- a/crates/pdf-image/src/image_decoder.rs
+++ b/crates/pdf-image/src/image_decoder.rs
@@ -57,7 +57,16 @@ fn decode_normalized_image_with_metadata(
     let DecodedSamples {
         num_color_components,
         image_data,
+        is_rgba,
     } = decoded_samples;
+    if is_rgba {
+        return Ok(image_from_rgba(
+            image_data,
+            metadata.size.width(),
+            metadata.size.height(),
+            soft_mask,
+        ));
+    }
     Ok(Image::from_decoded_samples(
         image_data,
         metadata.size.width(),
@@ -65,6 +74,58 @@ fn decode_normalized_image_with_metadata(
         num_color_components,
         soft_mask,
     ))
+}
+
+/// Builds a render image from color-space-converted RGBA and combines its alpha with `/SMask`.
+fn image_from_rgba(
+    data: Arc<Vec<u8>>,
+    width: usize,
+    height: usize,
+    soft_mask: Option<&Image>,
+) -> Image {
+    let byte_len = width
+        .saturating_mul(height)
+        .saturating_mul(4)
+        .min(data.len());
+    if soft_mask.is_none() && byte_len == data.len() {
+        return Image {
+            data,
+            width,
+            height,
+            pixel_format: pdf_graphics::PixelFormat::RGBA8888,
+        };
+    }
+
+    let mut rgba = data.get(..byte_len).map_or_else(Vec::new, <[u8]>::to_vec);
+    if let Some(mask) = soft_mask {
+        for (pixel, mask_alpha) in rgba.chunks_exact_mut(4).zip(soft_mask_alphas(mask)) {
+            if let [_, _, _, alpha] = pixel {
+                let combined = u16::from(*alpha).saturating_mul(u16::from(mask_alpha)) / 255;
+                *alpha = u8::try_from(combined).unwrap_or(u8::MAX);
+            }
+        }
+    }
+    Image {
+        data: Arc::new(rgba),
+        width,
+        height,
+        pixel_format: pdf_graphics::PixelFormat::RGBA8888,
+    }
+}
+
+fn soft_mask_alphas(mask: &Image) -> Box<dyn Iterator<Item = u8> + '_> {
+    match mask.pixel_format {
+        pdf_graphics::PixelFormat::Gray8 => Box::new(mask.data.iter().copied()),
+        pdf_graphics::PixelFormat::RGBA8888 => {
+            Box::new(mask.data.chunks_exact(4).filter_map(|pixel| match pixel {
+                [gray, _, _, alpha] => {
+                    let combined = u16::from(*gray).saturating_mul(u16::from(*alpha)) / 255;
+                    Some(u8::try_from(combined).unwrap_or(u8::MAX))
+                }
+                _ => None,
+            }))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -81,6 +142,74 @@ mod tests {
 
     use super::{InlineImage, decode_inline_image, decode_normalized_image, read_xobject};
     use crate::error::PdfImageError;
+
+    fn name(value: &str) -> ObjectVariant {
+        ObjectVariant::Name(value.as_bytes().to_vec())
+    }
+
+    fn fixture_cal_rgb() -> ObjectVariant {
+        ObjectVariant::Array(vec![
+            name("CalRGB"),
+            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([
+                (
+                    "WhitePoint".to_string(),
+                    ObjectVariant::Array(vec![
+                        ObjectVariant::Real(0.9505),
+                        ObjectVariant::Real(1.0),
+                        ObjectVariant::Real(1.089),
+                    ]),
+                ),
+                (
+                    "Matrix".to_string(),
+                    ObjectVariant::Array(vec![
+                        ObjectVariant::Real(0.9505),
+                        ObjectVariant::Real(1.0),
+                        ObjectVariant::Real(1.089),
+                        ObjectVariant::Integer(0),
+                        ObjectVariant::Integer(0),
+                        ObjectVariant::Integer(0),
+                        ObjectVariant::Integer(0),
+                        ObjectVariant::Integer(0),
+                        ObjectVariant::Integer(0),
+                    ]),
+                ),
+            ])))),
+        ])
+    }
+
+    fn fixture_device_n() -> ObjectVariant {
+        let function = StreamObject::new(
+            1,
+            0,
+            Box::new(Dictionary::new(BTreeMap::from([
+                ("FunctionType".to_string(), ObjectVariant::Integer(4)),
+                (
+                    "Domain".to_string(),
+                    ObjectVariant::Array(
+                        (0..4)
+                            .flat_map(|_| [ObjectVariant::Integer(0), ObjectVariant::Integer(1)])
+                            .collect(),
+                    ),
+                ),
+                (
+                    "Range".to_string(),
+                    ObjectVariant::Array(
+                        (0..3)
+                            .flat_map(|_| [ObjectVariant::Integer(0), ObjectVariant::Integer(1)])
+                            .collect(),
+                    ),
+                ),
+            ]))),
+            b"4 3 roll pop".to_vec(),
+        );
+
+        ObjectVariant::Array(vec![
+            name("DeviceN"),
+            ObjectVariant::Array(vec![name("IBM"), name("None"), name("None"), name("None")]),
+            fixture_cal_rgb(),
+            ObjectVariant::Stream(function),
+        ])
+    }
 
     #[test]
     fn read_xobject_uses_predecoded_filtered_stream_data() {
@@ -192,6 +321,132 @@ mod tests {
 
         assert_eq!(image.pixel_format, pdf_graphics::PixelFormat::RGBA8888);
         assert_eq!(image.data.as_ref(), &[10, 11, 12, 255, 20, 21, 22, 255]);
+    }
+
+    #[test]
+    fn indexed_device_n_palette_is_converted_through_cal_rgb() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            ("BitsPerComponent".to_string(), ObjectVariant::Integer(8)),
+            (
+                "ColorSpace".to_string(),
+                ObjectVariant::Array(vec![
+                    name("Indexed"),
+                    fixture_device_n(),
+                    ObjectVariant::Integer(0),
+                    ObjectVariant::HexString(vec![0, 255, 255, 255]),
+                ]),
+            ),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
+        ]));
+
+        let image =
+            decode_normalized_image(&dictionary, Arc::new(vec![0]), &PassthroughResolver, None)
+                .expect("Indexed DeviceN image should convert through its alternate space");
+
+        assert_eq!(image.pixel_format, PixelFormat::RGBA8888);
+        assert_eq!(image.data.as_ref(), &[255, 255, 255, 255]);
+    }
+
+    #[test]
+    fn direct_four_component_device_n_is_not_interpreted_as_cmyk() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            ("BitsPerComponent".to_string(), ObjectVariant::Integer(8)),
+            ("ColorSpace".to_string(), fixture_device_n()),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
+        ]));
+
+        let image = decode_normalized_image(
+            &dictionary,
+            Arc::new(vec![0, 255, 255, 255]),
+            &PassthroughResolver,
+            None,
+        )
+        .expect("DeviceN image should convert through its tint transform");
+
+        assert_eq!(image.data.as_ref(), &[255, 255, 255, 255]);
+    }
+
+    #[test]
+    fn indexed_device_cmyk_keeps_device_fast_path() {
+        let dictionary = Dictionary::new(BTreeMap::from([
+            ("BitsPerComponent".to_string(), ObjectVariant::Integer(8)),
+            (
+                "ColorSpace".to_string(),
+                ObjectVariant::Array(vec![
+                    name("Indexed"),
+                    name("DeviceCMYK"),
+                    ObjectVariant::Integer(0),
+                    ObjectVariant::HexString(vec![0, 0, 0, 0]),
+                ]),
+            ),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
+        ]));
+
+        let image =
+            decode_normalized_image(&dictionary, Arc::new(vec![0]), &PassthroughResolver, None)
+                .expect("Indexed DeviceCMYK image should retain its existing conversion");
+
+        assert_eq!(image.data.as_ref(), &[255, 255, 255, 255]);
+    }
+
+    #[test]
+    fn color_space_alpha_is_combined_with_soft_mask() {
+        let tint_function = StreamObject::new(
+            2,
+            0,
+            Box::new(Dictionary::new(BTreeMap::from([
+                ("FunctionType".to_string(), ObjectVariant::Integer(4)),
+                (
+                    "Domain".to_string(),
+                    ObjectVariant::Array(vec![
+                        ObjectVariant::Integer(0),
+                        ObjectVariant::Integer(1),
+                    ]),
+                ),
+                (
+                    "Range".to_string(),
+                    ObjectVariant::Array(
+                        (0..3)
+                            .flat_map(|_| [ObjectVariant::Integer(0), ObjectVariant::Integer(1)])
+                            .collect(),
+                    ),
+                ),
+            ]))),
+            b"pop 1 1 1".to_vec(),
+        );
+        let dictionary = Dictionary::new(BTreeMap::from([
+            ("BitsPerComponent".to_string(), ObjectVariant::Integer(8)),
+            (
+                "ColorSpace".to_string(),
+                ObjectVariant::Array(vec![
+                    name("Separation"),
+                    name("None"),
+                    name("DeviceRGB"),
+                    ObjectVariant::Stream(tint_function),
+                ]),
+            ),
+            ("Height".to_string(), ObjectVariant::Integer(1)),
+            ("Width".to_string(), ObjectVariant::Integer(1)),
+        ]));
+        let soft_mask = Image {
+            data: Arc::new(vec![128]),
+            width: 1,
+            height: 1,
+            pixel_format: PixelFormat::Gray8,
+        };
+
+        let image = decode_normalized_image(
+            &dictionary,
+            Arc::new(vec![255]),
+            &PassthroughResolver,
+            Some(&soft_mask),
+        )
+        .expect("Separation alpha should survive soft-mask application");
+
+        assert_eq!(image.data.as_ref(), &[0, 0, 0, 0]);
     }
 
     #[test]


### PR DESCRIPTION
Convert calibrated, spot, DeviceN, and ICC-based image samples through their declared color spaces instead of inferring CMYK from a four-component buffer. Preserve floating-point decode domains for the conversion and combine color-space alpha with image soft masks.

Cache converted RGBA palettes for Indexed non-device color spaces while retaining the existing device-space and preconverted JPEG/JPX paths. Add regressions for the issue9940 DeviceN tint transform and device-space behavior.