### PR TITLE
pdf-object: store dictionaries inline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,8 @@ dependencies = [
  "pdf-resources",
  "pdf-tokenizer",
  "raw-window-handle",
+ "serde",
+ "serde_json",
  "skia-safe",
  "thiserror 2.0.12",
  "wgpu",

--- a/crates/pdf-annotation-types/src/action.rs
+++ b/crates/pdf-annotation-types/src/action.rs
@@ -282,10 +282,10 @@ mod tests {
     fn action_dictionary(js: ObjectVariant) -> Dictionary {
         Dictionary::new(BTreeMap::from([(
             Vec::from(b"A"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([
                 (Vec::from(b"S"), ObjectVariant::Name(b"JavaScript".to_vec())),
                 (Vec::from(b"JS"), js),
-            ])))),
+            ]))),
         )]))
     }
 
@@ -293,7 +293,7 @@ mod tests {
         ObjectVariant::Stream(StreamObject::new(
             7,
             0,
-            Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+            Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
             data.to_vec(),
         ))
     }

--- a/crates/pdf-annotation-types/src/annotation.rs
+++ b/crates/pdf-annotation-types/src/annotation.rs
@@ -323,12 +323,7 @@ mod tests {
                 ObjectVariant::Integer(1),
             ]),
         )]));
-        ObjectVariant::Stream(StreamObject::new(
-            object_number,
-            0,
-            Box::new(dictionary),
-            Vec::new(),
-        ))
+        ObjectVariant::Stream(StreamObject::new(object_number, 0, dictionary, Vec::new()))
     }
 
     fn button_annotation(appearance_state: Option<&str>, states: &[&str]) -> Annotation {
@@ -342,11 +337,9 @@ mod tests {
                 )
             })
             .collect();
-        let normal = ObjectVariant::Dictionary(Box::new(Dictionary::new(states)));
-        let appearance = ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
-            Vec::from(b"N"),
-            normal,
-        )]))));
+        let normal = ObjectVariant::Dictionary(Dictionary::new(states));
+        let appearance =
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(Vec::from(b"N"), normal)])));
 
         let mut entries = vec![
             ("Subtype", ObjectVariant::Name(b"Widget".to_vec())),
@@ -507,21 +500,21 @@ mod tests {
         let mut objects = BTreeMap::new();
         objects.insert(
             4,
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                 Vec::from(b"Type"),
                 ObjectVariant::Name(b"Annot".to_vec()),
-            )])))),
+            )]))),
         );
 
         objects.insert(
             5,
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([
                 (Vec::from(b"Type"), ObjectVariant::Name(b"Annot".to_vec())),
                 (
                     Vec::from(b"Subtype"),
                     ObjectVariant::Name(b"Popup".to_vec()),
                 ),
-            ])))),
+            ]))),
         );
 
         let mut page_values = BTreeMap::new();

--- a/crates/pdf-annotation-types/src/subtypes/widget.rs
+++ b/crates/pdf-annotation-types/src/subtypes/widget.rs
@@ -412,11 +412,11 @@ fn widget_field_value(
         | ObjectVariant::LiteralString(bytes)
         | ObjectVariant::Name(bytes) => Ok(WidgetFieldValue::Bytes(bytes.clone())),
         ObjectVariant::Dictionary(dictionary) => {
-            Ok(WidgetFieldValue::Dictionary(dictionary.as_ref().clone()))
+            Ok(WidgetFieldValue::Dictionary(dictionary.clone()))
         }
-        ObjectVariant::Stream(stream) => Ok(WidgetFieldValue::Dictionary(
-            stream.dictionary.as_ref().clone(),
-        )),
+        ObjectVariant::Stream(stream) => {
+            Ok(WidgetFieldValue::Dictionary(stream.dictionary.clone()))
+        }
         ObjectVariant::Array(values) => values
             .iter()
             .map(|value| widget_field_value(entry, value, objects))

--- a/crates/pdf-canvas/benches/text_recording.rs
+++ b/crates/pdf-canvas/benches/text_recording.rs
@@ -60,7 +60,7 @@ fn content_stream(text: &[u8]) -> ContentStream {
     let mut data = b"BT /F1 10 Tf (".to_vec();
     data.extend_from_slice(text);
     data.extend_from_slice(b") Tj ET");
-    let stream = StreamObject::new(1, 0, Box::new(Dictionary::new(Default::default())), data);
+    let stream = StreamObject::new(1, 0, Dictionary::new(Default::default()), data);
     ContentStream::new(
         &ObjectVariant::Stream(stream),
         &PassthroughResolver,

--- a/crates/pdf-canvas/tests/common/mod.rs
+++ b/crates/pdf-canvas/tests/common/mod.rs
@@ -168,10 +168,10 @@ pub fn content_stream(object_number: usize, data: &[u8]) -> ContentStream {
     let stream = StreamObject::new(
         object_number,
         0,
-        Box::new(Dictionary::new(std::collections::BTreeMap::<
+        Dictionary::new(std::collections::BTreeMap::<
             Vec<u8>,
             pdf_object::object_variant::ObjectVariant,
-        >::new())),
+        >::new()),
         data.to_vec(),
     );
     let mut ids = ContentStreamIdAllocator::new();

--- a/crates/pdf-color-space/src/device_n_color_space.rs
+++ b/crates/pdf-color-space/src/device_n_color_space.rs
@@ -143,7 +143,7 @@ mod tests {
         ObjectVariant::Stream(StreamObject::new(
             1,
             0,
-            Box::new(Dictionary::new(dict)),
+            Dictionary::new(dict),
             code.as_bytes().to_vec(),
         ))
     }
@@ -175,10 +175,8 @@ mod tests {
 
     #[test]
     fn parses_five_element_device_n_array_with_attributes() {
-        let attrs = ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::<
-            Vec<u8>,
-            ObjectVariant,
-        >::new())));
+        let attrs =
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()));
         let arr = device_n_array(vec![
             ObjectVariant::Array(vec![name("Spot")]),
             name("DeviceCMYK"),

--- a/crates/pdf-color-space/src/icc_based_color_space.rs
+++ b/crates/pdf-color-space/src/icc_based_color_space.rs
@@ -116,10 +116,7 @@ mod tests {
         let stream = StreamObject::new(
             1,
             0,
-            Box::new(Dictionary::from_entries([(
-                b"N",
-                ObjectVariant::Integer(3),
-            )])),
+            Dictionary::from_entries([(b"N", ObjectVariant::Integer(3))]),
             vec![1, 2, 3, 4],
         );
         let stream_data = stream.shared_data();

--- a/crates/pdf-color-space/src/indexed_color_space.rs
+++ b/crates/pdf-color-space/src/indexed_color_space.rs
@@ -167,7 +167,7 @@ mod tests {
         let stream = StreamObject::new(
             1,
             0,
-            Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+            Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
             vec![1, 2, 3, 4],
         );
         let stream_data = stream.shared_data();

--- a/crates/pdf-content-stream/benches/operator_parsing.rs
+++ b/crates/pdf-content-stream/benches/operator_parsing.rs
@@ -20,7 +20,7 @@ fn repeated_stream(fragment: &[u8]) -> ObjectVariant {
     ObjectVariant::Stream(StreamObject::new(
         1,
         0,
-        Box::new(Dictionary::new(Default::default())),
+        Dictionary::new(Default::default()),
         data,
     ))
 }

--- a/crates/pdf-content-stream/src/content_stream.rs
+++ b/crates/pdf-content-stream/src/content_stream.rs
@@ -157,7 +157,7 @@ mod tests {
         StreamObject::new(
             object_number,
             0,
-            Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+            Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
             data.to_vec(),
         )
     }

--- a/crates/pdf-content-stream/tests/parser_api.rs
+++ b/crates/pdf-content-stream/tests/parser_api.rs
@@ -17,7 +17,7 @@ fn stream_object(object_number: usize, data: &[u8]) -> StreamObject {
     StreamObject::new(
         object_number,
         0,
-        Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+        Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
         data.to_vec(),
     )
 }

--- a/crates/pdf-document/src/decryption.rs
+++ b/crates/pdf-document/src/decryption.rs
@@ -405,9 +405,9 @@ impl DocumentDecryptor {
                 .map(|value| self.decrypt_object_value(value, object_number, generation_number))
                 .collect::<Result<Vec<_>, _>>()
                 .map(ObjectVariant::Array),
-            ObjectVariant::Dictionary(dictionary) => Ok(ObjectVariant::Dictionary(Box::new(
-                self.decrypt_dictionary(*dictionary, object_number, generation_number)?,
-            ))),
+            ObjectVariant::Dictionary(dictionary) => Ok(ObjectVariant::Dictionary(
+                self.decrypt_dictionary(dictionary, object_number, generation_number)?,
+            )),
             ObjectVariant::Stream(stream) => self.decrypt_stream_value(stream),
             other => Ok(other),
         }
@@ -445,11 +445,11 @@ impl DocumentDecryptor {
         let generation_number = stream.generation_number;
         let stream = self.decrypt_stream_object(stream)?;
         let dictionary =
-            self.decrypt_dictionary(*stream.dictionary, object_number, generation_number)?;
+            self.decrypt_dictionary(stream.dictionary, object_number, generation_number)?;
         Ok(ObjectVariant::Stream(StreamObject::new_encoded(
             object_number,
             generation_number,
-            Box::new(dictionary),
+            dictionary,
             stream.data,
         )))
     }
@@ -1101,7 +1101,7 @@ mod tests {
             entries.insert(Vec::from(b"Type"), ObjectVariant::Name(type_name.to_vec()));
         }
 
-        StreamObject::new(7, 0, Box::new(Dictionary::new(entries)), data)
+        StreamObject::new(7, 0, Dictionary::new(entries), data)
     }
 
     fn encrypt_for_object(
@@ -1335,7 +1335,7 @@ mod tests {
             number: object_number,
             generation: generation_number,
         };
-        let object = ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([
+        let object = ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([
             (
                 Vec::from(b"Contents"),
                 ObjectVariant::LiteralString(encrypt_for_object(
@@ -1359,7 +1359,7 @@ mod tests {
                 ObjectVariant::Name(b"FreeText".to_vec()),
             ),
             (Vec::from(b"Parent"), ObjectVariant::Reference(4)),
-        ]))));
+        ])));
 
         let decrypted = decryptor
             .decrypt_object(identifier, object)
@@ -1396,7 +1396,7 @@ mod tests {
         let stream = StreamObject::new(
             99,
             1,
-            Box::new(Dictionary::new(BTreeMap::from([(
+            Dictionary::new(BTreeMap::from([(
                 Vec::from(b"Label"),
                 ObjectVariant::LiteralString(encrypt_for_object(
                     &decryptor,
@@ -1404,7 +1404,7 @@ mod tests {
                     generation_number,
                     b"annotation appearance",
                 )),
-            )]))),
+            )])),
             encrypt_for_object(&decryptor, object_number, generation_number, contents),
         );
 
@@ -1438,13 +1438,13 @@ mod tests {
             number: 9,
             generation: 0,
         };
-        let object = ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([
+        let object = ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([
             (Vec::from(b"Type"), ObjectVariant::Name(b"Sig".to_vec())),
             (
                 Vec::from(b"Contents"),
                 ObjectVariant::HexString(vec![0, 0, 0, 0]),
             ),
-        ]))));
+        ])));
 
         let decrypted = decryptor
             .decrypt_object(identifier, object)

--- a/crates/pdf-document/src/encryption.rs
+++ b/crates/pdf-document/src/encryption.rs
@@ -358,8 +358,7 @@ mod tests {
             ("CFM", ObjectVariant::Name(b"AESV3".to_vec())),
             ("Length", ObjectVariant::Integer(32)),
         ]);
-        let crypt_filters =
-            make_dictionary(vec![("StdCF", ObjectVariant::Dictionary(Box::new(std_cf)))]);
+        let crypt_filters = make_dictionary(vec![("StdCF", ObjectVariant::Dictionary(std_cf))]);
         let dict = make_dictionary(vec![
             ("Filter", ObjectVariant::Name(b"Standard".to_vec())),
             ("V", ObjectVariant::Integer(5)),
@@ -370,7 +369,7 @@ mod tests {
             ("UE", ObjectVariant::HexString(vec![0u8; 32])),
             ("Perms", ObjectVariant::HexString(vec![0u8; 16])),
             ("P", ObjectVariant::Integer(-4)),
-            ("CF", ObjectVariant::Dictionary(Box::new(crypt_filters))),
+            ("CF", ObjectVariant::Dictionary(crypt_filters)),
             ("StmF", ObjectVariant::Name(b"StdCF".to_vec())),
             ("StrF", ObjectVariant::Name(b"Identity".to_vec())),
         ]);

--- a/crates/pdf-document/src/object_stream.rs
+++ b/crates/pdf-document/src/object_stream.rs
@@ -37,13 +37,13 @@ pub(crate) fn read_object_stream(
     stream: &StreamObject,
     objects: &dyn ObjectResolver,
 ) -> Result<Vec<CompressedObject>, PdfReaderError> {
-    let dict = stream.dictionary.as_ref();
-
     // /N: number of objects in this stream (required)
-    let n = dict.required_number::<usize>(b"N", objects)?;
+    let n = stream.dictionary.required_number::<usize>(b"N", objects)?;
 
     // /First: byte offset of the first object data within the decoded stream (required)
-    let first = dict.required_number::<usize>(b"First", objects)?;
+    let first = stream
+        .dictionary
+        .required_number::<usize>(b"First", objects)?;
 
     // Decode stream data (applies filters)
     let data = stream.raw_data();

--- a/crates/pdf-document/tests/pages.rs
+++ b/crates/pdf-document/tests/pages.rs
@@ -64,7 +64,7 @@ fn resources_dictionary(entries: &[(&str, &str)]) -> Dictionary {
 
     Dictionary::new(BTreeMap::from([(
         Vec::from(b"ColorSpace"),
-        ObjectVariant::Dictionary(Box::new(color_spaces)),
+        ObjectVariant::Dictionary(color_spaces),
     )]))
 }
 
@@ -83,7 +83,7 @@ fn page_dictionary(
     if let Some(resources) = resources {
         entries.insert(
             Vec::from(b"Resources"),
-            ObjectVariant::Dictionary(Box::new(resources)),
+            ObjectVariant::Dictionary(resources),
         );
     }
 
@@ -121,7 +121,7 @@ fn pages_dictionary(
     if let Some(resources) = resources {
         entries.insert(
             Vec::from(b"Resources"),
-            ObjectVariant::Dictionary(Box::new(resources)),
+            ObjectVariant::Dictionary(resources),
         );
     }
 
@@ -157,10 +157,7 @@ fn inherited_resources_and_media_box_apply_to_leaf_pages() {
     let page = page_dictionary(page_number, Some(root_number), None, None);
 
     let resolver = MapResolver {
-        objects: BTreeMap::from([(
-            page_number,
-            ObjectVariant::Dictionary(Box::new(page.clone())),
-        )]),
+        objects: BTreeMap::from([(page_number, ObjectVariant::Dictionary(page.clone()))]),
     };
 
     let mut cache = DefaultResourceCache::default();
@@ -220,10 +217,7 @@ fn child_resources_keep_their_own_entries_while_inheriting_missing_ones() {
     );
 
     let resolver = MapResolver {
-        objects: BTreeMap::from([(
-            page_number,
-            ObjectVariant::Dictionary(Box::new(page.clone())),
-        )]),
+        objects: BTreeMap::from([(page_number, ObjectVariant::Dictionary(page.clone()))]),
     };
 
     let mut cache = DefaultResourceCache::default();

--- a/crates/pdf-filter/src/filter.rs
+++ b/crates/pdf-filter/src/filter.rs
@@ -321,7 +321,7 @@ pub fn decode_data_with_resolver(
     for (index, filter) in filters.into_iter().enumerate() {
         let param_dict = match decode_parms {
             None => None,
-            Some(ObjectVariant::Dictionary(dictionary)) => Some(dictionary.as_ref()),
+            Some(ObjectVariant::Dictionary(dictionary)) => Some(dictionary),
             Some(ObjectVariant::Array(array)) => {
                 array.as_slice().optional_dictionary(index, objects)?
             }
@@ -547,7 +547,7 @@ mod tests {
         let stream = StreamObject::new(
             1,
             0,
-            Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+            Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
             b"shared stream data".to_vec(),
         );
 
@@ -566,7 +566,7 @@ mod tests {
             ObjectVariant::Name(b"JBIG2Decode".to_vec()),
         );
 
-        let stream = StreamObject::new(1, 0, Box::new(Dictionary::new(dict)), Vec::new());
+        let stream = StreamObject::new(1, 0, Dictionary::new(dict), Vec::new());
         let err = decode(&stream).expect_err("expected decode failure");
         assert!(matches!(err, FilterError::Decompression(_)));
     }
@@ -606,8 +606,7 @@ mod tests {
             Vec::from(b"Filter"),
             ObjectVariant::Name(b"JBIG2Decode".to_vec()),
         );
-        let globals_stream =
-            StreamObject::new(3, 0, Box::new(Dictionary::new(globals_dict)), Vec::new());
+        let globals_stream = StreamObject::new(3, 0, Dictionary::new(globals_dict), Vec::new());
 
         let mut decode_parms = BTreeMap::new();
         decode_parms.insert(Vec::from(b"JBIG2Globals"), ObjectVariant::Reference(3));
@@ -621,13 +620,10 @@ mod tests {
         dict.insert(Vec::from(b"Height"), ObjectVariant::Integer(1));
         dict.insert(Vec::from(b"DecodeParms"), ObjectVariant::Reference(2));
 
-        let stream = StreamObject::new(1, 0, Box::new(Dictionary::new(dict)), Vec::new());
+        let stream = StreamObject::new(1, 0, Dictionary::new(dict), Vec::new());
 
         let mut objects = BTreeMap::new();
-        objects.insert(
-            2,
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(decode_parms))),
-        );
+        objects.insert(2, ObjectVariant::Dictionary(Dictionary::new(decode_parms)));
         objects.insert(3, ObjectVariant::Stream(globals_stream));
 
         let resolver = TrackingResolver {
@@ -650,7 +646,7 @@ mod tests {
         dict.insert(Vec::from(b"Width"), ObjectVariant::Integer(8));
         dict.insert(Vec::from(b"Height"), ObjectVariant::Integer(1));
 
-        let stream = StreamObject::new(1, 0, Box::new(Dictionary::new(dict)), vec![0x00]);
+        let stream = StreamObject::new(1, 0, Dictionary::new(dict), vec![0x00]);
 
         let err = decode(&stream).expect_err("expected decode failure");
         assert!(matches!(err, FilterError::Decompression(_)));
@@ -667,7 +663,7 @@ mod tests {
         let stream = StreamObject::new(
             1,
             0,
-            Box::new(Dictionary::new(dict)),
+            Dictionary::new(dict),
             b"48 65 6c 6c 6f>ignored".to_vec(),
         );
 
@@ -711,7 +707,7 @@ mod tests {
             ObjectVariant::Integer(compressed.len() as i64),
         );
 
-        let stream = StreamObject::new(1, 0, Box::new(Dictionary::new(dict)), compressed);
+        let stream = StreamObject::new(1, 0, Dictionary::new(dict), compressed);
 
         let mut objects = BTreeMap::new();
         objects.insert(
@@ -788,10 +784,9 @@ mod tests {
         let resolver = TestResolver {
             objects: BTreeMap::from([(
                 2,
-                ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::<
-                    Vec<u8>,
-                    ObjectVariant,
-                >::new()))),
+                ObjectVariant::Dictionary(Dictionary::new(
+                    BTreeMap::<Vec<u8>, ObjectVariant>::new(),
+                )),
             )]),
         };
         let decoded = decode_data_with_resolver(&dictionary, Arc::new(compressed), &resolver)
@@ -811,7 +806,7 @@ mod tests {
         let stream = StreamObject::new(
             1,
             0,
-            Box::new(Dictionary::new(dict)),
+            Dictionary::new(dict),
             vec![2, b'A', b'B', b'C', 255, b'!', 128],
         );
 
@@ -824,7 +819,7 @@ mod tests {
         let mut dict = BTreeMap::new();
         dict.insert(Vec::from(b"Filter"), ObjectVariant::Name(b"RL".to_vec()));
 
-        let stream = StreamObject::new(1, 0, Box::new(Dictionary::new(dict)), vec![0, b'X', 128]);
+        let stream = StreamObject::new(1, 0, Dictionary::new(dict), vec![0, b'X', 128]);
 
         let decoded = decode(&stream).expect("decode failed");
         assert_eq!(decoded.as_ref(), b"X");

--- a/crates/pdf-font/src/fallback.rs
+++ b/crates/pdf-font/src/fallback.rs
@@ -87,7 +87,7 @@ mod tests {
             ),
             (
                 Vec::from(b"FontDescriptor"),
-                ObjectVariant::Dictionary(Box::new(descriptor)),
+                ObjectVariant::Dictionary(descriptor),
             ),
             (Vec::from(b"FirstChar"), ObjectVariant::Integer(65)),
             (Vec::from(b"LastChar"), ObjectVariant::Integer(65)),
@@ -133,14 +133,14 @@ mod tests {
     fn fallback_uses_cjk_program_from_type0_descendant() {
         let descendant = Dictionary::new(BTreeMap::from([(
             Vec::from(b"CIDSystemInfo"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                 Vec::from(b"Ordering"),
                 ObjectVariant::LiteralString(b"Japan1".to_vec()),
-            )])))),
+            )]))),
         )]));
         let dictionary = Dictionary::new(BTreeMap::from([(
             Vec::from(b"DescendantFonts"),
-            ObjectVariant::Array(vec![ObjectVariant::Dictionary(Box::new(descendant))]),
+            ObjectVariant::Array(vec![ObjectVariant::Dictionary(descendant)]),
         )]));
 
         let fallback = fallback_true_type_from_dictionary(&dictionary, &PassthroughResolver);

--- a/crates/pdf-font/src/true_type_font.rs
+++ b/crates/pdf-font/src/true_type_font.rs
@@ -167,7 +167,7 @@ mod tests {
         let stream = StreamObject::new(
             1,
             0,
-            Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+            Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
             vec![1, 2, 3, 4],
         );
         let stream_bytes = stream.raw_data().as_ptr();
@@ -177,7 +177,7 @@ mod tests {
         )]));
         let dictionary = Dictionary::new(BTreeMap::from([(
             b"FontDescriptor".to_vec(),
-            ObjectVariant::Dictionary(Box::new(descriptor)),
+            ObjectVariant::Dictionary(descriptor),
         )]));
 
         let font = TrueTypeFont::from_dictionary(&dictionary, &PassthroughResolver)

--- a/crates/pdf-font/src/type0_font.rs
+++ b/crates/pdf-font/src/type0_font.rs
@@ -384,12 +384,7 @@ mod tests {
         dictionary: Dictionary,
         data: Vec<u8>,
     ) -> ObjectVariant {
-        ObjectVariant::Stream(StreamObject::new(
-            object_number,
-            0,
-            Box::new(dictionary),
-            data,
-        ))
+        ObjectVariant::Stream(StreamObject::new(object_number, 0, dictionary, data))
     }
 
     #[test]
@@ -426,8 +421,7 @@ mod tests {
             Vec::from(b"Subtype"),
             ObjectVariant::Name(b"OpenType".to_vec()),
         );
-        let font_file3_stream =
-            StreamObject::new(3, 0, Box::new(Dictionary::new(file3_dict)), vec![0, 1, 2]);
+        let font_file3_stream = StreamObject::new(3, 0, Dictionary::new(file3_dict), vec![0, 1, 2]);
         let font_file3_bytes = font_file3_stream.raw_data().as_ptr();
         let font_file3 = ObjectVariant::Stream(font_file3_stream);
 
@@ -441,19 +435,17 @@ mod tests {
         );
         descendant_dict.insert(
             Vec::from(b"FontDescriptor"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(descriptor_dict))),
+            ObjectVariant::Dictionary(Dictionary::new(descriptor_dict)),
         );
         descendant_dict.insert(
             Vec::from(b"CIDSystemInfo"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                 Vec::from(b"Ordering"),
                 ObjectVariant::LiteralString(b"Japan1".to_vec()),
-            )])))),
+            )]))),
         );
 
-        let descendant_fonts = vec![ObjectVariant::Dictionary(Box::new(Dictionary::new(
-            descendant_dict,
-        )))];
+        let descendant_fonts = vec![ObjectVariant::Dictionary(Dictionary::new(descendant_dict))];
 
         let mut font_dict = BTreeMap::new();
         font_dict.insert(
@@ -509,7 +501,7 @@ mod tests {
             ObjectVariant::Stream(StreamObject::new(
                 3,
                 0,
-                Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+                Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
                 vec![0, 1, 0, 0],
             )),
         );
@@ -521,12 +513,10 @@ mod tests {
         );
         descendant_dict.insert(
             Vec::from(b"FontDescriptor"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(descriptor_dict))),
+            ObjectVariant::Dictionary(Dictionary::new(descriptor_dict)),
         );
 
-        let descendant_fonts = vec![ObjectVariant::Dictionary(Box::new(Dictionary::new(
-            descendant_dict,
-        )))];
+        let descendant_fonts = vec![ObjectVariant::Dictionary(Dictionary::new(descendant_dict))];
 
         let mut font_dict = BTreeMap::new();
         font_dict.insert(
@@ -576,10 +566,9 @@ mod tests {
             ),
             (
                 Vec::from(b"FontDescriptor"),
-                ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::<
-                    Vec<u8>,
-                    ObjectVariant,
-                >::new()))),
+                ObjectVariant::Dictionary(Dictionary::new(
+                    BTreeMap::<Vec<u8>, ObjectVariant>::new(),
+                )),
             ),
             (Vec::from(b"CIDSystemInfo"), ObjectVariant::Integer(1)),
         ]));
@@ -590,7 +579,7 @@ mod tests {
             ),
             (
                 Vec::from(b"DescendantFonts"),
-                ObjectVariant::Array(vec![ObjectVariant::Dictionary(Box::new(descendant))]),
+                ObjectVariant::Array(vec![ObjectVariant::Dictionary(descendant)]),
             ),
         ]));
 
@@ -730,17 +719,17 @@ mod tests {
             ),
             (
                 Vec::from(b"FontDescriptor"),
-                ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+                ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                     Vec::from(b"Flags"),
                     ObjectVariant::Integer(6),
-                )])))),
+                )]))),
             ),
             (
                 Vec::from(b"CIDSystemInfo"),
-                ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+                ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                     Vec::from(b"Ordering"),
                     ObjectVariant::LiteralString(Vec::from(ordering)),
-                )])))),
+                )]))),
             ),
         ])
     }
@@ -761,9 +750,7 @@ mod tests {
             ),
             (
                 Vec::from(b"DescendantFonts"),
-                ObjectVariant::Array(vec![ObjectVariant::Dictionary(Box::new(Dictionary::new(
-                    descendant,
-                )))]),
+                ObjectVariant::Array(vec![ObjectVariant::Dictionary(Dictionary::new(descendant))]),
             ),
         ]))
     }

--- a/crates/pdf-font/src/type1_font.rs
+++ b/crates/pdf-font/src/type1_font.rs
@@ -198,8 +198,7 @@ mod tests {
                 ObjectVariant::Name(subtype.as_bytes().to_vec()),
             );
         }
-        let font_file3_stream =
-            StreamObject::new(10, 0, Box::new(Dictionary::new(file3_stream_dict)), bytes);
+        let font_file3_stream = StreamObject::new(10, 0, Dictionary::new(file3_stream_dict), bytes);
 
         let mut descriptor_dict = BTreeMap::new();
         descriptor_dict.insert(
@@ -210,7 +209,7 @@ mod tests {
         let mut font_dict = BTreeMap::new();
         font_dict.insert(
             Vec::from(b"FontDescriptor"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(descriptor_dict))),
+            ObjectVariant::Dictionary(Dictionary::new(descriptor_dict)),
         );
         Dictionary::new(font_dict)
     }
@@ -239,7 +238,7 @@ mod tests {
             ObjectVariant::Stream(StreamObject::new(
                 11,
                 0,
-                Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+                Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
                 bytes,
             )),
         );
@@ -247,7 +246,7 @@ mod tests {
         let mut font_dict = BTreeMap::new();
         font_dict.insert(
             Vec::from(b"FontDescriptor"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(descriptor_dict))),
+            ObjectVariant::Dictionary(Dictionary::new(descriptor_dict)),
         );
         Dictionary::new(font_dict)
     }

--- a/crates/pdf-image/src/image_decoder.rs
+++ b/crates/pdf-image/src/image_decoder.rs
@@ -150,7 +150,7 @@ mod tests {
     fn fixture_cal_rgb() -> ObjectVariant {
         ObjectVariant::Array(vec![
             name("CalRGB"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([
                 (
                     Vec::from(b"WhitePoint"),
                     ObjectVariant::Array(vec![
@@ -173,7 +173,7 @@ mod tests {
                         ObjectVariant::Integer(0),
                     ]),
                 ),
-            ])))),
+            ]))),
         ])
     }
 
@@ -181,7 +181,7 @@ mod tests {
         let function = StreamObject::new(
             1,
             0,
-            Box::new(Dictionary::new(BTreeMap::from([
+            Dictionary::new(BTreeMap::from([
                 (Vec::from(b"FunctionType"), ObjectVariant::Integer(4)),
                 (
                     Vec::from(b"Domain"),
@@ -199,7 +199,7 @@ mod tests {
                             .collect(),
                     ),
                 ),
-            ]))),
+            ])),
             b"4 3 roll pop".to_vec(),
         );
 
@@ -214,7 +214,7 @@ mod tests {
     #[test]
     fn read_xobject_uses_predecoded_filtered_stream_data() {
         let dictionary = filtered_gray_dictionary();
-        let stream = StreamObject::new(1, 0, Box::new(dictionary.clone()), vec![0x2A]);
+        let stream = StreamObject::new(1, 0, dictionary.clone(), vec![0x2A]);
 
         let image = read_xobject(&dictionary, &stream, &PassthroughResolver, None)
             .expect("predecoded image data should not be filtered again");
@@ -226,7 +226,7 @@ mod tests {
     #[test]
     fn read_xobject_decodes_encoded_stream_data() {
         let dictionary = filtered_gray_dictionary();
-        let stream = StreamObject::new_encoded(1, 0, Box::new(dictionary.clone()), b"2A>".to_vec());
+        let stream = StreamObject::new_encoded(1, 0, dictionary.clone(), b"2A>".to_vec());
 
         let image = read_xobject(&dictionary, &stream, &PassthroughResolver, None)
             .expect("encoded image data should have its filter applied");
@@ -397,7 +397,7 @@ mod tests {
         let tint_function = StreamObject::new(
             2,
             0,
-            Box::new(Dictionary::new(BTreeMap::from([
+            Dictionary::new(BTreeMap::from([
                 (Vec::from(b"FunctionType"), ObjectVariant::Integer(4)),
                 (
                     Vec::from(b"Domain"),
@@ -414,7 +414,7 @@ mod tests {
                             .collect(),
                     ),
                 ),
-            ]))),
+            ])),
             b"pop 1 1 1".to_vec(),
         );
         let dictionary = Dictionary::new(BTreeMap::from([

--- a/crates/pdf-jbig2/src/huffman/tree.rs
+++ b/crates/pdf-jbig2/src/huffman/tree.rs
@@ -6,17 +6,12 @@ use pdf_utils::BitReader;
 /// ITU-T T.88 / ISO/IEC 14492 Annex B decodes Huffman prefixes bit by bit;
 /// this enum records whether a bit path is still empty, continues to another
 /// internal node, or resolves to a range-table symbol.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 enum Link {
+    #[default]
     Empty,
     Node(usize),
     Leaf(usize),
-}
-
-impl Default for Link {
-    fn default() -> Self {
-        Self::Empty
-    }
 }
 
 /// A node in the binary prefix-code decode tree.

--- a/crates/pdf-jbig2/src/segment.rs
+++ b/crates/pdf-jbig2/src/segment.rs
@@ -89,19 +89,14 @@ impl SegmentType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub(crate) enum JBig2SegmentResult {
+    #[default]
     None,
     HuffmanTable(CustomHuffmanDecoder),
     Image(JBig2Image),
     PatternDictionary(PatternDictionary),
     SymbolDictionary(SymbolDictionary),
-}
-
-impl Default for JBig2SegmentResult {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]

--- a/crates/pdf-jbig2/src/symbol_dictionary/arithmetic.rs
+++ b/crates/pdf-jbig2/src/symbol_dictionary/arithmetic.rs
@@ -86,12 +86,9 @@ fn decode_arithmetic_symbol_width_run(
         .ok_or(Jbig2Error::InvalidState(SYMBOL_DICTIONARY_AT_DATA))?;
     let mut width = 0i32;
 
-    loop {
-        let Some(delta_width) =
-            decoder.decode_integer(JBig2ArithIntegerContext::SymbolWidthDelta)?
-        else {
-            break;
-        };
+    while let Some(delta_width) =
+        decoder.decode_integer(JBig2ArithIntegerContext::SymbolWidthDelta)?
+    {
         width = width
             .checked_add(delta_width)
             .ok_or(Jbig2Error::Overflow(INTEGER_CONVERSION_OVERFLOW))?;

--- a/crates/pdf-object-collection/src/object_collection.rs
+++ b/crates/pdf-object-collection/src/object_collection.rs
@@ -151,7 +151,7 @@ impl ObjectCollection {
     #[cfg(feature = "json")]
     fn object_variant_to_json(obj: &ObjectVariant) -> JsonValue {
         match obj {
-            ObjectVariant::Dictionary(dict) => Self::dictionary_to_json(dict.as_ref()),
+            ObjectVariant::Dictionary(dict) => Self::dictionary_to_json(dict),
             ObjectVariant::Array(arr) => {
                 JsonValue::Array(arr.iter().map(Self::object_variant_to_json).collect())
             }
@@ -211,7 +211,7 @@ impl ObjectCollection {
                     "type": "Stream",
                     "object_number": stream.object_number,
                     "generation_number": stream.generation_number,
-                    "dictionary": Self::dictionary_to_json(stream.dictionary.as_ref()),
+                    "dictionary": Self::dictionary_to_json(&stream.dictionary),
                     "data_length": stream.raw_data().len()
                 })
             }
@@ -250,7 +250,7 @@ mod tests {
         let stream = StreamObject::new(
             99,
             4,
-            Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+            Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
             data,
         );
         let mut collection = ObjectCollection::default();
@@ -286,10 +286,9 @@ mod tests {
                     number: 7,
                     generation: 2,
                 },
-                ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::<
-                    Vec<u8>,
-                    ObjectVariant,
-                >::new()))),
+                ObjectVariant::Dictionary(Dictionary::new(
+                    BTreeMap::<Vec<u8>, ObjectVariant>::new(),
+                )),
             )
             .expect("dictionary insert failed");
 
@@ -347,8 +346,7 @@ mod tests {
         decode_parms.insert(Vec::from(b"Colors"), ObjectVariant::Integer(1));
         decode_parms.insert(Vec::from(b"BitsPerComponent"), ObjectVariant::Integer(8));
 
-        let decode_parms_object =
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(decode_parms)));
+        let decode_parms_object = ObjectVariant::Dictionary(Dictionary::new(decode_parms));
 
         let mut collection = ObjectCollection::default();
         collection
@@ -375,7 +373,7 @@ mod tests {
         let stream = ObjectVariant::Stream(StreamObject::new_encoded(
             1,
             0,
-            Box::new(Dictionary::new(stream_dict)),
+            Dictionary::new(stream_dict),
             compressed,
         ));
 
@@ -406,7 +404,7 @@ mod tests {
                 ObjectVariant::Name(b"ASCIIHexDecode".to_vec()),
             ),
         ]));
-        let stream = StreamObject::new_encoded(1, 0, Box::new(stream_dictionary), b"2A>".to_vec());
+        let stream = StreamObject::new_encoded(1, 0, stream_dictionary, b"2A>".to_vec());
         let mut collection = ObjectCollection::default();
 
         collection
@@ -434,10 +432,9 @@ mod tests {
                     number: 2,
                     generation: 0,
                 },
-                ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::<
-                    Vec<u8>,
-                    ObjectVariant,
-                >::new()))),
+                ObjectVariant::Dictionary(Dictionary::new(
+                    BTreeMap::<Vec<u8>, ObjectVariant>::new(),
+                )),
             )
             .expect("decode parameters should be inserted");
 

--- a/crates/pdf-object/src/object_lookup.rs
+++ b/crates/pdf-object/src/object_lookup.rs
@@ -1027,14 +1027,14 @@ mod tests {
         let dictionary = Dictionary::new(BTreeMap::from([
             (
                 b"Dictionary".to_vec(),
-                ObjectVariant::Dictionary(Box::new(nested.clone())),
+                ObjectVariant::Dictionary(nested.clone()),
             ),
             (
                 b"Stream".to_vec(),
                 ObjectVariant::Stream(StreamObject::new(
                     7,
                     0,
-                    Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+                    Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
                     Vec::new(),
                 )),
             ),
@@ -1129,7 +1129,7 @@ mod tests {
     fn slice_lookup_methods_convert_common_types() {
         let nested = Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new());
         let values = [
-            ObjectVariant::Dictionary(Box::new(nested.clone())),
+            ObjectVariant::Dictionary(nested.clone()),
             ObjectVariant::Array(vec![ObjectVariant::Integer(1), ObjectVariant::Integer(2)]),
             ObjectVariant::LiteralString(b"text".to_vec()),
             ObjectVariant::Boolean(false),

--- a/crates/pdf-object/src/object_variant.rs
+++ b/crates/pdf-object/src/object_variant.rs
@@ -14,7 +14,7 @@ use crate::trailer::Trailer;
 #[derive(Debug, PartialEq, Clone)]
 pub enum ObjectVariant {
     /// A PDF dictionary object.
-    Dictionary(Box<Dictionary>),
+    Dictionary(Dictionary),
     /// A PDF array of objects.
     Array(Vec<ObjectVariant>),
     /// A literal string (enclosed in parentheses in PDF syntax), stored as raw bytes.
@@ -68,8 +68,8 @@ impl ObjectVariant {
         };
 
         match object {
-            ObjectVariant::Dictionary(dict) => Ok(dict.as_ref()),
-            ObjectVariant::Stream(stream) => Ok(stream.dictionary.as_ref()),
+            ObjectVariant::Dictionary(dict) => Ok(dict),
+            ObjectVariant::Stream(stream) => Ok(&stream.dictionary),
             _ => Err(ObjectError::TypeMismatch("Dictionary", object.name())),
         }
     }
@@ -441,9 +441,9 @@ mod tests {
             .expect_err("null object should not decode as a stream");
         assert_eq!(null_err, ObjectError::TypeMismatch("Stream", "Null"));
 
-        let dict_object = ObjectVariant::Dictionary(Box::new(crate::dictionary::Dictionary::new(
+        let dict_object = ObjectVariant::Dictionary(crate::dictionary::Dictionary::new(
             std::collections::BTreeMap::<Vec<u8>, ObjectVariant>::new(),
-        )));
+        ));
         let dict_err = dict_object
             .try_stream(&PassthroughResolver)
             .expect_err("dictionary object should not decode as a stream");
@@ -456,9 +456,9 @@ mod tests {
             (ObjectVariant::Integer(7), "Integer"),
             (ObjectVariant::Array(Vec::new()), "Array"),
             (
-                ObjectVariant::Dictionary(Box::new(crate::dictionary::Dictionary::new(
+                ObjectVariant::Dictionary(crate::dictionary::Dictionary::new(
                     std::collections::BTreeMap::<Vec<u8>, ObjectVariant>::new(),
-                ))),
+                )),
                 "Dictionary",
             ),
             (ObjectVariant::Boolean(true), "Boolean"),

--- a/crates/pdf-object/src/stream.rs
+++ b/crates/pdf-object/src/stream.rs
@@ -15,7 +15,7 @@ pub struct StreamObject {
     /// The generation number, used for PDF incremental updates.
     pub generation_number: usize,
     /// The dictionary associated with this stream.
-    pub dictionary: Box<Dictionary>,
+    pub dictionary: Dictionary,
     /// Shared byte data of the stream.
     ///
     /// The bytes may still be encoded when the stream was created directly
@@ -32,7 +32,7 @@ impl StreamObject {
     pub fn new(
         object_number: usize,
         generation_number: usize,
-        dictionary: Box<Dictionary>,
+        dictionary: Dictionary,
         data: impl Into<Arc<Vec<u8>>>,
     ) -> Self {
         StreamObject {
@@ -48,7 +48,7 @@ impl StreamObject {
     pub fn new_encoded(
         object_number: usize,
         generation_number: usize,
-        dictionary: Box<Dictionary>,
+        dictionary: Dictionary,
         data: impl Into<Arc<Vec<u8>>>,
     ) -> Self {
         StreamObject {
@@ -100,13 +100,13 @@ mod tests {
         let decoded = StreamObject::new(
             1,
             0,
-            Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+            Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
             vec![1],
         );
         let encoded = StreamObject::new_encoded(
             2,
             0,
-            Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+            Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
             vec![2],
         );
 
@@ -119,7 +119,7 @@ mod tests {
         let mut stream = StreamObject::new_encoded(
             1,
             0,
-            Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+            Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
             vec![1],
         );
 

--- a/crates/pdf-parser/src/cross_reference_stream.rs
+++ b/crates/pdf-parser/src/cross_reference_stream.rs
@@ -19,24 +19,24 @@ use crate::error::ParserError;
 /// The stream data is decoded (filters such as FlateDecode and predictors
 /// are applied) before reading the binary xref entries.
 pub fn parse_xref_stream(
-    stream: &StreamObject,
+    stream: StreamObject,
     objects: &dyn ObjectResolver,
 ) -> Result<CrossReferenceTable, ParserError> {
-    let dict = stream.dictionary.as_ref();
-
-    validate_stream_type(stream, objects)?;
-    let size = dict.required_number::<usize>(b"Size", objects)?;
-    let layout = XrefStreamLayout::from_dictionary(stream, objects)?;
+    validate_stream_type(&stream, objects)?;
+    let layout = XrefStreamLayout::from_dictionary(&stream, objects)?;
+    let size = stream
+        .dictionary
+        .required_number::<usize>(b"Size", objects)?;
 
     if layout.entry_width == 0 {
         return Ok(CrossReferenceTable::new(
             BTreeMap::new(),
-            Trailer::new(stream.dictionary.clone(), 0),
+            Trailer::new(Box::new(stream.dictionary), 0),
         ));
     }
 
-    let subsections = parse_subsections(stream, objects, size)?;
-    let data = pdf_filter::filter::decode_with_resolver(stream, objects)?;
+    let subsections = parse_subsections(&stream, objects, size)?;
+    let data = pdf_filter::filter::decode_with_resolver(&stream, objects)?;
     let mut entries = BTreeMap::new();
 
     let mut decoder = XrefStreamEntryDecoder::new(&data, layout);
@@ -45,7 +45,7 @@ pub fn parse_xref_stream(
             let Some(entry) = decoder.next_entry() else {
                 return Ok(CrossReferenceTable::new(
                     entries,
-                    Trailer::new(stream.dictionary.clone(), 0),
+                    Trailer::new(Box::new(stream.dictionary), 0),
                 ));
             };
 
@@ -54,7 +54,7 @@ pub fn parse_xref_stream(
         }
     }
 
-    let trailer = Trailer::new(stream.dictionary.clone(), 0);
+    let trailer = Trailer::new(Box::new(stream.dictionary), 0);
     Ok(CrossReferenceTable::new(entries, trailer))
 }
 
@@ -255,7 +255,7 @@ mod tests {
             ObjectVariant::Integer(raw_data.len() as i64),
         );
 
-        StreamObject::new(0, 0, Box::new(Dictionary::new(dict_map)), raw_data)
+        StreamObject::new(0, 0, Dictionary::new(dict_map), raw_data)
     }
 
     #[test]
@@ -272,7 +272,7 @@ mod tests {
         data.extend_from_slice(&[1, 2, 0, 0]);
 
         let stream = build_xref_stream([1, 2, 1], None, 4, data);
-        let table = parse_xref_stream(&stream, &PassthroughResolver).unwrap();
+        let table = parse_xref_stream(stream, &PassthroughResolver).unwrap();
 
         assert_eq!(table.entries.len(), 4);
 
@@ -307,7 +307,7 @@ mod tests {
         data.extend_from_slice(&[0, 200]);
 
         let stream = build_xref_stream([0, 2, 0], None, 2, data);
-        let table = parse_xref_stream(&stream, &PassthroughResolver).unwrap();
+        let table = parse_xref_stream(stream, &PassthroughResolver).unwrap();
 
         assert_eq!(table.entries.len(), 2);
         assert_eq!(table.entries[&0].byte_offset(), Some(100));
@@ -323,7 +323,7 @@ mod tests {
         data.extend_from_slice(&[1, 100, 0]);
 
         let stream = build_xref_stream([1, 1, 1], Some(vec![5, 2, 10, 1]), 11, data);
-        let table = parse_xref_stream(&stream, &PassthroughResolver).unwrap();
+        let table = parse_xref_stream(stream, &PassthroughResolver).unwrap();
 
         assert_eq!(table.entries.len(), 3);
         assert_eq!(table.entries[&5].byte_offset(), Some(50));
@@ -337,7 +337,7 @@ mod tests {
     fn test_parse_xref_stream_keeps_complete_entries_from_truncated_data() {
         let stream = build_xref_stream([1, 1, 1], None, 2, vec![1, 42, 0, 1, 84]);
 
-        let table = parse_xref_stream(&stream, &PassthroughResolver).unwrap();
+        let table = parse_xref_stream(stream, &PassthroughResolver).unwrap();
 
         assert_eq!(table.entries.len(), 1);
         assert_eq!(table.entries[&0].byte_offset(), Some(42));
@@ -347,7 +347,7 @@ mod tests {
     fn test_parse_xref_stream_maps_unknown_entry_types_to_free_entries() {
         let stream = build_xref_stream([1, 1, 1], None, 1, vec![9, 42, 7]);
 
-        let table = parse_xref_stream(&stream, &PassthroughResolver).unwrap();
+        let table = parse_xref_stream(stream, &PassthroughResolver).unwrap();
 
         assert_eq!(table.entries[&0], CrossReferenceEntryType::new_free(0, 0));
     }
@@ -413,7 +413,7 @@ mod tests {
         );
         dict_map.insert(
             Vec::from(b"DecodeParms"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(
+            ObjectVariant::Dictionary(Dictionary::new(
                 vec![
                     (
                         Vec::from(b"Columns"),
@@ -423,14 +423,14 @@ mod tests {
                 ]
                 .into_iter()
                 .collect(),
-            ))),
+            )),
         );
         dict_map.insert(
             Vec::from(b"Length"),
             ObjectVariant::Integer(compressed.len() as i64),
         );
 
-        StreamObject::new(0, 0, Box::new(Dictionary::new(dict_map)), compressed)
+        StreamObject::new(0, 0, Dictionary::new(dict_map), compressed)
     }
 
     #[test]
@@ -454,7 +454,7 @@ mod tests {
             raw_entries,
             5, // columns = w1+w2+w3
         );
-        let table = parse_xref_stream(&stream, &PassthroughResolver).unwrap();
+        let table = parse_xref_stream(stream, &PassthroughResolver).unwrap();
 
         assert_eq!(table.entries.len(), 4);
 

--- a/crates/pdf-parser/src/parser.rs
+++ b/crates/pdf-parser/src/parser.rs
@@ -314,7 +314,7 @@ impl<'a> PdfParser<'a> {
                 }
             }
             PdfToken::DoubleLeftAngleBracket => {
-                ObjectVariant::Dictionary(Box::new(self.parse_dictionary(objects)?))
+                ObjectVariant::Dictionary(self.parse_dictionary(objects)?)
             }
             PdfToken::LeftAngleBracket => ObjectVariant::HexString(self.parse_hex_string()?),
             PdfToken::Solidus => ObjectVariant::Name(self.parse_name()?),

--- a/crates/pdf-parser/src/trailer.rs
+++ b/crates/pdf-parser/src/trailer.rs
@@ -39,7 +39,7 @@ impl PdfParser<'_> {
             0
         };
 
-        Ok(Trailer::new(dictionary, offset))
+        Ok(Trailer::new(Box::new(dictionary), offset))
     }
 }
 

--- a/crates/pdf-parser/src/xref_builder.rs
+++ b/crates/pdf-parser/src/xref_builder.rs
@@ -232,7 +232,7 @@ impl<'input> XrefBuilder<'input> {
     fn parse_stream_section(&self, stream: StreamObject) -> Result<ParsedXrefSection, ParserError> {
         Ok(ParsedXrefSection {
             kind: XrefSectionKind::Stream,
-            table: crate::cross_reference_stream::parse_xref_stream(&stream, &PassthroughResolver)?,
+            table: crate::cross_reference_stream::parse_xref_stream(stream, &PassthroughResolver)?,
         })
     }
 

--- a/crates/pdf-resources/src/form.rs
+++ b/crates/pdf-resources/src/form.rs
@@ -127,7 +127,7 @@ mod tests {
             ),
             (Vec::from(b"Subtype"), ObjectVariant::Name(b"Form".to_vec())),
         ]));
-        let stream = StreamObject::new(7, 0, Box::new(dictionary.clone()), Vec::new());
+        let stream = StreamObject::new(7, 0, dictionary.clone(), Vec::new());
         let mut cache = DefaultResourceCache::default();
         let mut cycle_tracker = ReadCycleTracker::default();
         let mut id_allocator = ContentStreamIdAllocator::new();

--- a/crates/pdf-resources/src/soft_mask.rs
+++ b/crates/pdf-resources/src/soft_mask.rs
@@ -105,12 +105,7 @@ mod tests {
                 ObjectVariant::Name(subtype.as_bytes().to_vec()),
             ),
         ]));
-        let stream = StreamObject::new(
-            stream_object_number,
-            0,
-            Box::new(form_dictionary),
-            Vec::new(),
-        );
+        let stream = StreamObject::new(stream_object_number, 0, form_dictionary, Vec::new());
 
         Dictionary::new(BTreeMap::from([
             (Vec::from(b"G"), ObjectVariant::Stream(stream)),

--- a/crates/pdf-resources/src/xobject.rs
+++ b/crates/pdf-resources/src/xobject.rs
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn self_referential_soft_mask_is_treated_as_absent() {
-        let stream = StreamObject::new(7, 0, Box::new(image_dictionary(7)), vec![0xAA]);
+        let stream = StreamObject::new(7, 0, image_dictionary(7), vec![0xAA]);
         let resolver = MapResolver {
             objects: BTreeMap::from([(7, ObjectVariant::Stream(stream.clone()))]),
         };
@@ -223,7 +223,7 @@ mod tests {
         let image_stream = StreamObject::new(
             1,
             0,
-            Box::new(Dictionary::new(BTreeMap::from([
+            Dictionary::new(BTreeMap::from([
                 (
                     Vec::from(b"Subtype"),
                     ObjectVariant::Name(b"Image".to_vec()),
@@ -236,13 +236,13 @@ mod tests {
                     ObjectVariant::Name(b"DeviceGray".to_vec()),
                 ),
                 (Vec::from(b"SMask"), ObjectVariant::Reference(2)),
-            ]))),
+            ])),
             vec![0x20, 0xC0],
         );
         let mask_stream = StreamObject::new(
             2,
             0,
-            Box::new(Dictionary::new(BTreeMap::from([
+            Dictionary::new(BTreeMap::from([
                 (
                     Vec::from(b"Subtype"),
                     ObjectVariant::Name(b"Image".to_vec()),
@@ -254,7 +254,7 @@ mod tests {
                     Vec::from(b"ColorSpace"),
                     ObjectVariant::Name(b"DeviceGray".to_vec()),
                 ),
-            ]))),
+            ])),
             vec![0x10, 0xE0],
         );
         let resolver = MapResolver {
@@ -294,14 +294,14 @@ mod tests {
 
     #[test]
     fn soft_mask_xobject_error_is_propagated() {
-        let image_stream = StreamObject::new(1, 0, Box::new(image_dictionary(2)), vec![0xAA]);
+        let image_stream = StreamObject::new(1, 0, image_dictionary(2), vec![0xAA]);
         let mask_stream = StreamObject::new(
             2,
             0,
-            Box::new(Dictionary::new(BTreeMap::from([(
+            Dictionary::new(BTreeMap::from([(
                 Vec::from(b"Subtype"),
                 ObjectVariant::Name(b"Unsupported".to_vec()),
-            )]))),
+            )])),
             vec![],
         );
         let resolver = MapResolver {
@@ -348,7 +348,7 @@ mod tests {
             ),
             (Vec::from(b"Width"), ObjectVariant::Integer(1)),
         ]));
-        let stream = StreamObject::new_encoded(1, 0, Box::new(dictionary), b"2A>".to_vec());
+        let stream = StreamObject::new_encoded(1, 0, dictionary, b"2A>".to_vec());
         let mut objects = ObjectCollection::default();
 
         objects
@@ -357,10 +357,9 @@ mod tests {
         objects
             .insert(
                 object_id(2),
-                ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::<
-                    Vec<u8>,
-                    ObjectVariant,
-                >::new()))),
+                ObjectVariant::Dictionary(Dictionary::new(
+                    BTreeMap::<Vec<u8>, ObjectVariant>::new(),
+                )),
             )
             .expect("decode parameters should be inserted");
 
@@ -396,7 +395,7 @@ mod tests {
         let stream = StreamObject::new(
             9,
             0,
-            Box::new(Dictionary::new(BTreeMap::from([
+            Dictionary::new(BTreeMap::from([
                 (
                     Vec::from(b"Subtype"),
                     ObjectVariant::Name(b"Image".to_vec()),
@@ -407,7 +406,7 @@ mod tests {
                     Vec::from(b"ColorSpace"),
                     ObjectVariant::Name(b"DeviceGray".to_vec()),
                 ),
-            ]))),
+            ])),
             vec![0],
         );
         let resolver = MapResolver {

--- a/crates/pdf-resources/tests/resources.rs
+++ b/crates/pdf-resources/tests/resources.rs
@@ -39,17 +39,17 @@ fn array(values: Vec<ObjectVariant>) -> ObjectVariant {
 }
 
 fn type2_function(c0: Vec<ObjectVariant>, c1: Vec<ObjectVariant>) -> ObjectVariant {
-    ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([
+    ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([
         (Vec::from(b"FunctionType"), integer(2)),
         (Vec::from(b"Domain"), array(vec![real(0.0), real(1.0)])),
         (Vec::from(b"C0"), array(c0)),
         (Vec::from(b"C1"), array(c1)),
         (Vec::from(b"N"), real(1.0)),
-    ]))))
+    ])))
 }
 
 fn inline_axial_shading() -> ObjectVariant {
-    ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([
+    ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([
         (Vec::from(b"ShadingType"), integer(2)),
         (Vec::from(b"ColorSpace"), name("DeviceRGB")),
         (
@@ -63,7 +63,7 @@ fn inline_axial_shading() -> ObjectVariant {
                 vec![real(1.0), real(1.0), real(1.0)],
             ),
         ),
-    ]))))
+    ])))
 }
 
 fn form_xobject_stream(object_number: usize, data: &[u8]) -> ObjectVariant {
@@ -78,7 +78,7 @@ fn form_xobject_stream(object_number: usize, data: &[u8]) -> ObjectVariant {
     ObjectVariant::Stream(StreamObject::new(
         object_number,
         0,
-        Box::new(dictionary),
+        dictionary,
         data.to_vec(),
     ))
 }
@@ -91,10 +91,10 @@ fn xobject_resources(entries: Vec<(&str, ObjectVariant)>) -> Dictionary {
 
     Dictionary::new(BTreeMap::from([(
         Vec::from(b"Resources"),
-        ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+        ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
             Vec::from(b"XObject"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(xobjects))),
-        )])))),
+            ObjectVariant::Dictionary(Dictionary::new(xobjects)),
+        )]))),
     )]))
 }
 
@@ -106,10 +106,10 @@ fn page_resources(entries: Vec<(&str, ObjectVariant)>) -> Dictionary {
 
     Dictionary::new(BTreeMap::from([(
         Vec::from(b"Resources"),
-        ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+        ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
             Vec::from(b"Shading"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(shading_entries))),
-        )])))),
+            ObjectVariant::Dictionary(Dictionary::new(shading_entries)),
+        )]))),
     )]))
 }
 
@@ -117,7 +117,7 @@ fn type3_char_proc(data: &[u8]) -> ObjectVariant {
     ObjectVariant::Stream(StreamObject::new(
         0,
         0,
-        Box::new(Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new())),
+        Dictionary::new(BTreeMap::<Vec<u8>, ObjectVariant>::new()),
         data.to_vec(),
     ))
 }
@@ -144,20 +144,20 @@ fn self_referential_type3_font(object_number: usize) -> Dictionary {
         ),
         (
             Vec::from(b"CharProcs"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                 Vec::from(b"A"),
                 type3_char_proc(b"0 0 d0"),
-            )])))),
+            )]))),
         ),
         (
             Vec::from(b"Resources"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                 Vec::from(b"Font"),
-                ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+                ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                     Vec::from(b"Self"),
                     ObjectVariant::Reference(object_number),
-                )])))),
-            )])))),
+                )]))),
+            )]))),
         ),
     ]))
 }
@@ -166,7 +166,7 @@ fn self_referential_tiling_pattern(object_number: usize) -> ObjectVariant {
     ObjectVariant::Stream(StreamObject::new(
         object_number,
         0,
-        Box::new(Dictionary::new(BTreeMap::from([
+        Dictionary::new(BTreeMap::from([
             (Vec::from(b"PatternType"), integer(1)),
             (Vec::from(b"PaintType"), integer(1)),
             (Vec::from(b"TilingType"), integer(1)),
@@ -178,15 +178,15 @@ fn self_referential_tiling_pattern(object_number: usize) -> ObjectVariant {
             (Vec::from(b"YStep"), real(10.0)),
             (
                 Vec::from(b"Resources"),
-                ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+                ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                     Vec::from(b"Pattern"),
-                    ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+                    ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                         Vec::from(b"Self"),
                         ObjectVariant::Reference(object_number),
-                    )])))),
-                )])))),
+                    )]))),
+                )]))),
             ),
-        ]))),
+        ])),
         b"q".to_vec(),
     ))
 }
@@ -275,10 +275,10 @@ fn dictionary_only_form_xobjects_are_loaded_as_empty_forms() {
 
     let resources_dict = Dictionary::new(BTreeMap::from([(
         Vec::from(b"XObject"),
-        ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+        ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
             Vec::from(b"Meta6"),
             ObjectVariant::Reference(101),
-        )])))),
+        )]))),
     )]));
 
     let form_dict = Dictionary::new(BTreeMap::from([
@@ -302,16 +302,10 @@ fn dictionary_only_form_xobjects_are_loaded_as_empty_forms() {
 
     let mut objects = ObjectCollection::default();
     objects
-        .insert(
-            object_id(100),
-            ObjectVariant::Dictionary(Box::new(resources_dict)),
-        )
+        .insert(object_id(100), ObjectVariant::Dictionary(resources_dict))
         .expect("resources dictionary should insert");
     objects
-        .insert(
-            object_id(101),
-            ObjectVariant::Dictionary(Box::new(form_dict)),
-        )
+        .insert(object_id(101), ObjectVariant::Dictionary(form_dict))
         .expect("dictionary-only form should insert");
 
     let mut cache = DefaultResourceCache::default();
@@ -377,7 +371,7 @@ fn cyclic_form_resources_resolve_lazily_without_recursing_forever() {
     let xobject_entries = BTreeMap::from([(Vec::from(b"Self"), ObjectVariant::Reference(11))]);
     let resource_dict = Dictionary::new(BTreeMap::from([(
         Vec::from(b"XObject"),
-        ObjectVariant::Dictionary(Box::new(Dictionary::new(xobject_entries))),
+        ObjectVariant::Dictionary(Dictionary::new(xobject_entries)),
     )]));
 
     let form_dict = Dictionary::new(BTreeMap::from([
@@ -396,15 +390,12 @@ fn cyclic_form_resources_resolve_lazily_without_recursing_forever() {
 
     let mut objects = ObjectCollection::default();
     objects
-        .insert(
-            object_id(10),
-            ObjectVariant::Dictionary(Box::new(resource_dict)),
-        )
+        .insert(object_id(10), ObjectVariant::Dictionary(resource_dict))
         .expect("resource dictionary should insert");
     objects
         .insert(
             object_id(11),
-            ObjectVariant::Stream(StreamObject::new(11, 0, Box::new(form_dict), b"q".to_vec())),
+            ObjectVariant::Stream(StreamObject::new(11, 0, form_dict, b"q".to_vec())),
         )
         .expect("form xobject should insert");
 
@@ -471,20 +462,20 @@ fn cyclic_form_resources_resolve_lazily_without_recursing_forever() {
 fn self_referential_font_resources_resolve_lazily() {
     let page_dict = Dictionary::new(BTreeMap::from([(
         Vec::from(b"Resources"),
-        ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+        ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
             Vec::from(b"Font"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                 Vec::from(b"Self"),
                 ObjectVariant::Reference(21),
-            )])))),
-        )])))),
+            )]))),
+        )]))),
     )]));
 
     let mut objects = ObjectCollection::default();
     objects
         .insert(
             object_id(21),
-            ObjectVariant::Dictionary(Box::new(self_referential_type3_font(21))),
+            ObjectVariant::Dictionary(self_referential_type3_font(21)),
         )
         .expect("font should insert");
 
@@ -527,22 +518,22 @@ fn self_referential_font_resources_resolve_lazily() {
 
 #[test]
 fn fallback_fonts_do_not_read_nested_type3_resources() {
-    let malformed_type3 = ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([
+    let malformed_type3 = ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([
         (
             Vec::from(b"Subtype"),
             ObjectVariant::Name(b"Type3".to_vec()),
         ),
         (Vec::from(b"Resources"), ObjectVariant::Integer(1)),
-    ]))));
+    ])));
     let page_dict = Dictionary::new(BTreeMap::from([(
         Vec::from(b"Resources"),
-        ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+        ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
             Vec::from(b"Font"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                 Vec::from(b"F1"),
                 malformed_type3,
-            )])))),
-        )])))),
+            )]))),
+        )]))),
     )]));
     let mut cache = DefaultResourceCache::default();
     let mut cycle_tracker = ReadCycleTracker::default();
@@ -567,13 +558,13 @@ fn fallback_fonts_do_not_read_nested_type3_resources() {
 fn self_referential_pattern_resources_resolve_lazily() {
     let page_dict = Dictionary::new(BTreeMap::from([(
         Vec::from(b"Resources"),
-        ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+        ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
             Vec::from(b"Pattern"),
-            ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([(
+            ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([(
                 Vec::from(b"Self"),
                 ObjectVariant::Reference(31),
-            )])))),
-        )])))),
+            )]))),
+        )]))),
     )]));
 
     let mut objects = ObjectCollection::default();

--- a/crates/pdf-shading/src/free_form_mesh.rs
+++ b/crates/pdf-shading/src/free_form_mesh.rs
@@ -47,7 +47,7 @@ pub(crate) fn parse_free_form_triangle_mesh(
     objects: &dyn ObjectResolver,
 ) -> Result<Shading, PdfShadingError> {
     let stream = object.try_stream(objects)?;
-    let config = FreeFormMeshConfig::parse(stream.dictionary.as_ref(), objects)?;
+    let config = FreeFormMeshConfig::parse(&stream.dictionary, objects)?;
     let triangles = FreeFormMeshParser::new(stream.raw_data(), &config)?.parse()?;
 
     Ok(Shading::FreeFormTriangleMesh {

--- a/crates/pdf-shading/src/patch_mesh.rs
+++ b/crates/pdf-shading/src/patch_mesh.rs
@@ -46,7 +46,7 @@ pub(crate) fn parse_patch_mesh(
 ) -> Result<Shading, PdfShadingError> {
     let kind = PatchKind::from_shading_type(shading_type)?;
     let stream = object.try_stream(objects)?;
-    let config = PatchMeshConfig::parse(stream.dictionary.as_ref(), objects)?;
+    let config = PatchMeshConfig::parse(&stream.dictionary, objects)?;
     let patches = PatchMeshParser::new(stream.raw_data(), &config, kind)?.parse()?;
 
     Ok(config.into_shading(shading_type, patches))

--- a/crates/pdf-shading/tests/parse.rs
+++ b/crates/pdf-shading/tests/parse.rs
@@ -27,13 +27,13 @@ fn number_array(values: &[f32]) -> ObjectVariant {
 }
 
 fn type_2_rgb_function() -> ObjectVariant {
-    ObjectVariant::Dictionary(Box::new(Dictionary::new(BTreeMap::from([
+    ObjectVariant::Dictionary(Dictionary::new(BTreeMap::from([
         (Vec::from(b"FunctionType"), integer(2)),
         (Vec::from(b"Domain"), number_array(&[0.0, 1.0])),
         (Vec::from(b"C0"), number_array(&[1.0, 0.0, 0.0])),
         (Vec::from(b"C1"), number_array(&[0.0, 0.0, 1.0])),
         (Vec::from(b"N"), ObjectVariant::Real(1.0)),
-    ]))))
+    ])))
 }
 
 fn free_form_stream(
@@ -93,12 +93,7 @@ fn mesh_entries(
 }
 
 fn shading_stream(entries: BTreeMap<Vec<u8>, ObjectVariant>, data: Vec<u8>) -> ObjectVariant {
-    ObjectVariant::Stream(StreamObject::new(
-        1,
-        0,
-        Box::new(Dictionary::new(entries)),
-        data,
-    ))
+    ObjectVariant::Stream(StreamObject::new(1, 0, Dictionary::new(entries), data))
 }
 
 fn push_field(bits: &mut Vec<bool>, value: u32, width: usize) {


### PR DESCRIPTION
Remove Box indirection from dictionary object variants and stream dictionaries. Migrate parsers, filters, resource loaders, and tests to use the inline representation.

Consume cross-reference streams while constructing trailers so their dictionaries can be moved without cloning.