### PR TITLE
pdf-content-stream: accelerate operator parsing

### DIFF
--- a/crates/pdf-content-stream-operators/src/color_operators.rs
+++ b/crates/pdf-content-stream-operators/src/color_operators.rs
@@ -5,6 +5,7 @@ use crate::{
     pdf_operator_backend::{BackendError, PdfOperatorBackend},
     variants::PdfOperatorVariant,
 };
+use pdf_object::object_resolver::PassthroughResolver;
 
 /// Sets the fill color to a grayscale value.
 /// The gray level applies to subsequent fill operations.
@@ -31,7 +32,9 @@ impl PdfOperator for SetGrayFill {
     const OPERAND_COUNT: Option<usize> = Some(1);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let gray = operands.get_f32()?;
+        let gray = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetGrayFill(Self::new(gray)))
     }
 
@@ -60,7 +63,9 @@ impl PdfOperator for SetGrayStroke {
     const OPERAND_COUNT: Option<usize> = Some(1);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let gray = operands.get_f32()?;
+        let gray = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetGrayStroke(Self::new(gray)))
     }
 
@@ -98,9 +103,7 @@ impl PdfOperator for SetRGBFill {
     const OPERAND_COUNT: Option<usize> = Some(3);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let r = operands.get_f32()?;
-        let g = operands.get_f32()?;
-        let b = operands.get_f32()?;
+        let [r, g, b] = operands.try_array_of::<f32, 3>()?;
         Ok(PdfOperatorVariant::SetRGBFill(Self::new(r, g, b)))
     }
 
@@ -133,9 +136,7 @@ impl PdfOperator for SetRGBStroke {
     const OPERAND_COUNT: Option<usize> = Some(3);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let r = operands.get_f32()?;
-        let g = operands.get_f32()?;
-        let b = operands.get_f32()?;
+        let [r, g, b] = operands.try_array_of::<f32, 3>()?;
         Ok(PdfOperatorVariant::SetRGBStroke(Self::new(r, g, b)))
     }
 
@@ -175,10 +176,7 @@ impl PdfOperator for SetCMYKFill {
     const OPERAND_COUNT: Option<usize> = Some(4);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let c = operands.get_f32()?;
-        let m = operands.get_f32()?;
-        let y = operands.get_f32()?;
-        let k = operands.get_f32()?;
+        let [c, m, y, k] = operands.try_array_of::<f32, 4>()?;
         Ok(PdfOperatorVariant::SetCMYKFill(Self::new(c, m, y, k)))
     }
 
@@ -213,10 +211,7 @@ impl PdfOperator for SetCMYKStroke {
     const OPERAND_COUNT: Option<usize> = Some(4);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let c = operands.get_f32()?;
-        let m = operands.get_f32()?;
-        let y = operands.get_f32()?;
-        let k = operands.get_f32()?;
+        let [c, m, y, k] = operands.try_array_of::<f32, 4>()?;
         Ok(PdfOperatorVariant::SetCMYKStroke(Self::new(c, m, y, k)))
     }
 
@@ -310,7 +305,9 @@ impl PdfOperator for SetStrokingColor {
             if value.is_name() {
                 break;
             }
-            let v = operands.get_f32()?;
+            let v = operands
+                .take_next()?
+                .try_number::<f32>(&PassthroughResolver)?;
             values.push(v);
         }
 
@@ -368,7 +365,9 @@ impl PdfOperator for SetNonStrokingColor {
             if value.is_name() {
                 break;
             }
-            let v = operands.get_f32()?;
+            let v = operands
+                .take_next()?
+                .try_number::<f32>(&PassthroughResolver)?;
             values.push(v);
         }
 
@@ -416,7 +415,11 @@ impl PdfOperator for SetNonStrokingColorSc {
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
         let mut values = vec![];
         while operands.peek_next().is_some() {
-            values.push(operands.get_f32()?);
+            values.push(
+                operands
+                    .take_next()?
+                    .try_number::<f32>(&PassthroughResolver)?,
+            );
         }
 
         if values.is_empty() {
@@ -452,7 +455,11 @@ impl PdfOperator for SetStrokingColorSc {
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
         let mut values = vec![];
         while operands.peek_next().is_some() {
-            values.push(operands.get_f32()?);
+            values.push(
+                operands
+                    .take_next()?
+                    .try_number::<f32>(&PassthroughResolver)?,
+            );
         }
 
         if values.is_empty() {

--- a/crates/pdf-content-stream-operators/src/graphics_state_operators.rs
+++ b/crates/pdf-content-stream-operators/src/graphics_state_operators.rs
@@ -1,5 +1,6 @@
 use num_traits::FromPrimitive;
 use pdf_graphics::{LineCap, LineJoin, transform::Transform};
+use pdf_object::object_resolver::PassthroughResolver;
 
 use crate::{
     error::PdfOperatorError,
@@ -28,7 +29,9 @@ impl PdfOperator for SetLineWidth {
     const OPERAND_COUNT: Option<usize> = Some(1);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let width = operands.get_f32()?;
+        let width = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetLineWidth(Self::new(width)))
     }
 
@@ -125,7 +128,9 @@ impl PdfOperator for SetMiterLimit {
     const OPERAND_COUNT: Option<usize> = Some(1);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let limit = operands.get_f32()?;
+        let limit = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetMiterLimit(Self::new(limit)))
     }
 
@@ -156,7 +161,9 @@ impl PdfOperator for SetDashPattern {
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
         let array = operands.get_f32_array()?;
-        let phase = operands.get_f32()?;
+        let phase = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetDashPattern(Self::new(array, phase)))
     }
 
@@ -185,7 +192,9 @@ impl PdfOperator for SetFlatnessTolerance {
     const OPERAND_COUNT: Option<usize> = Some(1);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let tolerance = operands.get_f32()?;
+        let tolerance = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetFlatnessTolerance(Self::new(
             tolerance,
         )))
@@ -285,12 +294,7 @@ impl PdfOperator for ConcatMatrix {
     const OPERAND_COUNT: Option<usize> = Some(6);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let a = operands.get_f32()?;
-        let b = operands.get_f32()?;
-        let c = operands.get_f32()?;
-        let d = operands.get_f32()?;
-        let e = operands.get_f32()?;
-        let f = operands.get_f32()?;
+        let [a, b, c, d, e, f] = operands.try_array_of::<f32, 6>()?;
         Ok(PdfOperatorVariant::ConcatMatrix(Self::new([
             a, b, c, d, e, f,
         ])))

--- a/crates/pdf-content-stream-operators/src/operands.rs
+++ b/crates/pdf-content-stream-operators/src/operands.rs
@@ -1,67 +1,240 @@
 use crate::error::PdfOperatorError;
-use pdf_object::{object_resolver::PassthroughResolver, object_variant::ObjectVariant};
+use num_traits::FromPrimitive;
+use pdf_object::{
+    error::ObjectError, object_resolver::PassthroughResolver, object_variant::ObjectVariant,
+};
 
-pub struct Operands(pub Vec<ObjectVariant>);
+/// Reusable storage for the operands belonging to one PDF operator.
+///
+/// Values are consumed through a cursor instead of being removed from the front
+/// of the backing vector. This keeps reads constant-time and lets the content
+/// stream parser reuse the allocation for subsequent operators.
+pub struct Operands {
+    values: Vec<ObjectVariant>,
+    position: usize,
+}
 
 impl Operands {
-    /// Peeks at the next operand without consuming it.
-    ///
-    /// Unlike [`take_next`], this method does not advance the internal slice.
-    ///
-    /// # Returns
-    ///
-    /// `Some` with a reference to the next operand, or `None` if there are no more operands.
-    pub fn peek_next(&self) -> Option<&ObjectVariant> {
-        self.0.first()
-    }
-
-    /// Pops and returns the next operand, advancing the internal slice.
-    pub(crate) fn take_next(&mut self) -> Result<ObjectVariant, PdfOperatorError> {
-        if !self.0.is_empty() {
-            Ok(self.0.remove(0))
-        } else {
-            Err(PdfOperatorError::OperandMissing {
-                expected: "an operand",
-            })
+    /// Creates an empty operand buffer with the requested capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            values: Vec::with_capacity(capacity),
+            position: 0,
         }
     }
 
-    pub fn get_f32(&mut self) -> Result<f32, PdfOperatorError> {
-        let value = self.take_next()?.try_number::<f32>(&PassthroughResolver)?;
-        Ok(value)
+    /// Appends an operand to the buffer.
+    pub fn push(&mut self, value: ObjectVariant) {
+        self.values.push(value);
     }
 
+    /// Returns the number of operands that have not yet been consumed.
+    pub fn len(&self) -> usize {
+        self.values.len().saturating_sub(self.position)
+    }
+
+    /// Returns whether every operand has been consumed.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the current backing allocation capacity.
+    pub fn capacity(&self) -> usize {
+        self.values.capacity()
+    }
+
+    /// Clears all operands and resets the read cursor while retaining capacity.
+    pub fn clear(&mut self) {
+        self.values.clear();
+        self.position = 0;
+    }
+
+    /// Peeks at the next operand without consuming it.
+    pub fn peek_next(&self) -> Option<&ObjectVariant> {
+        self.values.get(self.position)
+    }
+
+    /// Removes and returns the next operand in constant time.
+    pub(crate) fn take_next(&mut self) -> Result<ObjectVariant, PdfOperatorError> {
+        let Some(value) = self.values.get_mut(self.position) else {
+            return Err(PdfOperatorError::OperandMissing {
+                expected: "an operand",
+            });
+        };
+
+        self.position = self.position.saturating_add(1);
+        Ok(std::mem::replace(value, ObjectVariant::Null))
+    }
+
+    /// Converts and consumes the next `N` numeric operands.
+    pub(crate) fn try_array_of<T, const N: usize>(&mut self) -> Result<[T; N], ObjectError>
+    where
+        T: FromPrimitive + Copy + Default,
+    {
+        if self.len() < N {
+            return Err(ObjectError::InvalidArrayLength {
+                expected: N,
+                found: self.len(),
+            });
+        }
+
+        let mut result = [T::default(); N];
+        for output in &mut result {
+            *output = self
+                .take_next()
+                .map_err(|_| ObjectError::InvalidArrayLength {
+                    expected: N,
+                    found: self.len(),
+                })?
+                .try_number(&PassthroughResolver)?;
+        }
+        Ok(result)
+    }
+
+    /// Reads the next operand as an `f32`.
+    pub fn get_f32(&mut self) -> Result<f32, PdfOperatorError> {
+        Ok(self.take_next()?.try_number::<f32>(&PassthroughResolver)?)
+    }
+
+    /// Reads the next string-like operand as an owned UTF-8 string.
+    ///
+    /// The underlying byte allocation is moved into the returned `String`.
     pub fn get_str(&mut self) -> Result<String, PdfOperatorError> {
         let object = self.take_next()?;
-        match object.try_str(&PassthroughResolver) {
-            Ok(value) => Ok(value.to_owned()),
-            Err(_) => Err(PdfOperatorError::OperandTypeMismatch {
-                expected: "a string operand (HexString, Name, or LiteralString)",
-                found: object.name(),
-            }),
-        }
+        let (value, found) = match object {
+            ObjectVariant::HexString(value) => (value, "HexString"),
+            ObjectVariant::Name(value) => (value, "Name"),
+            ObjectVariant::LiteralString(value) => (value, "LiteralString"),
+            other => {
+                return Err(PdfOperatorError::OperandTypeMismatch {
+                    expected: "a string operand (HexString, Name, or LiteralString)",
+                    found: other.name(),
+                });
+            }
+        };
+
+        String::from_utf8(value).map_err(|_| PdfOperatorError::OperandTypeMismatch {
+            expected: "a string operand (HexString, Name, or LiteralString)",
+            found,
+        })
     }
 
+    /// Reads the next string-like operand as owned bytes.
     pub fn get_bytes(&mut self) -> Result<Vec<u8>, PdfOperatorError> {
         let object = self.take_next()?;
         match object {
-            ObjectVariant::HexString(s)
-            | ObjectVariant::Name(s)
-            | ObjectVariant::LiteralString(s) => Ok(s),
-            _ => Err(PdfOperatorError::OperandTypeMismatch {
+            ObjectVariant::HexString(value)
+            | ObjectVariant::Name(value)
+            | ObjectVariant::LiteralString(value) => Ok(value),
+            other => Err(PdfOperatorError::OperandTypeMismatch {
                 expected: "a byte string operand (HexString, Name, or LiteralString)",
-                found: object.name(),
+                found: other.name(),
             }),
         }
     }
 
+    /// Reads the next operand as a `u8`.
     pub fn get_u8(&mut self) -> Result<u8, PdfOperatorError> {
-        let value = self.take_next()?.try_number::<u8>(&PassthroughResolver)?;
-        Ok(value)
+        Ok(self.take_next()?.try_number::<u8>(&PassthroughResolver)?)
     }
 
+    /// Reads the next array operand as numeric `f32` values.
     pub fn get_f32_array(&mut self) -> Result<Vec<f32>, PdfOperatorError> {
         let array = self.take_next()?;
         Ok(array.try_vec_of::<f32>(&PassthroughResolver)?)
+    }
+}
+
+impl From<Vec<ObjectVariant>> for Operands {
+    fn from(values: Vec<ObjectVariant>) -> Self {
+        Self {
+            values,
+            position: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operands_are_consumed_in_order_without_reducing_capacity() {
+        let values = vec![
+            ObjectVariant::Integer(1),
+            ObjectVariant::Real(2.5),
+            ObjectVariant::Integer(3),
+        ];
+        let original_capacity = values.capacity();
+        let mut operands = Operands::from(values);
+
+        assert_eq!(operands.get_f32().expect("first number should parse"), 1.0);
+        assert_eq!(operands.peek_next(), Some(&ObjectVariant::Real(2.5)));
+        assert_eq!(
+            operands
+                .try_array_of::<f32, 2>()
+                .expect("remaining numbers should parse"),
+            [2.5, 3.0]
+        );
+        assert!(operands.is_empty());
+        assert_eq!(operands.capacity(), original_capacity);
+    }
+
+    #[test]
+    fn clear_resets_the_cursor_and_reuses_allocation() {
+        let mut operands = Operands::with_capacity(6);
+        operands.push(ObjectVariant::Integer(7));
+        let capacity = operands.capacity();
+
+        assert_eq!(operands.get_u8().expect("number should parse"), 7);
+        operands.clear();
+        operands.push(ObjectVariant::Integer(8));
+
+        assert_eq!(operands.get_u8().expect("reused number should parse"), 8);
+        assert!(operands.capacity() >= capacity);
+    }
+
+    #[test]
+    fn grouped_conversion_consumes_through_the_invalid_operand() {
+        let mut operands = Operands::from(vec![
+            ObjectVariant::Integer(1),
+            ObjectVariant::LiteralString(b"not a number".to_vec()),
+            ObjectVariant::Integer(3),
+        ]);
+
+        let result = operands.try_array_of::<f32, 2>();
+
+        assert!(matches!(
+            result,
+            Err(ObjectError::TypeMismatch("Number", _))
+        ));
+        assert_eq!(operands.peek_next(), Some(&ObjectVariant::Integer(3)));
+    }
+
+    #[test]
+    fn grouped_conversion_rejects_too_few_operands_without_consuming() {
+        let mut operands = Operands::from(vec![ObjectVariant::Integer(1)]);
+
+        assert!(matches!(
+            operands.try_array_of::<f32, 2>(),
+            Err(ObjectError::InvalidArrayLength {
+                expected: 2,
+                found: 1
+            })
+        ));
+        assert_eq!(operands.len(), 1);
+    }
+
+    #[test]
+    fn get_str_reuses_the_operand_byte_allocation() {
+        let bytes = b"ResourceName".to_vec();
+        let original_pointer = bytes.as_ptr();
+        let mut operands = Operands::from(vec![ObjectVariant::Name(bytes)]);
+
+        let value = operands.get_str().expect("name should be valid UTF-8");
+
+        assert_eq!(value, "ResourceName");
+        assert_eq!(value.as_ptr(), original_pointer);
     }
 }

--- a/crates/pdf-content-stream-operators/src/operation_map.rs
+++ b/crates/pdf-content-stream-operators/src/operation_map.rs
@@ -22,123 +22,111 @@ use crate::{
 use pdf_image::InlineImage;
 use pdf_parser::parser::PdfParser;
 
+/// Custom parser used by operators whose bytes are not represented by the
+/// regular operand list.
+pub type OperatorParseHook =
+    for<'a> fn(&mut PdfParser<'a>) -> Result<Option<PdfOperatorVariant>, PdfOperatorError>;
+
 /// Defines a mapping between a PDF operator's string representation (e.g., "m" for MoveTo)
 /// and a function that can construct that operator an array of operands.
 /// This is used to dynamically dispatch to the correct parsing logic based on the operator
 /// encountered in the PDF content.
+#[derive(Clone, Copy)]
 pub struct OpDescriptor {
-    pub name: &'static [u8],
     pub operand_count: Option<usize>,
     pub parser: fn(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError>,
-    pub parse_hook:
-        for<'a> fn(&mut PdfParser<'a>) -> Result<Option<PdfOperatorVariant>, PdfOperatorError>,
+    pub parse_hook: Option<OperatorParseHook>,
 }
 
 impl OpDescriptor {
     const fn from<T: PdfOperator>() -> Self {
         Self {
-            name: T::NAME,
             operand_count: T::OPERAND_COUNT,
             parser: T::read,
-            parse_hook: T::parse,
+            parse_hook: None,
+        }
+    }
+
+    const fn with_parse_hook<T: PdfOperator>() -> Self {
+        Self {
+            operand_count: T::OPERAND_COUNT,
+            parser: T::read,
+            parse_hook: Some(T::parse),
         }
     }
 }
 
-// MUST remain sorted lexicographically by `name` — binary search depends on this.
-// If you add a new entry, insert it in the correct position and verify with the
-// `read_map_is_sorted` test below.
-pub(crate) const READ_MAP: &[OpDescriptor] = &[
-    OpDescriptor::from::<SetSpacingMoveShowText>(), // "\""
-    OpDescriptor::from::<MoveNextLineShowText>(),   // "'"
-    OpDescriptor::from::<FillAndStrokePathNonZero>(), // "B"
-    OpDescriptor::from::<FillAndStrokePathEvenOdd>(), // "B*"
-    OpDescriptor::from::<BeginMarkedContentWithProps>(), // "BDC"
-    OpDescriptor::from::<InlineImage>(),            // "BI"
-    OpDescriptor::from::<BeginMarkedContent>(),     // "BMC"
-    OpDescriptor::from::<BeginText>(),              // "BT"
-    OpDescriptor::from::<BeginCompatibility>(),     // "BX"
-    OpDescriptor::from::<SetStrokeColorSpace>(),    // "CS"
-    OpDescriptor::from::<InvokeXObject>(),          // "Do"
-    OpDescriptor::from::<EndMarkedContent>(),       // "EMC"
-    OpDescriptor::from::<EndText>(),                // "ET"
-    OpDescriptor::from::<EndCompatibility>(),       // "EX"
-    OpDescriptor::from::<SetGrayStroke>(),          // "G"
-    OpDescriptor::from::<SetLineCapStyle>(),        // "J"
-    OpDescriptor::from::<SetCMYKStroke>(),          // "K"
-    OpDescriptor::from::<SetMiterLimit>(),          // "M"
-    OpDescriptor::from::<RestoreGraphicsState>(),   // "Q"
-    OpDescriptor::from::<SetRGBStroke>(),           // "RG"
-    OpDescriptor::from::<StrokePath>(),             // "S"
-    OpDescriptor::from::<SetStrokingColorSc>(),     // "SC"
-    OpDescriptor::from::<SetStrokingColor>(),       // "SCN"
-    OpDescriptor::from::<MoveToNextLine>(),         // "T*"
-    OpDescriptor::from::<MoveTextPositionAndSetLeading>(), // "TD"
-    OpDescriptor::from::<ShowTextArray>(),          // "TJ"
-    OpDescriptor::from::<SetLeading>(),             // "TL"
-    OpDescriptor::from::<SetCharacterSpacing>(),    // "Tc"
-    OpDescriptor::from::<MoveTextPosition>(),       // "Td"
-    OpDescriptor::from::<SetFont>(),                // "Tf"
-    OpDescriptor::from::<ShowText>(),               // "Tj"
-    OpDescriptor::from::<SetTextMatrix>(),          // "Tm"
-    OpDescriptor::from::<SetRenderingMode>(),       // "Tr"
-    OpDescriptor::from::<SetTextRise>(),            // "Ts"
-    OpDescriptor::from::<SetWordSpacing>(),         // "Tw"
-    OpDescriptor::from::<SetHorizontalScaling>(),   // "Tz"
-    OpDescriptor::from::<ClipNonZero>(),            // "W"
-    OpDescriptor::from::<ClipEvenOdd>(),            // "W*"
-    OpDescriptor::from::<CloseFillAndStrokePathNonZero>(), // "b"
-    OpDescriptor::from::<CloseFillAndStrokePathEvenOdd>(), // "b*"
-    OpDescriptor::from::<CurveTo>(),                // "c"
-    OpDescriptor::from::<ConcatMatrix>(),           // "cm"
-    OpDescriptor::from::<SetNonStrokingColorSpace>(), // "cs"
-    OpDescriptor::from::<SetDashPattern>(),         // "d"
-    OpDescriptor::from::<SetCharWidth>(),           // "d0"
-    OpDescriptor::from::<SetCharWidthAndBoundingBox>(), // "d1"
-    OpDescriptor::from::<FillPathNonZero>(),        // "f"
-    OpDescriptor::from::<FillPathEvenOdd>(),        // "f*"
-    OpDescriptor::from::<SetGrayFill>(),            // "g"
-    OpDescriptor::from::<SetGraphicsStateFromDict>(), // "gs"
-    OpDescriptor::from::<ClosePath>(),              // "h"
-    OpDescriptor::from::<SetFlatnessTolerance>(),   // "i"
-    OpDescriptor::from::<SetLineJoinStyle>(),       // "j"
-    OpDescriptor::from::<SetCMYKFill>(),            // "k"
-    OpDescriptor::from::<LineTo>(),                 // "l"
-    OpDescriptor::from::<MoveTo>(),                 // "m"
-    OpDescriptor::from::<EndPath>(),                // "n"
-    OpDescriptor::from::<SaveGraphicsState>(),      // "q"
-    OpDescriptor::from::<Rectangle>(),              // "re"
-    OpDescriptor::from::<SetRGBFill>(),             // "rg"
-    OpDescriptor::from::<SetRenderingIntent>(),     // "ri"
-    OpDescriptor::from::<CloseStrokePath>(),        // "s"
-    OpDescriptor::from::<SetNonStrokingColorSc>(),  // "sc"
-    OpDescriptor::from::<SetNonStrokingColor>(),    // "scn"
-    OpDescriptor::from::<PaintShading>(),           // "sh"
-    OpDescriptor::from::<CurveToV>(),               // "v"
-    OpDescriptor::from::<SetLineWidth>(),           // "w"
-    OpDescriptor::from::<CurveToY>(),               // "y"
-];
-
-pub fn get_operation_descriptor(name: &[u8]) -> Option<&'static OpDescriptor> {
-    READ_MAP
-        .binary_search_by(|op| op.name.cmp(name))
-        .ok()
-        .and_then(|idx| READ_MAP.get(idx))
-}
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn read_map_is_sorted() {
-        let names: Vec<_> = READ_MAP.iter().map(|op| op.name).collect();
-        let mut expected = names.clone();
-        expected.sort_unstable();
-        assert_eq!(
-            names, expected,
-            "READ_MAP must be sorted lexicographically by name for binary search to work"
-        );
+/// Returns the parser descriptor for a PDF content-stream operator.
+pub fn get_operation_descriptor(name: &[u8]) -> Option<OpDescriptor> {
+    match name {
+        b"\"" => Some(OpDescriptor::from::<SetSpacingMoveShowText>()),
+        b"'" => Some(OpDescriptor::from::<MoveNextLineShowText>()),
+        b"B" => Some(OpDescriptor::from::<FillAndStrokePathNonZero>()),
+        b"B*" => Some(OpDescriptor::from::<FillAndStrokePathEvenOdd>()),
+        b"BDC" => Some(OpDescriptor::from::<BeginMarkedContentWithProps>()),
+        b"BI" => Some(OpDescriptor::with_parse_hook::<InlineImage>()),
+        b"BMC" => Some(OpDescriptor::from::<BeginMarkedContent>()),
+        b"BT" => Some(OpDescriptor::from::<BeginText>()),
+        b"BX" => Some(OpDescriptor::from::<BeginCompatibility>()),
+        b"CS" => Some(OpDescriptor::from::<SetStrokeColorSpace>()),
+        b"Do" => Some(OpDescriptor::from::<InvokeXObject>()),
+        b"EMC" => Some(OpDescriptor::from::<EndMarkedContent>()),
+        b"ET" => Some(OpDescriptor::from::<EndText>()),
+        b"EX" => Some(OpDescriptor::from::<EndCompatibility>()),
+        b"G" => Some(OpDescriptor::from::<SetGrayStroke>()),
+        b"J" => Some(OpDescriptor::from::<SetLineCapStyle>()),
+        b"K" => Some(OpDescriptor::from::<SetCMYKStroke>()),
+        b"M" => Some(OpDescriptor::from::<SetMiterLimit>()),
+        b"Q" => Some(OpDescriptor::from::<RestoreGraphicsState>()),
+        b"RG" => Some(OpDescriptor::from::<SetRGBStroke>()),
+        b"S" => Some(OpDescriptor::from::<StrokePath>()),
+        b"SC" => Some(OpDescriptor::from::<SetStrokingColorSc>()),
+        b"SCN" => Some(OpDescriptor::from::<SetStrokingColor>()),
+        b"T*" => Some(OpDescriptor::from::<MoveToNextLine>()),
+        b"TD" => Some(OpDescriptor::from::<MoveTextPositionAndSetLeading>()),
+        b"TJ" => Some(OpDescriptor::from::<ShowTextArray>()),
+        b"TL" => Some(OpDescriptor::from::<SetLeading>()),
+        b"Tc" => Some(OpDescriptor::from::<SetCharacterSpacing>()),
+        b"Td" => Some(OpDescriptor::from::<MoveTextPosition>()),
+        b"Tf" => Some(OpDescriptor::from::<SetFont>()),
+        b"Tj" => Some(OpDescriptor::from::<ShowText>()),
+        b"Tm" => Some(OpDescriptor::from::<SetTextMatrix>()),
+        b"Tr" => Some(OpDescriptor::from::<SetRenderingMode>()),
+        b"Ts" => Some(OpDescriptor::from::<SetTextRise>()),
+        b"Tw" => Some(OpDescriptor::from::<SetWordSpacing>()),
+        b"Tz" => Some(OpDescriptor::from::<SetHorizontalScaling>()),
+        b"W" => Some(OpDescriptor::from::<ClipNonZero>()),
+        b"W*" => Some(OpDescriptor::from::<ClipEvenOdd>()),
+        b"b" => Some(OpDescriptor::from::<CloseFillAndStrokePathNonZero>()),
+        b"b*" => Some(OpDescriptor::from::<CloseFillAndStrokePathEvenOdd>()),
+        b"c" => Some(OpDescriptor::from::<CurveTo>()),
+        b"cm" => Some(OpDescriptor::from::<ConcatMatrix>()),
+        b"cs" => Some(OpDescriptor::from::<SetNonStrokingColorSpace>()),
+        b"d" => Some(OpDescriptor::from::<SetDashPattern>()),
+        b"d0" => Some(OpDescriptor::from::<SetCharWidth>()),
+        b"d1" => Some(OpDescriptor::from::<SetCharWidthAndBoundingBox>()),
+        b"f" => Some(OpDescriptor::from::<FillPathNonZero>()),
+        b"f*" => Some(OpDescriptor::from::<FillPathEvenOdd>()),
+        b"g" => Some(OpDescriptor::from::<SetGrayFill>()),
+        b"gs" => Some(OpDescriptor::from::<SetGraphicsStateFromDict>()),
+        b"h" => Some(OpDescriptor::from::<ClosePath>()),
+        b"i" => Some(OpDescriptor::from::<SetFlatnessTolerance>()),
+        b"j" => Some(OpDescriptor::from::<SetLineJoinStyle>()),
+        b"k" => Some(OpDescriptor::from::<SetCMYKFill>()),
+        b"l" => Some(OpDescriptor::from::<LineTo>()),
+        b"m" => Some(OpDescriptor::from::<MoveTo>()),
+        b"n" => Some(OpDescriptor::from::<EndPath>()),
+        b"q" => Some(OpDescriptor::from::<SaveGraphicsState>()),
+        b"re" => Some(OpDescriptor::from::<Rectangle>()),
+        b"rg" => Some(OpDescriptor::from::<SetRGBFill>()),
+        b"ri" => Some(OpDescriptor::from::<SetRenderingIntent>()),
+        b"s" => Some(OpDescriptor::from::<CloseStrokePath>()),
+        b"sc" => Some(OpDescriptor::from::<SetNonStrokingColorSc>()),
+        b"scn" => Some(OpDescriptor::from::<SetNonStrokingColor>()),
+        b"sh" => Some(OpDescriptor::from::<PaintShading>()),
+        b"v" => Some(OpDescriptor::from::<CurveToV>()),
+        b"w" => Some(OpDescriptor::from::<SetLineWidth>()),
+        b"y" => Some(OpDescriptor::from::<CurveToY>()),
+        _ => None,
     }
 }

--- a/crates/pdf-content-stream-operators/src/path_operators.rs
+++ b/crates/pdf-content-stream-operators/src/path_operators.rs
@@ -28,8 +28,7 @@ impl PdfOperator for MoveTo {
     const OPERAND_COUNT: Option<usize> = Some(2);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let x = operands.get_f32()?;
-        let y = operands.get_f32()?;
+        let [x, y] = operands.try_array_of::<f32, 2>()?;
         Ok(PdfOperatorVariant::MoveTo(Self::new(x, y)))
     }
 
@@ -60,8 +59,7 @@ impl PdfOperator for LineTo {
     const OPERAND_COUNT: Option<usize> = Some(2);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let x = operands.get_f32()?;
-        let y = operands.get_f32()?;
+        let [x, y] = operands.try_array_of::<f32, 2>()?;
         Ok(PdfOperatorVariant::LineTo(Self::new(x, y)))
     }
 
@@ -108,12 +106,7 @@ impl PdfOperator for CurveTo {
     const OPERAND_COUNT: Option<usize> = Some(6);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let x1 = operands.get_f32()?;
-        let y1 = operands.get_f32()?;
-        let x2 = operands.get_f32()?;
-        let y2 = operands.get_f32()?;
-        let x3 = operands.get_f32()?;
-        let y3 = operands.get_f32()?;
+        let [x1, y1, x2, y2, x3, y3] = operands.try_array_of::<f32, 6>()?;
         Ok(PdfOperatorVariant::CurveTo(Self::new(
             x1, y1, x2, y2, x3, y3,
         )))
@@ -152,10 +145,7 @@ impl PdfOperator for CurveToV {
     const OPERAND_COUNT: Option<usize> = Some(4);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let x2 = operands.get_f32()?;
-        let y2 = operands.get_f32()?;
-        let x3 = operands.get_f32()?;
-        let y3 = operands.get_f32()?;
+        let [x2, y2, x3, y3] = operands.try_array_of::<f32, 4>()?;
         Ok(PdfOperatorVariant::CurveToV(Self::new(x2, y2, x3, y3)))
     }
 
@@ -191,10 +181,7 @@ impl PdfOperator for CurveToY {
     const OPERAND_COUNT: Option<usize> = Some(4);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let x1 = operands.get_f32()?;
-        let y1 = operands.get_f32()?;
-        let x3 = operands.get_f32()?;
-        let y3 = operands.get_f32()?;
+        let [x1, y1, x3, y3] = operands.try_array_of::<f32, 4>()?;
         Ok(PdfOperatorVariant::CurveToY(Self::new(x1, y1, x3, y3)))
     }
 
@@ -254,10 +241,7 @@ impl PdfOperator for Rectangle {
     const OPERAND_COUNT: Option<usize> = Some(4);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let x = operands.get_f32()?;
-        let y = operands.get_f32()?;
-        let width = operands.get_f32()?;
-        let height = operands.get_f32()?;
+        let [x, y, width, height] = operands.try_array_of::<f32, 4>()?;
         Ok(PdfOperatorVariant::Rectangle(Self::new(
             x, y, width, height,
         )))

--- a/crates/pdf-content-stream-operators/src/text_positioning_operators.rs
+++ b/crates/pdf-content-stream-operators/src/text_positioning_operators.rs
@@ -32,8 +32,7 @@ impl PdfOperator for MoveTextPosition {
     const OPERAND_COUNT: Option<usize> = Some(2);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let tx = operands.get_f32()?;
-        let ty = operands.get_f32()?;
+        let [tx, ty] = operands.try_array_of::<f32, 2>()?;
         Ok(PdfOperatorVariant::MoveTextPosition(Self::new(tx, ty)))
     }
 
@@ -65,8 +64,7 @@ impl PdfOperator for MoveTextPositionAndSetLeading {
     const OPERAND_COUNT: Option<usize> = Some(2);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let tx = operands.get_f32()?;
-        let ty = operands.get_f32()?;
+        let [tx, ty] = operands.try_array_of::<f32, 2>()?;
         Ok(PdfOperatorVariant::MoveTextPositionAndSetLeading(
             Self::new(tx, ty),
         ))
@@ -105,12 +103,7 @@ impl PdfOperator for SetTextMatrix {
     const OPERAND_COUNT: Option<usize> = Some(6);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let a = operands.get_f32()?;
-        let b = operands.get_f32()?;
-        let c = operands.get_f32()?;
-        let d = operands.get_f32()?;
-        let e = operands.get_f32()?;
-        let f = operands.get_f32()?;
+        let [a, b, c, d, e, f] = operands.try_array_of::<f32, 6>()?;
         Ok(PdfOperatorVariant::SetTextMatrix(Self::new([
             a, b, c, d, e, f,
         ])))

--- a/crates/pdf-content-stream-operators/src/text_showing_operators.rs
+++ b/crates/pdf-content-stream-operators/src/text_showing_operators.rs
@@ -31,7 +31,7 @@ impl PdfOperator for ShowText {
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
         let text = operands.get_bytes()?;
-        Ok(PdfOperatorVariant::ShowText(Self::new(text.to_vec())))
+        Ok(PdfOperatorVariant::ShowText(Self::new(text)))
     }
 
     fn call<T: PdfOperatorBackend>(&self, backend: &mut T) -> Result<(), BackendError<T>> {
@@ -59,9 +59,7 @@ impl PdfOperator for MoveNextLineShowText {
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
         let text = operands.get_bytes()?;
-        Ok(PdfOperatorVariant::MoveNextLineShowText(Self::new(
-            text.to_vec(),
-        )))
+        Ok(PdfOperatorVariant::MoveNextLineShowText(Self::new(text)))
     }
 
     fn call<T: PdfOperatorBackend>(&self, backend: &mut T) -> Result<(), BackendError<T>> {
@@ -97,14 +95,13 @@ impl PdfOperator for SetSpacingMoveShowText {
     const OPERAND_COUNT: Option<usize> = Some(3);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let word_spacing = operands.get_f32()?;
-        let char_spacing = operands.get_f32()?;
+        let [word_spacing, char_spacing] = operands.try_array_of::<f32, 2>()?;
         let text = operands.get_bytes()?;
 
         Ok(PdfOperatorVariant::SetSpacingMoveShowText(Self::new(
             word_spacing,
             char_spacing,
-            text.to_vec(),
+            text,
         )))
     }
 
@@ -161,5 +158,46 @@ impl PdfOperator for ShowTextArray {
 
     fn call<T: PdfOperatorBackend>(&self, backend: &mut T) -> Result<(), BackendError<T>> {
         backend.show_text_with_glyph_positioning(&self.elements)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn show_text_moves_the_operand_byte_allocation() {
+        let text = b"text without a copy".to_vec();
+        let original_pointer = text.as_ptr();
+        let mut operands = Operands::from(vec![ObjectVariant::LiteralString(text)]);
+
+        let operator = ShowText::read(&mut operands).expect("text should parse");
+        let PdfOperatorVariant::ShowText(operator) = operator else {
+            panic!("expected ShowText variant");
+        };
+
+        assert_eq!(operator.text, b"text without a copy");
+        assert_eq!(operator.text.as_ptr(), original_pointer);
+    }
+
+    #[test]
+    fn spacing_move_show_text_groups_numeric_prefix_before_text() {
+        let mut operands = Operands::from(vec![
+            ObjectVariant::Real(1.5),
+            ObjectVariant::Integer(2),
+            ObjectVariant::LiteralString(b"text".to_vec()),
+        ]);
+
+        let operator = SetSpacingMoveShowText::read(&mut operands)
+            .expect("mixed operands should parse successfully");
+        let PdfOperatorVariant::SetSpacingMoveShowText(operator) = operator else {
+            panic!("expected SetSpacingMoveShowText variant");
+        };
+
+        assert_eq!(operator.word_spacing, 1.5);
+        assert_eq!(operator.char_spacing, 2.0);
+        assert_eq!(operator.text, b"text");
+        assert!(operands.is_empty());
     }
 }

--- a/crates/pdf-content-stream-operators/src/text_state_operators.rs
+++ b/crates/pdf-content-stream-operators/src/text_state_operators.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use num_traits::FromPrimitive;
 use pdf_graphics::TextRenderingMode;
+use pdf_object::object_resolver::PassthroughResolver;
 
 /// Sets the character spacing, `Tc`, which is a number expressed in unscaled text space units.
 #[derive(Debug, Clone, PartialEq)]
@@ -27,7 +28,9 @@ impl PdfOperator for SetCharacterSpacing {
     const OPERAND_COUNT: Option<usize> = Some(1);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let spacing = operands.get_f32()?;
+        let spacing = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetCharacterSpacing(Self::new(spacing)))
     }
 
@@ -56,7 +59,9 @@ impl PdfOperator for SetWordSpacing {
     const OPERAND_COUNT: Option<usize> = Some(1);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let spacing = operands.get_f32()?;
+        let spacing = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetWordSpacing(Self::new(spacing)))
     }
 
@@ -85,7 +90,9 @@ impl PdfOperator for SetHorizontalScaling {
     const OPERAND_COUNT: Option<usize> = Some(1);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let scale = operands.get_f32()?;
+        let scale = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetHorizontalScaling(Self::new(scale)))
     }
 
@@ -120,7 +127,9 @@ impl PdfOperator for SetLeading {
     const OPERAND_COUNT: Option<usize> = Some(1);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let leading = operands.get_f32()?;
+        let leading = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetLeading(Self::new(leading)))
     }
 
@@ -162,7 +171,9 @@ impl PdfOperator for SetFont {
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
         let name = operands.get_str()?;
-        let size = operands.get_f32()?;
+        let size = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetFont(Self::new(name, size)))
     }
 
@@ -226,7 +237,9 @@ impl PdfOperator for SetTextRise {
     const OPERAND_COUNT: Option<usize> = Some(1);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let rise = operands.get_f32()?;
+        let rise = operands
+            .take_next()?
+            .try_number::<f32>(&PassthroughResolver)?;
         Ok(PdfOperatorVariant::SetTextRise(Self::new(rise)))
     }
 

--- a/crates/pdf-content-stream-operators/src/type3_font_operators.rs
+++ b/crates/pdf-content-stream-operators/src/type3_font_operators.rs
@@ -28,12 +28,7 @@ impl PdfOperator for SetCharWidthAndBoundingBox {
     const OPERAND_COUNT: Option<usize> = Some(6);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let wx = operands.get_f32()?;
-        let wy = operands.get_f32()?;
-        let llx = operands.get_f32()?;
-        let lly = operands.get_f32()?;
-        let urx = operands.get_f32()?;
-        let ury = operands.get_f32()?;
+        let [wx, wy, llx, lly, urx, ury] = operands.try_array_of::<f32, 6>()?;
 
         Ok(PdfOperatorVariant::SetCharWidthAndBoundingBox(Self {
             wx,
@@ -64,8 +59,7 @@ impl PdfOperator for SetCharWidth {
     const OPERAND_COUNT: Option<usize> = Some(2);
 
     fn read(operands: &mut Operands) -> Result<PdfOperatorVariant, PdfOperatorError> {
-        let wx = operands.get_f32()?;
-        let wy = operands.get_f32()?;
+        let [wx, wy] = operands.try_array_of::<f32, 2>()?;
 
         Ok(PdfOperatorVariant::SetCharWidth(Self { wx, wy }))
     }

--- a/crates/pdf-content-stream/Cargo.toml
+++ b/crates/pdf-content-stream/Cargo.toml
@@ -16,3 +16,10 @@ pdf-graphics = { path = "../pdf-graphics" }
 pdf-content-stream-operators = { path = "../pdf-content-stream-operators" }
 thiserror = "2.0.12"
 num-traits = "0.2.19"
+
+[dev-dependencies]
+criterion = "0.8"
+
+[[bench]]
+name = "operator_parsing"
+harness = false

--- a/crates/pdf-content-stream/benches/operator_parsing.rs
+++ b/crates/pdf-content-stream/benches/operator_parsing.rs
@@ -1,0 +1,80 @@
+#![allow(clippy::arithmetic_side_effects, clippy::expect_used)]
+
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use pdf_content_stream::{ContentStream, ContentStreamIdAllocator};
+use pdf_object::{
+    dictionary::Dictionary, object_resolver::PassthroughResolver, object_variant::ObjectVariant,
+    stream::StreamObject,
+};
+
+const REPETITIONS: usize = 1_024;
+
+fn repeated_stream(fragment: &[u8]) -> ObjectVariant {
+    let mut data = Vec::with_capacity(fragment.len() * REPETITIONS);
+    for _ in 0..REPETITIONS {
+        data.extend_from_slice(fragment);
+    }
+
+    ObjectVariant::Stream(StreamObject::new(
+        1,
+        0,
+        Box::new(Dictionary::new(Default::default())),
+        data,
+    ))
+}
+
+fn benchmark_stream(
+    criterion: &mut Criterion,
+    name: &str,
+    fragment: &[u8],
+    operators_per_fragment: usize,
+) {
+    let stream = repeated_stream(fragment);
+    let ObjectVariant::Stream(stream_object) = &stream else {
+        return;
+    };
+    let input_size = stream_object.raw_data().len();
+    let expected_operators = operators_per_fragment * REPETITIONS;
+    let mut group = criterion.benchmark_group(name);
+    group.throughput(Throughput::Bytes(
+        u64::try_from(input_size).expect("benchmark input length should fit u64"),
+    ));
+
+    group.bench_function("materialize", |bencher| {
+        bencher.iter(|| {
+            let mut allocator = ContentStreamIdAllocator::new();
+            let parsed =
+                ContentStream::new(black_box(&stream), &PassthroughResolver, &mut allocator)
+                    .expect("benchmark content stream should parse");
+            assert_eq!(parsed.operators.len(), expected_operators);
+            black_box(parsed);
+        });
+    });
+    group.finish();
+}
+
+fn benchmark_operator_parsing(criterion: &mut Criterion) {
+    benchmark_stream(
+        criterion,
+        "operator_parsing/numeric_heavy",
+        b"q 1 0 0 1 10 20 cm 10 20 m 30 40 l 1 2 3 4 5 6 c 10 20 30 40 re 0.1 0.2 0.3 rg Q\n",
+        8,
+    );
+    benchmark_stream(
+        criterion,
+        "operator_parsing/dispatch_heavy",
+        b"q Q BT ET BX EX h n S s f f* W W*\n",
+        14,
+    );
+    benchmark_stream(
+        criterion,
+        "operator_parsing/mixed",
+        b"q /F1 12 Tf BT 1 0 0 1 10 20 Tm (Hello) Tj [(A) -20 <42> 5] TJ ET /DeviceRGB cs 0.1 0.2 0.3 sc 0.1 0.2 0.3 /P1 scn /X1 Do Q\n",
+        12,
+    );
+}
+
+criterion_group!(benches, benchmark_operator_parsing);
+criterion_main!(benches);

--- a/crates/pdf-content-stream/src/operator_stream_parser.rs
+++ b/crates/pdf-content-stream/src/operator_stream_parser.rs
@@ -1,5 +1,4 @@
 use pdf_object::object_resolver::PassthroughResolver;
-use pdf_object::object_variant::ObjectVariant;
 use pdf_parser::error::ParserError;
 use pdf_parser::parser::PdfParser;
 use pdf_tokenizer::error::TokenizerError;
@@ -15,7 +14,7 @@ use pdf_content_stream_operators::{
 /// same operand buffer across operator boundaries.
 pub(super) struct OperatorStreamParser<'a, 'out> {
     parser: PdfParser<'a>,
-    operands: Vec<ObjectVariant>,
+    operands: Operands,
     out: &'out mut Vec<PdfOperatorVariant>,
 }
 
@@ -27,7 +26,7 @@ impl<'a, 'out> OperatorStreamParser<'a, 'out> {
     pub(super) fn new(input: &'a [u8], out: &'out mut Vec<PdfOperatorVariant>) -> Self {
         Self {
             parser: PdfParser::from(input),
-            operands: Vec::with_capacity(6),
+            operands: Operands::with_capacity(6),
             out,
         }
     }
@@ -47,7 +46,7 @@ impl<'a, 'out> OperatorStreamParser<'a, 'out> {
         let result = if next_item_is_operator(next_byte) {
             self.parse_operator_from_stream().map(|()| true)
         } else {
-            self.parse_operand_or_stop()
+            self.parse_operand_or_stop(next_byte)
         };
 
         match result {
@@ -74,15 +73,19 @@ impl<'a, 'out> OperatorStreamParser<'a, 'out> {
     }
 
     /// Parses one operand object and appends it to the reusable operand buffer.
-    fn parse_operand(&mut self) -> Result<(), PdfOperatorError> {
-        let value = self.parser.parse_object(&PassthroughResolver)?;
+    fn parse_operand(&mut self, first_byte: u8) -> Result<(), PdfOperatorError> {
+        let value = if matches!(first_byte, b'+' | b'-' | b'.' | b'0'..=b'9') {
+            self.parser.parse_number()?
+        } else {
+            self.parser.parse_object(&PassthroughResolver)?
+        };
         self.operands.push(value);
         Ok(())
     }
 
     /// Parses one operand object or stops cleanly when the stream ends mid-object.
-    fn parse_operand_or_stop(&mut self) -> Result<bool, PdfOperatorError> {
-        match self.parse_operand() {
+    fn parse_operand_or_stop(&mut self, first_byte: u8) -> Result<bool, PdfOperatorError> {
+        match self.parse_operand(first_byte) {
             Ok(()) => Ok(true),
             Err(error) if is_truncated_operand_error(&error) => {
                 self.operands.clear();
@@ -104,10 +107,14 @@ impl<'a, 'out> OperatorStreamParser<'a, 'out> {
             return Ok(());
         };
 
-        let parsed = if let Some(operator) = (descriptor.parse_hook)(&mut self.parser)? {
-            Some(operator)
+        let parsed = if let Some(parse_hook) = descriptor.parse_hook {
+            if let Some(operator) = parse_hook(&mut self.parser)? {
+                Some(operator)
+            } else {
+                parse_operator(&descriptor, &mut self.operands)?
+            }
         } else {
-            parse_operator(descriptor, &mut self.operands)?
+            parse_operator(&descriptor, &mut self.operands)?
         };
 
         self.push_if_parsed(parsed);
@@ -118,9 +125,7 @@ impl<'a, 'out> OperatorStreamParser<'a, 'out> {
     /// Reads a single operator token and normalizes low-level tokenization
     /// failures into content-stream operator errors.
     fn read_operator_name(&mut self) -> Result<&[u8], PdfOperatorError> {
-        self.parser
-            .read_operator_name()
-            .map_err(map_operator_name_error)
+        Ok(self.parser.read_operator_name()?)
     }
 
     /// Appends a parsed operator when dispatch produced one.
@@ -144,17 +149,6 @@ impl<'a, 'out> OperatorStreamParser<'a, 'out> {
 /// numeric operand.
 fn next_item_is_operator(byte: u8) -> bool {
     PdfParser::is_pdf_regular_character(byte) && !matches!(byte, b'+' | b'-' | b'.' | b'0'..=b'9')
-}
-
-/// Converts operator-token parser failures into content-stream operator errors.
-fn map_operator_name_error(error: ParserError) -> PdfOperatorError {
-    match error {
-        ParserError::UnexpectedEndOfFile => {
-            PdfOperatorError::UnknownOperator("(end of input)".to_string())
-        }
-        ParserError::InvalidToken(c) => PdfOperatorError::UnknownOperator(format!("{c:?}")),
-        other => PdfOperatorError::ParserError(other),
-    }
 }
 
 /// Returns whether an operand parse error means the content stream ended
@@ -186,11 +180,11 @@ fn is_truncated_operand_error(error: &PdfOperatorError) -> bool {
 /// Parses a single operator with its operands.
 ///
 /// Looks up the operator descriptor by name and validates the operand count
-/// before parsing. Takes `operands` by `&mut` so its heap allocation can be
-/// reclaimed and reused for the next operator.
+/// before parsing. The operand buffer retains its allocation for the next
+/// operator, including when parsing fails.
 fn parse_operator(
     descriptor: &OpDescriptor,
-    operands: &mut Vec<ObjectVariant>,
+    operands: &mut Operands,
 ) -> Result<Option<PdfOperatorVariant>, PdfOperatorError> {
     if let Some(required_count) = descriptor.operand_count
         && operands.len() != required_count
@@ -198,9 +192,7 @@ fn parse_operator(
         return Ok(None);
     }
 
-    let mut ops = Operands(std::mem::take(operands));
-    let operator = (descriptor.parser)(&mut ops)?;
-    *operands = ops.0;
+    let operator = (descriptor.parser)(operands)?;
     Ok(Some(operator))
 }
 
@@ -210,6 +202,7 @@ mod tests {
     use pdf_content_stream_operators::{
         graphics_state_operators::RestoreGraphicsState, variants::PdfOperatorVariant,
     };
+    use pdf_object::object_variant::ObjectVariant;
 
     use super::*;
 
@@ -228,23 +221,6 @@ mod tests {
                 "byte {byte:?} should be an operator"
             );
         }
-    }
-
-    #[test]
-    fn operator_name_eof_maps_to_unknown_operator() {
-        let error = map_operator_name_error(ParserError::UnexpectedEndOfFile);
-
-        assert_eq!(
-            error,
-            PdfOperatorError::UnknownOperator("(end of input)".to_string())
-        );
-    }
-
-    #[test]
-    fn operator_name_invalid_token_maps_to_unknown_operator() {
-        let error = map_operator_name_error(ParserError::InvalidToken('/'));
-
-        assert_eq!(error, PdfOperatorError::UnknownOperator("'/'".to_string()));
     }
 
     #[test]
@@ -270,10 +246,11 @@ mod tests {
     #[test]
     fn parse_operator_reuses_operand_buffer_after_success() {
         let descriptor = get_operation_descriptor(b"m").expect("operator descriptor should exist");
-        let mut operands = vec![ObjectVariant::Integer(10), ObjectVariant::Integer(20)];
+        let mut operands =
+            Operands::from(vec![ObjectVariant::Integer(10), ObjectVariant::Integer(20)]);
         let original_capacity = operands.capacity();
 
-        let operator = parse_operator(descriptor, &mut operands).expect("operator should parse");
+        let operator = parse_operator(&descriptor, &mut operands).expect("operator should parse");
 
         assert!(matches!(operator, Some(PdfOperatorVariant::MoveTo(_))));
         assert!(operands.is_empty());
@@ -283,25 +260,19 @@ mod tests {
     #[test]
     fn parse_operator_skips_malformed_fixed_arity_operator_without_consuming_buffer() {
         let descriptor = get_operation_descriptor(b"m").expect("operator descriptor should exist");
-        let mut operands = vec![
+        let mut operands = Operands::from(vec![
             ObjectVariant::Integer(1),
             ObjectVariant::Integer(2),
             ObjectVariant::Integer(3),
-        ];
+        ]);
         let original_capacity = operands.capacity();
 
-        let operator = parse_operator(descriptor, &mut operands)
+        let operator = parse_operator(&descriptor, &mut operands)
             .expect("malformed operator should be skipped");
 
         assert!(operator.is_none());
-        assert_eq!(
-            operands,
-            vec![
-                ObjectVariant::Integer(1),
-                ObjectVariant::Integer(2),
-                ObjectVariant::Integer(3),
-            ]
-        );
+        assert_eq!(operands.len(), 3);
+        assert_eq!(operands.peek_next(), Some(&ObjectVariant::Integer(1)));
         assert_eq!(operands.capacity(), original_capacity);
     }
 
@@ -431,9 +402,48 @@ mod tests {
     }
 
     #[test]
+    fn numeric_operands_recover_from_top_level_reference_syntax() {
+        let mut out = Vec::new();
+        let mut parser = OperatorStreamParser::new(b"1 0 R q", &mut out);
+
+        while parser
+            .parse_next_item()
+            .expect("invalid top-level reference should be skipped")
+        {}
+
+        assert_eq!(parser.out.len(), 1);
+        assert!(matches!(
+            parser.out.first(),
+            Some(PdfOperatorVariant::SaveGraphicsState(_))
+        ));
+    }
+
+    #[test]
+    fn generic_operands_keep_nested_indirect_references() {
+        let mut out = Vec::new();
+        let mut parser = OperatorStreamParser::new(b"/Tag << /Ref 5 0 R >> BDC EMC", &mut out);
+
+        while parser
+            .parse_next_item()
+            .expect("nested reference should parse in a dictionary")
+        {}
+
+        assert_eq!(parser.out.len(), 2);
+        assert!(matches!(
+            parser.out.first(),
+            Some(PdfOperatorVariant::BeginMarkedContentWithProps(_))
+        ));
+        assert!(matches!(
+            parser.out.get(1),
+            Some(PdfOperatorVariant::EndMarkedContent(_))
+        ));
+    }
+
+    #[test]
     fn parse_next_item_recovers_from_invalid_operator_operand_value() {
         let mut out = Vec::new();
         let mut parser = OperatorStreamParser::new(b"9 J q", &mut out);
+        let original_capacity = parser.operands.capacity();
 
         while parser
             .parse_next_item()
@@ -441,6 +451,7 @@ mod tests {
         {}
 
         assert!(parser.operands.is_empty());
+        assert_eq!(parser.operands.capacity(), original_capacity);
         assert_eq!(parser.out.len(), 1);
         assert!(matches!(
             parser.out.first(),


### PR DESCRIPTION
Reuse cursor-based operand storage and parse numeric operands without repeated shifts or indirect-object probes.

Dispatch operators with a direct match, skip unused parse hooks, move owned text buffers without copying, and add parsing benchmarks.