### PR TITLE
pdf-color-space: centralize device color conversion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ Supporting crates:
 
 - Idiomatic Rust: iterators, ownership, lifetimes over cloning
 - Small, composable functions over monolithic ones
+- Do not add trivial helper functions whose only purpose is to construct and return a single error variant; inline the error construction at the call site
 - Avoid unnecessary heap allocations; prefer references and slices
 - Document public functions, structs, and enums with `///` comments
 - Unit tests go in `mod tests {}` within the same file

--- a/crates/pdf-canvas/src/canvas_color_ops.rs
+++ b/crates/pdf-canvas/src/canvas_color_ops.rs
@@ -8,25 +8,20 @@ use crate::{
 };
 use pdf_graphics::color::Color;
 
-fn color_from_generic_components(components: &[f32]) -> Option<Color> {
-    match *components {
-        [gray] => Some(Color::from_gray(gray)),
-        [r, g, b] => Some(Color::from_rgb(r, g, b)),
-        [c, m, y, k] => Some(Color::from_cmyk(c, m, y, k)),
-        _ => None,
-    }
-}
-
 fn apply_content_stream_color(
     color_space: &ColorSpace,
     components: &[f32],
 ) -> Result<Color, ColorSpaceError> {
+    // Honor the declared color space whenever its component count is valid.
     match color_space.apply(components) {
         Ok(color) => Ok(color),
+        // Some malformed content streams use SC/sc/SCN/scn operands whose count
+        // identifies a different device color space than the active one. Recover
+        // only from that arity mismatch; other color spaces and errors stay strict.
         Err(err @ ColorSpaceError::InsufficientComponents(_, _))
             if color_space.is_device_space() =>
         {
-            color_from_generic_components(components).ok_or(err)
+            Color::from_device_components(components).ok_or(err)
         }
         Err(err) => Err(err),
     }

--- a/crates/pdf-color-space/src/color_space.rs
+++ b/crates/pdf-color-space/src/color_space.rs
@@ -102,22 +102,61 @@ impl ColorSpace {
             ColorSpace::CalGray(cal_gray) => cal_gray.apply(components),
             ColorSpace::CalRGB(cal_rgb) => cal_rgb.apply(components),
             ColorSpace::DeviceN(dn) => dn.apply(components),
-            ColorSpace::DeviceGray => match *components {
-                [g] => Ok(Color::from_gray(g)),
-                _ => Err(ColorSpaceError::InsufficientComponents(1, components.len())),
-            },
-            ColorSpace::DeviceRGB => match *components {
-                [r, g, b] => Ok(Color::from_rgb(r, g, b)),
-                _ => Err(ColorSpaceError::InsufficientComponents(3, components.len())),
-            },
-            ColorSpace::DeviceCMYK => match *components {
-                [c, m, y, k] => Ok(Color::from_cmyk(c, m, y, k)),
-                _ => Err(ColorSpaceError::InsufficientComponents(4, components.len())),
-            },
+            device_space @ (ColorSpace::DeviceGray
+            | ColorSpace::DeviceRGB
+            | ColorSpace::DeviceCMYK) => {
+                let expected_components = device_space.num_color_components();
+                Color::from_device_components(components)
+                    .filter(|_| components.len() == expected_components)
+                    .ok_or(ColorSpaceError::InsufficientComponents(
+                        expected_components,
+                        components.len(),
+                    ))
+            }
             ColorSpace::Pattern(_) => Err(ColorSpaceError::Unsupported(
                 "Pattern color space: color is set by the pattern resource, not by components"
                     .into(),
             )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pdf_graphics::color::Color;
+
+    use super::ColorSpace;
+    use crate::error::ColorSpaceError;
+
+    #[test]
+    fn applies_device_color_space_components() {
+        assert_eq!(
+            ColorSpace::DeviceGray.apply(&[0.5]).expect("valid gray"),
+            Color::from_gray(0.5)
+        );
+        assert_eq!(
+            ColorSpace::DeviceRGB
+                .apply(&[0.1, 0.2, 0.3])
+                .expect("valid RGB"),
+            Color::from_rgb(0.1, 0.2, 0.3)
+        );
+        assert_eq!(
+            ColorSpace::DeviceCMYK
+                .apply(&[0.1, 0.2, 0.3, 0.4])
+                .expect("valid CMYK"),
+            Color::from_cmyk(0.1, 0.2, 0.3, 0.4)
+        );
+    }
+
+    #[test]
+    fn device_color_space_remains_strict_about_component_count() {
+        let error = ColorSpace::DeviceRGB
+            .apply(&[0.5])
+            .expect_err("DeviceRGB must not interpret one component as gray");
+
+        assert!(matches!(
+            error,
+            ColorSpaceError::InsufficientComponents(3, 1)
+        ));
     }
 }

--- a/crates/pdf-color-space/src/icc_based_color_space.rs
+++ b/crates/pdf-color-space/src/icc_based_color_space.rs
@@ -20,11 +20,11 @@ pub struct ICCBasedColorSpace {
     ///
     /// If absent, the device-equivalent for `num_components` is used instead.
     pub alternate_space: Option<Box<ColorSpace>>,
-    /// Raw ICC profile bytes.
+    /// Shared raw ICC profile bytes.
     ///
     /// ICC colour management is not yet implemented. The alternate space (or a
     /// device-equivalent) is used for rendering until ICC support is added.
-    pub profile_data: Arc<[u8]>,
+    pub profile_data: Arc<Vec<u8>>,
 }
 
 /// Parses an ICCBased color space: `[/ICCBased stream]`
@@ -60,7 +60,7 @@ pub(crate) fn parse_icc_based_color_space(
         .transpose()?
         .map(Box::new);
 
-    let profile_data: Arc<[u8]> = stream.raw_data().to_vec().into();
+    let profile_data = stream.shared_data();
 
     Ok(ColorSpace::ICCBased(ICCBasedColorSpace {
         num_components,
@@ -82,13 +82,78 @@ impl ICCBasedColorSpace {
         if let Some(alt) = &self.alternate_space {
             return alt.apply(components);
         }
-        match (self.num_components, components) {
-            (1, [g]) => Ok(Color::from_gray(*g)),
-            (3, [r, g, b]) => Ok(Color::from_rgb(*r, *g, *b)),
-            (4, [c, m, y, k]) => Ok(Color::from_cmyk(*c, *m, *y, *k)),
-            (n, _) => Err(ColorSpaceError::Unsupported(format!(
-                "ICCBased with {n} components has no alternate space"
-            ))),
+        Color::from_device_components(components).ok_or_else(|| {
+            ColorSpaceError::Unsupported(format!(
+                "ICCBased with {} components has no alternate space",
+                self.num_components
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::BTreeMap, sync::Arc};
+
+    use pdf_graphics::color::Color;
+    use pdf_object::{
+        dictionary::Dictionary, object_resolver::PassthroughResolver,
+        object_variant::ObjectVariant, stream::StreamObject,
+    };
+
+    use super::{ICCBasedColorSpace, parse_icc_based_color_space};
+
+    fn icc_based(num_components: usize) -> ICCBasedColorSpace {
+        ICCBasedColorSpace {
+            num_components,
+            alternate_space: None,
+            profile_data: Arc::new(Vec::new()),
         }
+    }
+
+    #[test]
+    fn parsed_profile_shares_stream_data() {
+        let stream = StreamObject::new(
+            1,
+            0,
+            Box::new(Dictionary::new(BTreeMap::from([(
+                "N".to_string(),
+                ObjectVariant::Integer(3),
+            )]))),
+            vec![1, 2, 3, 4],
+        );
+        let stream_data = stream.shared_data();
+        let array = [
+            ObjectVariant::Name(b"ICCBased".to_vec()),
+            ObjectVariant::Stream(stream),
+        ];
+
+        let parsed = parse_icc_based_color_space(&PassthroughResolver, &array, 0)
+            .expect("ICCBased color space should parse");
+        let crate::color_space::ColorSpace::ICCBased(icc_based) = parsed else {
+            panic!("expected ICCBased color space");
+        };
+
+        assert!(Arc::ptr_eq(&icc_based.profile_data, &stream_data));
+    }
+
+    #[test]
+    fn uses_device_equivalent_without_an_alternate_space() {
+        assert_eq!(
+            icc_based(1).apply(&[0.5]).expect("valid gray fallback"),
+            Color::from_gray(0.5)
+        );
+        assert_eq!(
+            icc_based(3)
+                .apply(&[0.1, 0.2, 0.3])
+                .expect("valid RGB fallback"),
+            Color::from_rgb(0.1, 0.2, 0.3)
+        );
+        assert_eq!(
+            icc_based(4)
+                .apply(&[0.1, 0.2, 0.3, 0.4])
+                .expect("valid CMYK fallback"),
+            Color::from_cmyk(0.1, 0.2, 0.3, 0.4)
+        );
     }
 }

--- a/crates/pdf-graphics/src/color.rs
+++ b/crates/pdf-graphics/src/color.rs
@@ -69,6 +69,21 @@ impl Color {
         Self { r, g, b, a: 1.0 }
     }
 
+    /// Creates a color from device color-space components.
+    ///
+    /// The component count determines the device color space: one component
+    /// is grayscale, three components are RGB, and four components are CMYK.
+    /// Returns `None` for any other component count.
+    #[must_use]
+    pub fn from_device_components(components: &[f32]) -> Option<Self> {
+        match *components {
+            [gray] => Some(Self::from_gray(gray)),
+            [r, g, b] => Some(Self::from_rgb(r, g, b)),
+            [c, m, y, k] => Some(Self::from_cmyk(c, m, y, k)),
+            _ => None,
+        }
+    }
+
     /// Converts a CIE L\*a\*b\* color to sRGB.
     ///
     /// Implements the standard pipeline: LAB → XYZ (using the PDF-provided white point)
@@ -180,6 +195,32 @@ mod tests {
 
         let white = Color::from_gray(1.0);
         assert!(approx_eq(white.r, 1.0) && approx_eq(white.g, 1.0) && approx_eq(white.b, 1.0));
+    }
+
+    #[test]
+    fn creates_colors_from_device_components() {
+        assert_eq!(
+            Color::from_device_components(&[0.5]),
+            Some(Color::from_gray(0.5))
+        );
+        assert_eq!(
+            Color::from_device_components(&[0.1, 0.2, 0.3]),
+            Some(Color::from_rgb(0.1, 0.2, 0.3))
+        );
+        assert_eq!(
+            Color::from_device_components(&[0.1, 0.2, 0.3, 0.4]),
+            Some(Color::from_cmyk(0.1, 0.2, 0.3, 0.4))
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_device_component_counts() {
+        assert_eq!(Color::from_device_components(&[]), None);
+        assert_eq!(Color::from_device_components(&[0.1, 0.2]), None);
+        assert_eq!(
+            Color::from_device_components(&[0.1, 0.2, 0.3, 0.4, 0.5]),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add a shared Color constructor for device components and use it for strict device spaces, ICC fallbacks, and tolerant content-stream recovery. Preserve declared-space validation and document why malformed device operands are inferred only while rendering content streams.

Share ICC profile stream storage through Arc<Vec<u8>> instead of copying the profile into a new allocation. Add regression coverage for device arity, ICC fallbacks, and shared profile data.

Document the preference to inline one-off error construction helpers.